### PR TITLE
Deploy `dhstore` to `dev` on minimal resources

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dhstore
+spec:
+  template:
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+      containers:
+        - name: dhstore
+          args:
+            - '--storePath=/data'
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            limits:
+              cpu: "3"
+              memory: 10Gi
+            requests:
+              cpu: "3"
+              memory: 10Gi
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: dhstore-data

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore/internal-service.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore/internal-service.yaml
@@ -1,0 +1,26 @@
+# DHStore internal service, accessible only within K8S cluster VPC via:
+#  - http://dhstore.internal.dev.cid.contact
+#
+# See: https://github.com/ipni/dhstore
+kind: Service
+apiVersion: v1
+metadata:
+  name: dhstore-internal
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internal
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+    external-dns.alpha.kubernetes.io/access: private
+    external-dns.alpha.kubernetes.io/hostname: dhstore.internal.dev.cid.contact
+  labels:
+    app: dhstore
+spec:
+  externalTrafficPolicy: Cluster
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+  selector:
+    app: dhstore
+  type: LoadBalancer

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - github.com/ipni/dhstore/deploy/kubernetes?ref=58dfcad7aae9c172c68237dad25494625d8ac160
+  - pvc.yaml
+  - internal-service.yaml
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: dhstore
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
+    newTag: 20230118112018-58dfcad7aae9c172c68237dad25494625d8ac160

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore/pvc.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dhstore-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Ti
+  storageClassName: io2

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - assigner
 - instances
 - indexstar
+- dhstore
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}


### PR DESCRIPTION
Deploy `dhstore` as an internally accessible service only on `dev` with minimal resource demand and a 10Ti `io2` PVC volume.

The internal service configures an internal DNS name for the service, resolvable only within the VPC pointing at an internal NLB.

