### PR TITLE
Configure indexers to use assigner service

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/assigner/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/assigner/config.json
@@ -17,7 +17,11 @@
       },
       {
         "AdminURL": "http://oden-indexer:3002",
-        "IngestURL": "http://oden-indexer:3001"
+        "IngestURL": "http://oden-indexer:3001",
+        "PresetPeers": [
+          "QmQzqxhK82kAmKvARFZSkUVS6fo9sySaiogAnx5EnZ6ZmC",
+          "12D3KooW9yi2xLhXds9HC4x9vRN99mphq6ds8qN2YRf8zks1F32G"
+        ]
       }
     ],
     "Policy": {
@@ -25,7 +29,7 @@
       "Except": null
     },
     "PubSubTopic": "/indexer/ingest/mainnet",
-    "Replication": 1
+    "Replication": 2
   },
   "Bootstrap": {
     "Peers": [
@@ -49,7 +53,7 @@
   },
   "Daemon": {
     "HTTPAddr": "/ip4/0.0.0.0/tcp/3001",
-    "P2PAddr": "/ip4/0.0.0.0/tcp/3000",
+    "P2PAddr": "/ip4/0.0.0.0/tcp/3003",
     "NoResourceManager": false
   },
   "Logging": {

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/assigner/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/assigner/kustomization.yaml
@@ -25,4 +25,4 @@ configMapGenerator:
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-  newTag: 20221202100425-3d964311737ecfd308495164c297e5d9a4d348c9
+  newTag: 20221206014628-cce5307191f067627811b4e96f1bc76f07a86ac1

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/config.json
@@ -51,7 +51,8 @@
     "PollStopAfter": "168h0m0s",
     "PollOverrides": null,
     "RediscoverWait": "5m0s",
-    "Timeout": "2m0s"
+    "Timeout": "2m0s",
+    "UseAssigner": true
   },
   "Indexer": {
     "CacheSize": -1,
@@ -93,7 +94,7 @@
   },
   "Peering": {
     "Peers": [
-      "/dns4/kepa-indexer/tcp/3003/p2p/12D3KooWJMn6BzkMixb2w8hR83Jpvugbqw3pBXwHqmbiFxh7nHz3"
+      "/dns4/assigner/tcp/3003/p2p/12D3KooWQAymjDKMivbkUNiJP7ChRsvsDuazerHW4wERRvQMWNor"
     ]
   }
 }

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kepa/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kepa/config.json
@@ -51,7 +51,8 @@
     "PollStopAfter": "168h0m0s",
     "PollOverrides": null,
     "RediscoverWait": "5m0s",
-    "Timeout": "2m0s"
+    "Timeout": "2m0s",
+    "UseAssigner": true
   },
   "Indexer": {
     "CacheSize": -1,
@@ -92,6 +93,8 @@
     }
   },
   "Peering": {
-    "Peers": null
+    "Peers": [
+      "/dns4/assigner/tcp/3003/p2p/12D3KooWQAymjDKMivbkUNiJP7ChRsvsDuazerHW4wERRvQMWNor"
+    ]
   }
 }

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/config.json
@@ -60,7 +60,8 @@
       }
     ],
     "RediscoverWait": "5m0s",
-    "Timeout": "2m0s"
+    "Timeout": "2m0s",
+    "UseAssigner": true
   },
   "Indexer": {
     "CacheSize": -1,
@@ -101,7 +102,7 @@
   },
   "Peering": {
     "Peers": [
-      "/dns4/kepa-indexer/tcp/3003/p2p/12D3KooWJMn6BzkMixb2w8hR83Jpvugbqw3pBXwHqmbiFxh7nHz3"
+      "/dns4/assigner/tcp/3003/p2p/12D3KooWQAymjDKMivbkUNiJP7ChRsvsDuazerHW4wERRvQMWNor"
     ]
   }
 }

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -9,4 +9,4 @@ resources:
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}
-  newTag: 0.5.1 # {"$imagepolicy": "storetheindex:storetheindex:tag"}
+  newTag: 0.5.3 # {"$imagepolicy": "storetheindex:storetheindex:tag"}


### PR DESCRIPTION
- Configure assigner for replication of 2
- Configure assigner to assign NFT storage to oden node
- Configure all indexers to peer to assigner node (instead of kepa)
- Configure all indexers to use assigner service
- Configure all indexers and assigner to use v0.5.3 image
