### PR TITLE
Reset assignments on indexer

### DIFF
--- a/config/discovery.go
+++ b/config/discovery.go
@@ -49,6 +49,10 @@ type Discovery struct {
 	// Timeout is the maximum amount of time that the indexer will spend trying
 	// to discover and verify a new provider.
 	Timeout Duration
+	// RemoveOldAssignments, if true, removes persisted assignments of previous
+	// versions. When false, previous versions of persisted assignments are
+	// migrated. Only applies if UseAssigner is true.
+	RemoveOldAssignments bool
 	// UseAssigner configures the indexer to work with an assigner service.
 	// This also requires that Policy.Allow is false, making Policy.Except into
 	// a list of allowed peers. Peers listed in Policy.Except in the

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/config.json
@@ -52,6 +52,7 @@
     "PollOverrides": null,
     "RediscoverWait": "5m0s",
     "Timeout": "2m0s",
+    "RemoveOldAssignments": true,
     "UseAssigner": true
   },
   "Indexer": {

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kepa/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kepa/config.json
@@ -52,6 +52,7 @@
     "PollOverrides": null,
     "RediscoverWait": "5m0s",
     "Timeout": "2m0s",
+    "RemoveOldAssignments": true,
     "UseAssigner": true
   },
   "Indexer": {

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/config.json
@@ -58,6 +58,7 @@
     ],
     "RediscoverWait": "5m0s",
     "Timeout": "2m0s",
+    "RemoveOldAssignments": true,
     "UseAssigner": true
   },
   "Indexer": {


### PR DESCRIPTION
## Context
Due to the situation described in #1116, initial configuration of the production indexers to use the assigned service resulted in a very unbalanced assignment. This PR is a way to do a one-time reset of the assignments on the production indexer.

Fixes #1118 

## Proposed Changes
When persisted assignments of a previous version are present on an indexer, these are migrated to the new version. If the configuration value `Discovery.RemoveOldAssignments` is true, then the old version assignments are deleted instead.

Configuration of the production indexers is set to delete these assignments.

## Tests
manual testing

## Revert Strategy
Reverting will result in losing persisted assignments because they will not be recognized.