### PR TITLE
Put fixed multiaddr into peerstore

### DIFF
--- a/dagsync/subscriber.go
+++ b/dagsync/subscriber.go
@@ -400,8 +400,9 @@ func (s *Subscriber) Sync(ctx context.Context, peerID peer.ID, nextCid cid.Cid, 
 
 	var peerAddrs []multiaddr.Multiaddr
 	if peerAddr != nil {
-		transport, pid := peer.SplitAddr(peerAddr)
-		peerAddrs = []multiaddr.Multiaddr{transport}
+		var pid peer.ID
+		peerAddr, pid = peer.SplitAddr(peerAddr)
+		peerAddrs = []multiaddr.Multiaddr{peerAddr}
 		if peerID == "" {
 			peerID = pid
 		}


### PR DESCRIPTION
Need to store the fixed multiaddr, with the p2p peer ID removed, in the peerstore. This is a follow-up to #1160