### PR TITLE
Use consistent port for libp2p listener

### DIFF
--- a/assigner/config/daemon.go
+++ b/assigner/config/daemon.go
@@ -5,8 +5,8 @@ type Daemon struct {
 	// HTTPAddr is the HTTP host multiaddr for receiving direct announce
 	// messages. Set to "none" to disable HTTP hosting.
 	HTTPAddr string
-	// P2PAddr is the libp2p host multiaddr for receiving announce messages. Set to "none" to
-	// disable libp2p hosting.
+	// P2PAddr is the libp2p host multiaddr for receiving announce messages.
+	// Set to "none" to disable libp2p hosting.
 	P2PAddr string
 	// NoResourceManager disables the libp2p resource manager when true.
 	NoResourceManager bool
@@ -16,7 +16,7 @@ type Daemon struct {
 func NewDaemon() Daemon {
 	return Daemon{
 		HTTPAddr: "/ip4/0.0.0.0/tcp/3001",
-		P2PAddr:  "/ip4/0.0.0.0/tcp/3000",
+		P2PAddr:  "/ip4/0.0.0.0/tcp/3003",
 	}
 }
 

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/assigner/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/assigner/config.json
@@ -45,7 +45,7 @@
   },
   "Daemon": {
     "HTTPAddr": "/ip4/0.0.0.0/tcp/3001",
-    "P2PAddr": "/ip4/0.0.0.0/tcp/3000",
+    "P2PAddr": "/ip4/0.0.0.0/tcp/3003",
     "NoResourceManager": false
   },
   "Logging": {

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/assigner/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/assigner/kustomization.yaml
@@ -25,4 +25,4 @@ configMapGenerator:
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-  newTag: 20221202100425-3d964311737ecfd308495164c297e5d9a4d348c9
+  newTag: 20221206014628-cce5307191f067627811b4e96f1bc76f07a86ac1

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/config.json
@@ -93,6 +93,8 @@
     }
   },
   "Peering": {
-    "Peers": null
+    "Peers": [
+      "/dns4/assigner/tcp/3003/p2p/12D3KooWDBjcDRQ7CKJeF9Yy3UKbriHfyETDrXKzTDB6biH3ibBd"
+    ]
   }
 }

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/config.json
@@ -94,7 +94,7 @@
   },
   "Peering": {
     "Peers": [
-      "/dns4/ber-indexer/tcp/3003/p2p/12D3KooWSQpUgBZwbNuMN3ctZjMesnoH9UDhwEXroxParXQCgurN"
+      "/dns4/assigner/tcp/3003/p2p/12D3KooWDBjcDRQ7CKJeF9Yy3UKbriHfyETDrXKzTDB6biH3ibBd"
     ]
   }
 }


### PR DESCRIPTION
Indexers all use port 3003 for their libp2p listener, and the assigner should use this also by default.

- Update assigner to latest image
- Peer ber-indexer and cali-indexer to assigner
