### PR TITLE
Fix `PUT` route in HTTP delegated routing on `dev`

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
@@ -18,4 +18,4 @@ replicas:
 images:
   - name: indexstar
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/indexstar/indexstar
-    newTag:  20221215083801-f62bd46329541256e5bf435e60001d141388e47c
+    newTag:  20221215113602-67c9360d3785d2f77975c21287efffd99bc50bc2


### PR DESCRIPTION
Handle `PUT` to root of `/routing/v1/providers` as 501 and respond to `OPTIONS` correctly.
