### PR TITLE
Update version to deploy multiaddr fix to prod

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.5.5"
+  "version": "v0.5.6"
 }


### PR DESCRIPTION
Turns out that a multiaddr with a p2p peer ID is not dialable. This new version has a fix for that.