### PR TITLE
Deploy HTTP delegated routing metrics  to `dev`

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
@@ -18,4 +18,4 @@ replicas:
 images:
   - name: indexstar
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/indexstar/indexstar
-    newTag:  20221207164414-ec5ab278c30737eb21046ec485eec2deb32191f6
+    newTag:  20221215083801-f62bd46329541256e5bf435e60001d141388e47c


### PR DESCRIPTION
Deploy latest `indexstar` to `dev`.

Relates to:
- https://github.com/ipni/indexstar/issues/54
