### PR TITLE
Upgrade to latest indexstar on `dev` and configure dhstore backend

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -17,6 +17,7 @@ spec:
             # TLS handshake overhead.
             - '--backends=http://ber-indexer:3000/'
             - '--backends=http://cali-indexer:3000/'
+            - '--backends=http://dhstore.internal.dev.cid.contact/'
           resources:
             limits:
               cpu: "3"

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
@@ -18,4 +18,4 @@ replicas:
 images:
   - name: indexstar
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/indexstar/indexstar
-    newTag:  20221215113602-67c9360d3785d2f77975c21287efffd99bc50bc2
+    newTag:  20230116130936-91b0b589df99e9447c7cadfa90a6f39f354a290e


### PR DESCRIPTION
Upgrade to the latest indexstar in order to roll out encrypted results aggregation capability.

Configure `dhstore` as a backend.
