### PR TITLE
Only poll assigned publishers when using assigner

### DIFF
--- a/assigner/server/server_test.go
+++ b/assigner/server/server_test.go
@@ -144,8 +144,9 @@ func TestAnnounce(t *testing.T) {
 		t.Fatal("timed out waiting for indexer to start")
 	}
 
-	// Allow a peer to test that assigner reads this at startup.
-	assign(ctx, "localhost:3602", pubIdent2.PeerID)
+	// Assign a peer, to test that assigner reads this at startup.
+	err = assign(ctx, "localhost:3602", pubIdent2.PeerID)
+	require.NoError(t, err)
 
 	// Initialize everything
 	peerID, _, err := pubIdent.Decode()

--- a/dagsync/dtsync/syncer.go
+++ b/dagsync/dtsync/syncer.go
@@ -67,7 +67,9 @@ func (s *Syncer) Sync(ctx context.Context, nextCid cid.Cid, sel ipld.Node) error
 		log.Debugw("Starting data channel for message source", "cid", nextCid, "source_peer", s.peerID)
 
 		v := Voucher{&nextCid}
-		_, err := s.sync.dtManager.OpenPullDataChannel(ctx, s.peerID, &v, nextCid, sel)
+		// Do not pass cancelable context into OpenPullDataChannel because a
+		// canceled context causes it to hang.
+		_, err := s.sync.dtManager.OpenPullDataChannel(context.Background(), s.peerID, &v, nextCid, sel)
 		if err != nil {
 			s.sync.signalSyncDone(inProgressSyncK, nil)
 			return fmt.Errorf("cannot open data channel: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.2.0
 	github.com/filecoin-project/go-data-transfer v1.15.2
-	github.com/filecoin-project/go-indexer-core v0.6.20-0.20221124171445-aaa74eb24a1a
+	github.com/filecoin-project/go-indexer-core v0.6.20-0.20221203094717-421546fb9fb6
 	github.com/frankban/quicktest v1.14.3
 	github.com/gammazero/deque v0.2.0
 	github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -240,8 +240,8 @@ github.com/filecoin-project/go-data-transfer v1.15.2 h1:PzqsFr2Q/onMGKrGh7TtRT0d
 github.com/filecoin-project/go-data-transfer v1.15.2/go.mod h1:qXOJ3IF5dEJQHykXXTwcaRxu17bXAxr+LglXzkL6bZQ=
 github.com/filecoin-project/go-ds-versioning v0.1.2 h1:to4pTadv3IeV1wvgbCbN6Vqd+fu+7tveXgv/rCEZy6w=
 github.com/filecoin-project/go-ds-versioning v0.1.2/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
-github.com/filecoin-project/go-indexer-core v0.6.20-0.20221124171445-aaa74eb24a1a h1:d7nXUve0qaRg15N3AWTO6Ul/tFW+AtXHr2KGDULukFU=
-github.com/filecoin-project/go-indexer-core v0.6.20-0.20221124171445-aaa74eb24a1a/go.mod h1:Q3SSHCIdEN8bdfgpJuqMTC3BvO+8huqx5OEMRalNCXw=
+github.com/filecoin-project/go-indexer-core v0.6.20-0.20221203094717-421546fb9fb6 h1:r+dhFYFR2DAf3Gxr2bxwHcbYFPm3zORsmhefBYnAQNU=
+github.com/filecoin-project/go-indexer-core v0.6.20-0.20221203094717-421546fb9fb6/go.mod h1:Q3SSHCIdEN8bdfgpJuqMTC3BvO+8huqx5OEMRalNCXw=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statemachine v1.0.2 h1:421SSWBk8GIoCoWYYTE/d+qCWccgmRH0uXotXRDjUbc=
 github.com/filecoin-project/go-statemachine v1.0.2/go.mod h1:jZdXXiHa61n4NmgWFG4w8tnqgvZVHYbJ3yW7+y8bF54=

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -640,11 +640,13 @@ func (ing *Ingester) metricsUpdater() {
 					log.Errorw("Error getting indexer value store size", "err", err)
 					return
 				}
-				indexCount, err := ing.indexCounts.Total()
-				if err != nil {
-					log.Errorw("Error getting index counts", "err", err)
+				if ing.indexCounts != nil {
+					indexCount, err := ing.indexCounts.Total()
+					if err != nil {
+						log.Errorw("Error getting index counts", "err", err)
+					}
+					stats.Record(context.Background(), coremetrics.StoreSize.M(size), metrics.IndexCount.M(int64(indexCount)))
 				}
-				stats.Record(context.Background(), coremetrics.StoreSize.M(size), metrics.IndexCount.M(int64(indexCount)))
 				hasUpdate = false
 			}
 			t.Reset(time.Minute)

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -12,10 +12,8 @@ import (
 	"time"
 
 	"github.com/filecoin-project/go-indexer-core"
-	"github.com/filecoin-project/go-indexer-core/cache"
-	"github.com/filecoin-project/go-indexer-core/cache/radixcache"
 	"github.com/filecoin-project/go-indexer-core/engine"
-	"github.com/filecoin-project/go-indexer-core/store/storethehash"
+	"github.com/filecoin-project/go-indexer-core/store/memory"
 	schema "github.com/filecoin-project/storetheindex/api/v0/ingest/schema"
 	"github.com/filecoin-project/storetheindex/config"
 	"github.com/filecoin-project/storetheindex/dagsync"
@@ -34,7 +32,6 @@ import (
 	"github.com/ipld/go-ipld-prime/linking"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipld/go-ipld-prime/traversal/selector"
-	sth "github.com/ipld/go-storethehash/store"
 	"github.com/libp2p/go-libp2p"
 	crypto "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/host"
@@ -1487,15 +1484,7 @@ func TestAnnounceArrivedJustBeforeEntriesProcessingStartsDoesNotDeadlock(t *test
 
 // Make new indexer engine
 func mkIndexer(t *testing.T, withCache bool) *engine.Engine {
-	valueStore, err := storethehash.New(context.Background(), t.TempDir(), testCorePutConcurrency, sth.IndexBitSize(8))
-	if err != nil {
-		t.Fatal(err)
-	}
-	var resultCache cache.Interface
-	if withCache {
-		resultCache = radixcache.New(1000)
-	}
-	return engine.New(resultCache, valueStore)
+	return engine.New(nil, memory.New())
 }
 
 func mkRegistry(t *testing.T) *registry.Registry {

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -43,8 +43,6 @@ import (
 )
 
 const (
-	testCorePutConcurrency = 4
-
 	testRetryInterval = 2 * time.Second
 	testRetryTimeout  = 15 * time.Second
 

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -308,6 +308,9 @@ func TestDatastore(t *testing.T) {
 		}
 	}
 
+	require.ErrorIs(t, r.AssignPeer(pubID), ErrNoAssigner)
+	require.ErrorIs(t, r.UnassignPeer(pubID), ErrNoAssigner)
+
 	err = r.Close()
 	require.NoError(t, err)
 
@@ -329,6 +332,24 @@ func TestDatastore(t *testing.T) {
 	preferred, err := r.ListPreferredPeers()
 	require.NoError(t, err)
 	require.Equal(t, 1, len(preferred))
+
+	// Assign peer and check that it is assigned.
+	err = r.AssignPeer(preferred[0])
+	require.NoError(t, err)
+	assigned, err = r.ListAssignedPeers()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(assigned))
+
+	// Unassign peer and check that it is not assigned.
+	err = r.UnassignPeer(preferred[0])
+	require.NoError(t, err)
+	assigned, err = r.ListAssignedPeers()
+	require.NoError(t, err)
+	require.Zero(t, len(assigned))
+
+	// Should not be able to assigned blocked peer.
+	require.True(t, r.BlockPeer(preferred[0]))
+	require.ErrorIs(t, r.AssignPeer(preferred[0]), ErrNotAllowed)
 
 	require.NoError(t, r.Close())
 }

--- a/server/finder/handler/finder_handler.go
+++ b/server/finder/handler/finder_handler.go
@@ -249,16 +249,16 @@ func (h *FinderHandler) GetProvider(providerID peer.ID) ([]byte, error) {
 	return json.Marshal(&rsp)
 }
 
+func (h *FinderHandler) RefreshStats() {
+	h.stats.refresh()
+}
+
 func (h *FinderHandler) GetStats() ([]byte, error) {
 	stats, err := h.stats.get()
-	switch {
-	case err != nil:
+	if err != nil {
 		return nil, err
-	case stats.EntriesEstimate == 0:
-		return nil, nil
-	default:
-		return model.MarshalStats(&stats)
 	}
+	return model.MarshalStats(&stats)
 }
 
 func (h *FinderHandler) Close() {

--- a/server/finder/http/protocol_test.go
+++ b/server/finder/http/protocol_test.go
@@ -218,7 +218,7 @@ func TestProviderInfo(t *testing.T) {
 }
 
 func TestGetStats(t *testing.T) {
-	ind := test.InitIndex(t, true)
+	ind := test.InitPebbleIndex(t, false)
 	defer ind.Close()
 	reg := test.InitRegistry(t)
 	defer reg.Close()
@@ -239,7 +239,7 @@ func TestGetStats(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	test.GetStatsTest(ctx, t, httpClient)
+	test.GetStatsTest(ctx, t, ind, s.RefreshStats, httpClient)
 
 	err := s.Close()
 	if err != nil {

--- a/server/finder/http/server.go
+++ b/server/finder/http/server.go
@@ -105,6 +105,10 @@ func (s *Server) Start() error {
 	return s.server.Serve(s.l)
 }
 
+func (s *Server) RefreshStats() {
+	s.h.finderHandler.RefreshStats()
+}
+
 func (s *Server) Close() error {
 	log.Info("finder http server shutdown")
 	s.h.finderHandler.Close()

--- a/server/finder/libp2p/handler.go
+++ b/server/finder/libp2p/handler.go
@@ -85,6 +85,10 @@ func (h *libp2pHandler) HandleMessage(ctx context.Context, msgPeer peer.ID, msgb
 	}, nil
 }
 
+func (h *libp2pHandler) RefreshStats() {
+	h.finderHandler.RefreshStats()
+}
+
 func (h *libp2pHandler) find(ctx context.Context, p peer.ID, msg *pb.FinderMessage) ([]byte, error) {
 	startTime := time.Now()
 

--- a/server/finder/libp2p/protocol_test.go
+++ b/server/finder/libp2p/protocol_test.go
@@ -7,7 +7,6 @@ import (
 	indexer "github.com/filecoin-project/go-indexer-core"
 	p2pclient "github.com/filecoin-project/storetheindex/api/v0/finder/client/libp2p"
 	"github.com/filecoin-project/storetheindex/internal/counter"
-	"github.com/filecoin-project/storetheindex/internal/libp2pserver"
 	"github.com/filecoin-project/storetheindex/internal/registry"
 	p2pserver "github.com/filecoin-project/storetheindex/server/finder/libp2p"
 	"github.com/filecoin-project/storetheindex/server/finder/test"
@@ -17,7 +16,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
-func setupServer(ctx context.Context, ind indexer.Interface, reg *registry.Registry, idxCts *counter.IndexCounts, t *testing.T) (*libp2pserver.Server, host.Host) {
+func setupServer(ctx context.Context, ind indexer.Interface, reg *registry.Registry, idxCts *counter.IndexCounts, t *testing.T) (*p2pserver.FinderServer, host.Host) {
 	h, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/0"))
 	if err != nil {
 		t.Fatal(err)
@@ -123,7 +122,7 @@ func TestGetStats(t *testing.T) {
 	defer cancel()
 
 	// Initialize everything
-	ind := test.InitIndex(t, true)
+	ind := test.InitPebbleIndex(t, false)
 	defer ind.Close()
 	reg := test.InitRegistry(t)
 	defer reg.Close()
@@ -133,7 +132,7 @@ func TestGetStats(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	test.GetStatsTest(ctx, t, c)
+	test.GetStatsTest(ctx, t, ind, s.RefreshStats, c)
 }
 
 func TestRemoveProvider(t *testing.T) {

--- a/server/finder/libp2p/server.go
+++ b/server/finder/libp2p/server.go
@@ -10,7 +10,21 @@ import (
 	"github.com/libp2p/go-libp2p/core/host"
 )
 
+type FinderServer struct {
+	libp2pserver.Server
+	p2pHandler *libp2pHandler
+}
+
 // New creates a new libp2p server
-func New(ctx context.Context, h host.Host, indexer indexer.Interface, registry *registry.Registry, indexCounts *counter.IndexCounts) *libp2pserver.Server {
-	return libp2pserver.New(ctx, h, newHandler(indexer, registry, indexCounts))
+func New(ctx context.Context, h host.Host, indexer indexer.Interface, registry *registry.Registry, indexCounts *counter.IndexCounts) *FinderServer {
+	p2ph := newHandler(indexer, registry, indexCounts)
+	s := &FinderServer{
+		p2pHandler: p2ph,
+	}
+	s.Server = *libp2pserver.New(ctx, h, p2ph)
+	return s
+}
+
+func (s *FinderServer) RefreshStats() {
+	s.p2pHandler.finderHandler.RefreshStats()
 }

--- a/server/ingest/test/test.go
+++ b/server/ingest/test/test.go
@@ -9,10 +9,8 @@ import (
 	"time"
 
 	"github.com/filecoin-project/go-indexer-core"
-	"github.com/filecoin-project/go-indexer-core/cache"
-	"github.com/filecoin-project/go-indexer-core/cache/radixcache"
 	"github.com/filecoin-project/go-indexer-core/engine"
-	"github.com/filecoin-project/go-indexer-core/store/storethehash"
+	"github.com/filecoin-project/go-indexer-core/store/memory"
 	v0 "github.com/filecoin-project/storetheindex/api/v0"
 	"github.com/filecoin-project/storetheindex/api/v0/ingest/client"
 	"github.com/filecoin-project/storetheindex/api/v0/ingest/schema"
@@ -33,15 +31,7 @@ var rng = rand.New(rand.NewSource(1413))
 
 // InitIndex initialize a new indexer engine.
 func InitIndex(t *testing.T, withCache bool) indexer.Interface {
-	valueStore, err := storethehash.New(context.Background(), t.TempDir(), 4)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var resultCache cache.Interface
-	if withCache {
-		resultCache = radixcache.New(100000)
-	}
-	return engine.New(resultCache, valueStore)
+	return engine.New(nil, memory.New())
 }
 
 // InitRegistry initializes a new registry


### PR DESCRIPTION
When an existing indexer is configured to use an assigner service, that indexer may have registered providers/publishers where the publishers are not assigned. These should not be polled since the indexer does not have responsibility for them.

Also, stabilize stats tests by refreshing stats in order to have a non-zero entries count.