### PR TITLE
Update version in prep for deployment of freeze/handoff functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BIN := storetheindex
 all: vet test build
 
 build:
-	go build -ldflags "-X 'github.com/ipni/storetheindex/internal/version.GitVersion=$(git rev-list -1 HEAD)'"
+	go build -ldflags "-X 'github.com/ipni/storetheindex/version.GitVersion=$(git rev-list -1 HEAD)'"
 
 docker: Dockerfile clean
 	docker build . --force-rm -f Dockerfile -t storetheindex:$(shell git rev-parse --short HEAD)

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.5.4"
+  "version": "v0.5.5"
 }


### PR DESCRIPTION
Freeze/handoff functionality is a major feature that is the final part of the write-scalability solution. However, if does not introduce any breaking changes, so only a minor version update.

- Fixed Makefile to set version correctly.
