### PR TITLE
kepa should not republish direct announce messages

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kepa/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kepa/config.json
@@ -78,7 +78,7 @@
       "BlocksPerSecond": 0,
       "BurstSize": 500
     },
-    "ResendDirectAnnounce": true,
+    "ResendDirectAnnounce": false,
     "StoreBatchSize": 8192,
     "SyncSegmentDepthLimit": 2000,
     "SyncTimeout": "2h0m0s"


### PR DESCRIPTION
Only the assigner should be resending direct announcements. Otherwise, there will be unnecessary noise.