### PR TITLE
Revert assigner deployment strategy

### DIFF
--- a/deploy/manifests/base/assigner/deployment.yaml
+++ b/deploy/manifests/base/assigner/deployment.yaml
@@ -8,9 +8,6 @@ spec:
   selector:
     matchLabels:
       app: assigner
-  # Terminate previous assigner before rolling out new ones to avoid conflicts between assignments.
-  strategy:
-    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
It appears to be causing a deployment problem: Deployment/storetheindex/assigner dry-run failed, reason: Invalid, error: Deployment.apps "assigner" is invalid: spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'...
