### PR TITLE
Add disk usage metric for value store

### DIFF
--- a/assigner/core/assigner.go
+++ b/assigner/core/assigner.go
@@ -168,12 +168,10 @@ func NewAssigner(ctx context.Context, cfg config.Assignment, p2pHost host.Host) 
 		replication = len(indexerPool)
 	}
 
-	httpClient := &http.Client{}
-
 	a := &Assigner{
 		assigned:    make(map[peer.ID]*assignment),
 		indexerPool: indexerPool,
-		httpClient:  httpClient,
+		httpClient:  &http.Client{},
 		p2pHost:     p2pHost,
 		policy:      policy,
 		pollDone:    make(chan struct{}),

--- a/dagsync/subscriber_test.go
+++ b/dagsync/subscriber_test.go
@@ -791,7 +791,6 @@ func (b dagsyncPubSubBuilder) Build(t *testing.T, topicName string, pubSys hostS
 		pub, err = dtsync.NewPublisher(pubSys.host, pubSys.ds, pubSys.lsys, topicName, dtsync.WithAnnounceSenders(p2pSender))
 		require.NoError(t, err)
 		pubAddr = pubSys.host.Addrs()[0]
-		test.WaitForPublisher(pubSys.host, topicName, subSys.host.ID())
 	}
 	require.NoError(t, err)
 	sub, err := dagsync.NewSubscriber(subSys.host, subSys.ds, subSys.lsys, topicName, nil, subOpts...)

--- a/dagsync/subscriber_test.go
+++ b/dagsync/subscriber_test.go
@@ -235,6 +235,7 @@ func TestConcurrentSync(t *testing.T) {
 func TestSync(t *testing.T) {
 	err := quick.Check(func(dpsb dagsyncPubSubBuilder, ll llBuilder) bool {
 		return t.Run("Quickcheck", func(t *testing.T) {
+			t.Parallel()
 			pubSys := newHostSystem(t)
 			subSys := newHostSystem(t)
 			defer pubSys.close()
@@ -291,6 +292,7 @@ func TestSync(t *testing.T) {
 func TestSyncWithHydratedDataStore(t *testing.T) {
 	err := quick.Check(func(dpsb dagsyncPubSubBuilder, ll llBuilder) bool {
 		return t.Run("Quickcheck", func(t *testing.T) {
+			t.Parallel()
 			pubPrivKey, _, err := crypto.GenerateEd25519Key(cryptorand.Reader)
 			require.NoError(t, err)
 

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -701,11 +701,21 @@ func (ing *Ingester) metricsUpdater() {
 					return
 				}
 				if ing.indexCounts != nil {
+					var usage float64
+					usageStats, err := ing.reg.ValueStoreUsage()
+					if err != nil {
+						log.Errorw("Error getting disk usage", "err", err)
+					} else {
+						usage = usageStats.Percent
+					}
 					indexCount, err := ing.indexCounts.Total()
 					if err != nil {
 						log.Errorw("Error getting index counts", "err", err)
 					}
-					stats.Record(context.Background(), coremetrics.StoreSize.M(size), metrics.IndexCount.M(int64(indexCount)))
+					stats.Record(context.Background(),
+						coremetrics.StoreSize.M(size),
+						metrics.IndexCount.M(int64(indexCount)),
+						metrics.PercentUsage.M(usage))
 				}
 				hasUpdate = false
 			}

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -504,7 +504,6 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 			ing.indexCounts.AddCount(providerID, ad.ContextID, uint64(mhCount))
 		}
 	}
-	ing.signalMetricsUpdate()
 
 	if len(errsIngestingEntryChunks) > 0 {
 		return adIngestError{adIngestEntryChunkErr, fmt.Errorf("failed to ingest entry chunks: %v", errsIngestingEntryChunks)}
@@ -536,7 +535,6 @@ func (ing *Ingester) ingestEntryChunk(ctx context.Context, ad schema.Advertiseme
 		return fmt.Errorf("failed processing entries for advertisement: %w", err)
 	}
 
-	ing.signalMetricsUpdate()
 	return nil
 }
 

--- a/internal/metrics/server.go
+++ b/internal/metrics/server.go
@@ -36,6 +36,7 @@ var (
 	EntriesSyncLatency   = stats.Float64("ingest/entriessynclatency", "How long it took to sync an Ad's entries", stats.UnitMilliseconds)
 	MhStoreNanoseconds   = stats.Int64("ingest/mhstorenanoseconds", "Average nanoseconds to store one multihash", stats.UnitDimensionless)
 	IndexCount           = stats.Int64("provider/indexCount", "Number of indexes stored for all providers", stats.UnitDimensionless)
+	PercentUsage         = stats.Float64("ingest/percentusage", "Percent usage of storage available in value store", stats.UnitDimensionless)
 )
 
 // Views
@@ -99,6 +100,10 @@ var (
 		Measure:     IndexCount,
 		Aggregation: view.LastValue(),
 	}
+	percentUsageView = &view.View{
+		Measure:     PercentUsage,
+		Aggregation: view.LastValue(),
+	}
 )
 
 var log = logging.Logger("indexer/metrics")
@@ -121,6 +126,7 @@ func Start(views []*view.View) http.Handler {
 		adLoadError,
 		mhStoreNanosecondsView,
 		indexCountView,
+		percentUsageView,
 	)
 	if err != nil {
 		log.Errorf("cannot register metrics default views: %s", err)


### PR DESCRIPTION
Maintain a disk usage metric, percent usage, for the file system located at the location of the value store.

This addresses #119 and #484

Also removed useless metrics update signaling:

Ingestion metrics are updated periodically if an update has been signaled. If the indexer has any activity, update is signaled. So in almost all cases the update is signaled. If the indexer has no activity, there is no point in avoiding the update because the indexer has nothing better to do, plus the metrics should still be updated as they may be affected by other external factors like fs usage or storage compacting.

So, remove the update signaling since it does not help anything, and only causes unnecessary context switches. Simply update the metrics periodically instead.