### PR TITLE
Deploy support for new delegated routing on `indexstar`

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
@@ -18,4 +18,4 @@ replicas:
 images:
   - name: indexstar
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/indexstar/indexstar
-    newTag:  20221201110144-97695b30018b73af427805d3a5065b357a0f41f2
+    newTag:  20221203114316-f76da437a6d701ddd414c0322d6547976c4ce0a1


### PR DESCRIPTION
Deploy support for the new HTTP delegated routing in `dev` environment for testing purposes.

See: https://github.com/ipni/indexstar/pull/45
