### PR TITLE
Deploy latest to `indexstar` with changes to delegation routing

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
@@ -18,4 +18,4 @@ replicas:
 images:
   - name: indexstar
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/indexstar/indexstar
-    newTag:  20221203163907-ae7e6434760b4a451e3906e6197b29ab32f89ca0
+    newTag:  20221207164414-ec5ab278c30737eb21046ec485eec2deb32191f6


### PR DESCRIPTION
Deploy the latest changes to translated delegated routing on `dev`, which introduces a dedicated field, `Schema`.

See:
 - https://github.com/ipni/indexstar/pull/52
