### PR TITLE
Add script to generate random peer identity

### DIFF
--- a/scripts/generate_peer_id.go
+++ b/scripts/generate_peer_id.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"crypto/rand"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+func main() {
+
+	dest := flag.String("out", "", "Path at which to store the marshalled peer identity. Required.")
+	flag.Parse()
+
+	if dest == nil || *dest == "" {
+		panic("destination path must be specified via --out flag.")
+	}
+
+	out := filepath.Clean(*dest)
+	k, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		panic(err)
+	}
+
+	pid, err := peer.IDFromPrivateKey(k)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Generated random private key with peer ID: %s\n", pid)
+
+	mk, err := crypto.MarshalPrivateKey(k)
+	if err != nil {
+		panic(err)
+	}
+
+	if err := os.WriteFile(out, mk, 0666); err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Marshalled **unencrypted** private key is stored at: %s\n", out)
+}


### PR DESCRIPTION


## Context
Deployment of indexer nodes works with explicitly generated peer identity that is then encrypted and checked into code. Add a script that makes the generation of random identity easier. 

## Proposed Changes
Add a script to generate a random peer identity, used to instantiate
new indexer nodes. The script also prints out the peer ID from the
generated private key.

## Tests
Used to generate identities locally.

## Revert Strategy
`git revert`