### PR TITLE
Remove unneeded code

### DIFF
--- a/api/v0/libp2pclient/client.go
+++ b/api/v0/libp2pclient/client.go
@@ -140,11 +140,7 @@ func (c *Client) Close() error {
 	}
 
 	if c.ownHost {
-		rm := c.host.Network().ResourceManager()
 		if err = c.host.Close(); err != nil {
-			return err
-		}
-		if err = rm.Close(); err != nil {
 			return err
 		}
 	}

--- a/dagsync/p2p/protocol/head/head.go
+++ b/dagsync/p2p/protocol/head/head.go
@@ -57,13 +57,6 @@ func QueryRootCid(ctx context.Context, host host.Host, topic string, peerID peer
 	client := http.Client{
 		Transport: &http.Transport{
 			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-				addrInfo := peer.AddrInfo{
-					ID: peerID,
-				}
-				err := host.Connect(ctx, addrInfo)
-				if err != nil {
-					return nil, err
-				}
 				conn, err := gostream.Dial(ctx, host, peerID, deriveProtocolID(topic))
 				if err != nil {
 					// If protocol ID is wrong, then try the old "double-slashed" protocol ID.


### PR DESCRIPTION
- Remove code to resolve address before gostream.Dial
- No longer necessary to explicitly close resource manager