### PR TITLE
Option to store advertisements and entries in a separate datastore

### DIFF
--- a/config/datastore.go
+++ b/config/datastore.go
@@ -6,6 +6,12 @@ type Datastore struct {
 	// absolute path then the location is relative to the indexer repo
 	// directory.
 	Dir string
+	// DirAdvertisements specifies to keep advertisements in a separate
+	// datastore directory, using a separate datastore instance. If this is not
+	// set or is set to the same value as Dir, then the same datastore instance
+	// is used to store advertisements. If this is not an absolute path then
+	// the location is relative to the indexer repo directory.
+	DirAdvertisements string
 	// Type is the type of datastore.
 	Type string
 }

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -41,6 +41,9 @@ type Ingest struct {
 	// IngestWorkerCount sets how many ingest worker goroutines to spawn. This
 	// controls how many concurrent ingest from different providers we can handle.
 	IngestWorkerCount int
+	// KeepAdvertisements, when true, prevents advertisements from being
+	// deleted after they are ingested.
+	KeepAdvertisements bool
 	// MinimumKeyLengt causes any multihash, that has a digest length less than
 	// this, to be ignored. If using storethehash, this value is automatically
 	// set to 4 if it was configured to be anything less.

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -330,7 +330,7 @@ func TestRestartDuringSync(t *testing.T) {
 	// Now we bring up the ingester again.
 	ingesterHost := mkTestHost(libp2p.Identity(te.ingesterPriv))
 	connectHosts(t, te.pubHost, ingesterHost)
-	ingester, err := NewIngester(defaultTestIngestConfig, ingesterHost, te.ingester.indexer, mkRegistry(t), te.ingester.ds, nil)
+	ingester, err := NewIngester(defaultTestIngestConfig, ingesterHost, te.ingester.indexer, mkRegistry(t), te.ingester.ds)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		ingester.Close()
@@ -1314,7 +1314,7 @@ func TestRateLimitConfig(t *testing.T) {
 	h := mkTestHost()
 
 	cfg := defaultTestIngestConfig
-	ingester, err := NewIngester(cfg, h, core, reg, store, nil)
+	ingester, err := NewIngester(cfg, h, core, reg, store)
 	require.NoError(t, err)
 	limiter := ingester.getRateLimiter(pubHost.ID())
 	require.NotNil(t, limiter)
@@ -1322,7 +1322,7 @@ func TestRateLimitConfig(t *testing.T) {
 	ingester.Close()
 
 	cfg.RateLimit.Apply = false
-	ingester, err = NewIngester(cfg, h, core, reg, store, nil)
+	ingester, err = NewIngester(cfg, h, core, reg, store)
 	require.NoError(t, err)
 	limiter = ingester.getRateLimiter(pubHost.ID())
 	require.NotNil(t, limiter)
@@ -1331,7 +1331,7 @@ func TestRateLimitConfig(t *testing.T) {
 
 	cfg.RateLimit.Apply = true
 	cfg.RateLimit.BlocksPerSecond = 0
-	ingester, err = NewIngester(cfg, h, core, reg, store, nil)
+	ingester, err = NewIngester(cfg, h, core, reg, store)
 	require.NoError(t, err)
 	limiter = ingester.getRateLimiter(pubHost.ID())
 	require.NotNil(t, limiter)
@@ -1579,7 +1579,7 @@ func mkIngestWithConfig(t *testing.T, h host.Host, cfg config.Ingest) (*Ingester
 	reg := mkRegistry(t)
 	core := mkIndexer(t, true)
 	indexCounts := counter.NewIndexCounts(store)
-	ing, err := NewIngester(cfg, h, core, reg, store, indexCounts)
+	ing, err := NewIngester(cfg, h, core, reg, store, WithIndexCounts(indexCounts))
 	require.NoError(t, err)
 	return ing, core, reg, indexCounts
 }

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -356,7 +356,7 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 		}
 		defer func() {
 			for _, c := range hamtCids {
-				err := ing.ds.Delete(ctx, datastore.NewKey(c.String()))
+				err := ing.dsAds.Delete(ctx, datastore.NewKey(c.String()))
 				if err != nil {
 					log.Errorw("Error deleting HAMT cid from datastore", "cid", c, "err", err)
 				}
@@ -524,7 +524,7 @@ func (ing *Ingester) ingestEntryChunk(ctx context.Context, ad schema.Advertiseme
 		// has finished. This prevents storing redundant information in several
 		// datastores.
 		entryChunkKey := datastore.NewKey(entryChunkCid.String())
-		err := ing.ds.Delete(ctx, entryChunkKey)
+		err := ing.dsAds.Delete(ctx, entryChunkKey)
 		if err != nil {
 			log.Errorw("Error deleting index from datastore", "err", err)
 		}
@@ -636,7 +636,7 @@ func (ing *Ingester) loadHamt(c cid.Cid) (*hamt.Node, error) {
 
 func (ing *Ingester) loadNode(c cid.Cid, prototype ipld.NodePrototype) (ipld.Node, error) {
 	key := datastore.NewKey(c.String())
-	val, err := ing.ds.Get(context.Background(), key)
+	val, err := ing.dsAds.Get(context.Background(), key)
 	if err != nil {
 		return nil, fmt.Errorf("cannot fetch the node from datastore: %w", err)
 	}

--- a/internal/ingest/option.go
+++ b/internal/ingest/option.go
@@ -1,0 +1,44 @@
+package ingest
+
+import (
+	"fmt"
+
+	"github.com/ipfs/go-datastore"
+	"github.com/ipni/storetheindex/internal/counter"
+)
+
+// configIngest contains all options for the ingester.
+type configIngest struct {
+	idxCounts *counter.IndexCounts
+	dsAds     datastore.Batching
+}
+
+// Option is a function that sets a value in a config.
+type Option func(*configIngest) error
+
+// getOpts creates a configIngest and applies Options to it.
+func getOpts(opts []Option) (configIngest, error) {
+	var cfg configIngest
+	for i, opt := range opts {
+		if err := opt(&cfg); err != nil {
+			return configIngest{}, fmt.Errorf("option %d error: %s", i, err)
+		}
+	}
+	return cfg, nil
+}
+
+// WithAdsDatastore configures a separate datastore for advertizements.
+func WithAdsDatastore(ds datastore.Batching) Option {
+	return func(c *configIngest) error {
+		c.dsAds = ds
+		return nil
+	}
+}
+
+// WithIndexCounts configures counting indexes using an IndexCounts instance.
+func WithIndexCounts(ic *counter.IndexCounts) Option {
+	return func(c *configIngest) error {
+		c.idxCounts = ic
+		return nil
+	}
+}

--- a/server/admin/http/server_test.go
+++ b/server/admin/http/server_test.go
@@ -310,7 +310,7 @@ func initIngest(t *testing.T, indx indexer.Interface, reg *registry.Registry) *i
 		t.Fatal(err)
 	}
 
-	ing, err := ingest.NewIngester(cfg, host, indx, reg, ds, nil)
+	ing, err := ingest.NewIngester(cfg, host, indx, reg, ds)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/ingest/http/handler_test.go
+++ b/server/ingest/http/handler_test.go
@@ -86,7 +86,7 @@ func init() {
 		panic(err)
 	}
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
-	ing, err := ingest.NewIngester(config.NewIngest(), host, idx, reg, ds, nil)
+	ing, err := ingest.NewIngester(config.NewIngest(), host, idx, reg, ds)
 	if err != nil {
 		panic(err)
 	}

--- a/server/ingest/test/test.go
+++ b/server/ingest/test/test.go
@@ -63,7 +63,7 @@ func InitIngest(t *testing.T, indx indexer.Interface, reg *registry.Registry) *i
 		t.Fatal(err)
 	}
 
-	ing, err := ingest.NewIngester(cfg, host, indx, reg, ds, nil)
+	ing, err := ingest.NewIngester(cfg, host, indx, reg, ds)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Separate datastore for ads and entries is optional and only done if the configuration `Datastore.DirAdvertisements` is set.

Added option, Ingest.KeepAdvertisements, to prevent advertisements and entries from being removed after ingestion.
