### PR TITLE
Assigner waits to get existing assignments from indexers

### DIFF
--- a/assigner/core/assigner.go
+++ b/assigner/core/assigner.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
@@ -28,6 +29,8 @@ type Assigner struct {
 	assigned map[peer.ID]*assignment
 	// indexerPool is the set of indexers to assign publishers to.
 	indexerPool []indexerInfo
+	// initDone is true when assignments have been read from all indexers.
+	initDone bool
 	// mutex protects assigned.
 	mutex   sync.Mutex
 	p2pHost host.Host
@@ -78,6 +81,7 @@ type indexerInfo struct {
 	adminURL  string
 	ingestURL string
 	assigned  int32
+	initDone  bool
 }
 
 // assignedCount returns the number of publishers assigned to this indexer.
@@ -106,9 +110,6 @@ func NewAssigner(ctx context.Context, cfg config.Assignment, p2pHost host.Host) 
 		return nil, err
 	}
 
-	// Get the publishers currently assigned to each indexer in the pool.
-	assigned := initAssignments(ctx, indexerPool, presets)
-
 	policy, err := peerutil.NewPolicyStrings(cfg.Policy.Allow, cfg.Policy.Except)
 	if err != nil {
 		return nil, fmt.Errorf("bad allow policy: %s", err)
@@ -126,7 +127,7 @@ func NewAssigner(ctx context.Context, cfg config.Assignment, p2pHost host.Host) 
 	log.Infof("Assigner operating with %d indexers", len(indexerPool))
 
 	a := &Assigner{
-		assigned:    assigned,
+		assigned:    make(map[peer.ID]*assignment),
 		indexerPool: indexerPool,
 		p2pHost:     p2pHost,
 		policy:      policy,
@@ -134,6 +135,18 @@ func NewAssigner(ctx context.Context, cfg config.Assignment, p2pHost host.Host) 
 		receiver:    rcvr,
 		replication: cfg.Replication,
 		watchDone:   make(chan struct{}),
+	}
+
+	// Get the publishers currently assigned to each indexer in the pool. If
+	// assignments cannot be read from all, then retry later when an unassigned
+	// publisher is seen. Reduce the needed assignments for the publisher by
+	// the number of offline indexers to prevent ofer-assigning indexers in the
+	// pool.
+	downCount := a.initAssignments(ctx)
+	if downCount != 0 {
+		log.Warnw("Could not get existing assignments for all indexers in pool, will retry later")
+	} else {
+		log.Infow("Read assignments from all indexers")
 	}
 
 	go a.watch()
@@ -153,13 +166,17 @@ func (a *Assigner) IndexerAssignedCounts() []int {
 	return counts
 }
 
-func initAssignments(ctx context.Context, indexerPool []indexerInfo, presets map[peer.ID][]int) map[peer.ID]*assignment {
-	assigned := make(map[peer.ID]*assignment)
+func (a *Assigner) InitDone() bool {
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+	return a.initDone
+}
 
+func (a *Assigner) initAssignments(ctx context.Context) int {
 	// If a publisher is pre-assigned to specific indexers, then ignore
 	// any indexer that is not one of those pre-assigned.
 	wrongPreset := func(pubID peer.ID, indexerNum int) bool {
-		preset, usesPreset := presets[pubID]
+		preset, usesPreset := a.presets[pubID]
 		if usesPreset {
 			for _, p := range preset {
 				if p == indexerNum {
@@ -174,10 +191,16 @@ func initAssignments(ctx context.Context, indexerPool []indexerInfo, presets map
 		return false
 	}
 
-	for i := range indexerPool {
-		pubs, prefPubs, err := getAssignments(ctx, indexerPool[i].adminURL)
+	var needInit int
+	for i := range a.indexerPool {
+		if a.indexerPool[i].initDone {
+			continue
+		}
+
+		pubs, prefPubs, err := getAssignments(ctx, a.indexerPool[i].adminURL)
 		if err != nil {
-			log.Errorw("Could not get assignments from indexer", "err", err, "indexer", i, "adminURL", indexerPool[i].adminURL)
+			needInit++
+			log.Errorw("Could not get assignments from indexer", "err", err, "indexer", i, "adminURL", a.indexerPool[i].adminURL)
 			continue
 		}
 
@@ -186,37 +209,44 @@ func initAssignments(ctx context.Context, indexerPool []indexerInfo, presets map
 			if wrongPreset(pubID, i) {
 				continue
 			}
-			asmt, found := assigned[pubID]
+			asmt, found := a.assigned[pubID]
 			if !found {
 				asmt = &assignment{
 					indexers: []int{},
 				}
-				assigned[pubID] = asmt
+				a.assigned[pubID] = asmt
 			}
 			asmt.addIndexer(i)
-			indexerPool[i].assigned++
+			a.indexerPool[i].assigned++
 		}
-		log.Infof("Indexer %d has %d assignments", i, indexerPool[i].assigned)
+		log.Infof("Indexer %d has %d assignments", i, a.indexerPool[i].assigned)
 
 		// Add this indexer to each publisher's preferred assignments.
 		for _, pubID := range prefPubs {
 			if wrongPreset(pubID, i) {
 				continue
 			}
-			asmt, found := assigned[pubID]
+			asmt, found := a.assigned[pubID]
 			if !found {
 				asmt = &assignment{
 					indexers: []int{},
 				}
-				assigned[pubID] = asmt
+				a.assigned[pubID] = asmt
 			} else if asmt.hasIndexer(i) {
 				log.Errorw("Publisher assigned to indexer cannot be listed as preferred", "indexer", i, "publisher", pubID)
 				continue
 			}
 			asmt.preferred = append(asmt.preferred, i)
 		}
+
+		a.indexerPool[i].initDone = true
 	}
-	return assigned
+
+	if needInit == 0 {
+		a.initDone = true
+	}
+
+	return needInit
 }
 
 // indexersFromConfig reads the indexer pool config to create the indexer pool.
@@ -383,6 +413,7 @@ func (a *Assigner) closeNotifyAssignment(pubID peer.ID) {
 // watch fetches announce messages from the Receiver.
 func (a *Assigner) watch() {
 	defer close(a.watchDone)
+	var pending sync.WaitGroup
 
 	// Cancel any pending messages if this function exits.
 	ctx, cancel := context.WithCancel(context.Background())
@@ -402,8 +433,14 @@ func (a *Assigner) watch() {
 			continue
 		}
 
-		go a.makeAssignments(ctx, amsg, asmt, need)
+		pending.Add(1)
+		go func() {
+			a.makeAssignments(ctx, amsg, asmt, need)
+			pending.Done()
+		}()
 	}
+	// Wait for pending assignments in to complete.
+	pending.Wait()
 }
 
 // checkAssignment checks if a publisher is assigned to sufficient indexers.
@@ -433,8 +470,34 @@ func (a *Assigner) checkAssignment(pubID peer.ID) (*assignment, int) {
 			log.Debug("Publisher already assigned to all required indexers")
 			return nil, 0
 		}
+
+		need := required - len(asmt.indexers)
+		if !a.initDone {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+			downCount := a.initAssignments(ctx)
+			cancel()
+			// If the number of unavailable indexers is as many or more than needed, then do not do
+			// assignment since peer could already be assigned to offline indexers.
+			need -= downCount
+			if need <= 0 {
+				return nil, 0
+			}
+		}
+
 		asmt.processing = true
-		return asmt, required - len(asmt.indexers)
+		return asmt, need
+	}
+
+	if !a.initDone {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		downCount := a.initAssignments(ctx)
+		cancel()
+		// If the number of unavailable indexers is as many or more than needed, then do not do
+		// assignment since peer could already be assigned to offline indexers.
+		required -= downCount
+		if required <= 0 {
+			return nil, 0
+		}
 	}
 
 	// Publisher not yet assigned to an indexer, so make assignment.
@@ -488,7 +551,8 @@ func (a *Assigner) makeAssignments(ctx context.Context, amsg announce.Announce, 
 	for _, indexerNum := range candidates {
 		err := assignIndexer(ctx, a.indexerPool[indexerNum], amsg)
 		if err != nil {
-			log.Errorw("Could not assign publisher to indexer", "indexer", indexerNum, "adminURL", a.indexerPool[indexerNum].adminURL)
+			log.Errorw("Could not assign publisher to indexer", "err", err,
+				"indexer", indexerNum, "adminURL", a.indexerPool[indexerNum].adminURL)
 			continue
 		}
 		asmt.addIndexer(indexerNum)

--- a/assigner/core/assigner.go
+++ b/assigner/core/assigner.go
@@ -126,6 +126,13 @@ func NewAssigner(ctx context.Context, cfg config.Assignment, p2pHost host.Host) 
 
 	log.Infof("Assigner operating with %d indexers", len(indexerPool))
 
+	replication := cfg.Replication
+	if replication <= 0 {
+		replication = 1
+	} else if replication > len(indexerPool) {
+		replication = len(indexerPool)
+	}
+
 	a := &Assigner{
 		assigned:    make(map[peer.ID]*assignment),
 		indexerPool: indexerPool,
@@ -133,7 +140,7 @@ func NewAssigner(ctx context.Context, cfg config.Assignment, p2pHost host.Host) 
 		policy:      policy,
 		presets:     presets,
 		receiver:    rcvr,
-		replication: cfg.Replication,
+		replication: replication,
 		watchDone:   make(chan struct{}),
 	}
 
@@ -451,9 +458,6 @@ func (a *Assigner) checkAssignment(pubID peer.ID) (*assignment, int) {
 		required = len(preset)
 	} else {
 		required = a.replication
-		if required == 0 {
-			required = len(a.indexerPool)
-		}
 	}
 
 	a.mutex.Lock()

--- a/assigner/core/assigner_test.go
+++ b/assigner/core/assigner_test.go
@@ -463,7 +463,7 @@ func TestPoolIndexerOffline(t *testing.T) {
 		select {
 		case <-ready:
 		default:
-			http.Error(w, "not ready", 503)
+			http.Error(w, "not ready", http.StatusServiceUnavailable)
 			return
 		}
 

--- a/assigner/core/assigner_test.go
+++ b/assigner/core/assigner_test.go
@@ -76,6 +76,7 @@ func TestAssignerAll(t *testing.T) {
 
 	assigner, err := core.NewAssigner(ctx, cfgAssignment, nil)
 	require.NoError(t, err)
+	require.True(t, assigner.InitDone())
 
 	t.Log("Presets for", peer1IDStr, "=", assigner.Presets(peer1ID))
 	require.Equal(t, []int{0, 1}, assigner.Presets(peer1ID))
@@ -447,6 +448,97 @@ func TestAssignerPreferred(t *testing.T) {
 	require.Equal(t, 2, len(counts))
 	require.Equal(t, 0, counts[0])
 	require.Equal(t, 2, counts[1])
+
+	require.NoError(t, assigner.Close())
+}
+
+func TestPoolIndexerOffline(t *testing.T) {
+	fakeIndexer1 := newTestIndexer(nil)
+	defer fakeIndexer1.close()
+
+	ready := make(chan struct{})
+	fakeIndexer2 := newTestIndexer(func(w http.ResponseWriter, req *http.Request) {
+		defer req.Body.Close()
+
+		select {
+		case <-ready:
+		default:
+			http.Error(w, "not ready", 503)
+			return
+		}
+
+		if req.Method == "GET" {
+			switch req.URL.String() {
+			case "/ingest/assigned":
+				peers := []string{peer1IDStr}
+				data, err := json.Marshal(peers)
+				if err != nil {
+					panic(err.Error())
+				}
+				writeJsonResponse(w, http.StatusOK, data)
+			case "/ingest/preferred":
+				writeJsonResponse(w, http.StatusNoContent, nil)
+			default:
+				http.Error(w, "", http.StatusNotFound)
+			}
+		} else {
+			writeJsonResponse(w, http.StatusOK, nil)
+		}
+	})
+	defer fakeIndexer2.close()
+
+	cfgAssignment := config.Assignment{
+		// IndexerPool is the set of indexers the pool.
+		IndexerPool: []config.Indexer{
+			{
+				AdminURL:  fakeIndexer1.adminServer.URL,
+				IngestURL: fakeIndexer1.ingestServer.URL,
+			},
+			{
+				AdminURL:  fakeIndexer2.adminServer.URL,
+				IngestURL: fakeIndexer2.ingestServer.URL,
+			},
+		},
+		Policy: config.Policy{
+			Allow: true,
+		},
+		PubSubTopic: "testtopic",
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Should not get all initial assignments.
+	assigner, err := core.NewAssigner(ctx, cfgAssignment, nil)
+	require.NoError(t, err)
+	require.False(t, assigner.InitDone())
+
+	// Allow second indexer to work so that initialization can complete, and
+	// check that it is done after processing another announce.
+	close(ready)
+
+	asmtChan, cancel := assigner.OnAssignment(peer2ID)
+	defer cancel()
+
+	adCid, _ := cid.Decode("bafybeigvgzoolc3drupxhlevdp2ugqcrbcsqfmcek2zxiw5wctk3xjpjwy")
+	a, _ := multiaddr.NewMultiaddr("/ip4/127.0.0.1/tcp/9999")
+	addrInfo := peer.AddrInfo{
+		ID:    peer2ID,
+		Addrs: []multiaddr.Multiaddr{a},
+	}
+
+	err = assigner.Announce(ctx, adCid, addrInfo)
+	require.NoError(t, err)
+
+	timeout := time.NewTimer(3 * time.Second)
+	select {
+	case <-asmtChan:
+	case <-timeout.C:
+		t.Fatal("timed out waiting for assignment")
+	}
+	timeout.Stop()
+
+	require.True(t, assigner.InitDone())
 
 	require.NoError(t, assigner.Close())
 }


### PR DESCRIPTION
## Context
If an indexer is offline when the assigner service starts, the assigner cannot read the existing assignments or preferences from that indexer. The assigner will not know what publishers are assigned to that indexer, resulting in assigning those publishers to other indexers as announcements from them arrive.

The assigner service needs to retry getting indexer assignments before assigning a publisher to an indexer, since that publisher may already be assigned to an offline indexer. This prevents over-assigning publishers to the indexer pool.

Fixes #1118 

## Proposed Changes
If the assigner starts without getting assignment information for all indexers in the pool, then it will recheck each time an announce message is received from an unassigned peer. If there are still indexers offline, the assigner assumes that the peer may be assigned to an offline indexer and reduces the required number of assignments by the number of indexers offline.

This may mean that an unassigned peer will not get assigned until indexer(s) come back online. It is necessary to prevent over-assigning publishers to the indexer pool.

## Tests
Tests include starting with an indexer offline and testing that:
- Assignment information is initially unread
- Publisher is not assigned when indexers assignments are unknown
- After indexer is back online, all assignment info is all read when unassigned publisher seen
 
## Revert Strategy
Reverting will return to the previous situation and may require resetting indexer assignments.