### PR TITLE
Deploy latest indexers to dev

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/README.md
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/README.md
@@ -4,5 +4,5 @@ List of individually configurable instances:
 
 | Instance | Storage Class |IOPS per GiB | Backing store | Running                                                                                                                                       |
 |----------|---------------|-------------|---------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
-| `ber`    | io2           |1            | Pebble        | [db83b7c9fab3615621063378fdda568c6e8ba209](https://github.com/filecoin-project/storetheindex/commit/db83b7c9fab3615621063378fdda568c6e8ba209) |
-| `cali`   | io2           |1            | Pebble        | [db83b7c9fab3615621063378fdda568c6e8ba209](https://github.com/filecoin-project/storetheindex/commit/db83b7c9fab3615621063378fdda568c6e8ba209) |
+| `ber`    | io2           |1            | Pebble        | [db83b7c9fab3615621063378fdda568c6e8ba209](https://github.com/filecoin-project/storetheindex/commit/9bdf7023f520aec1526e82dcb153e37d7eccd880) |
+| `cali`   | io2           |1            | Pebble        | [db83b7c9fab3615621063378fdda568c6e8ba209](https://github.com/filecoin-project/storetheindex/commit/9bdf7023f520aec1526e82dcb153e37d7eccd880) |

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -8,4 +8,4 @@ resources:
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}
-  newTag: 20221202100425-3d964311737ecfd308495164c297e5d9a4d348c9 # {"$imagepolicy": "storetheindex:storetheindex:tag"}
+  newTag: 20221203101550-9bdf7023f520aec1526e82dcb153e37d7eccd880 # {"$imagepolicy": "storetheindex:storetheindex:tag"}


### PR DESCRIPTION
This prevents the indexers from polling unassigned publishers.
