### PR TITLE
Test assigner `Recreate` redeployment strategy on dev only take 2

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/assigner/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/assigner/deployment.yaml
@@ -3,6 +3,9 @@ kind: Deployment
 metadata:
   name: assigner
 spec:
+  # Terminate previous assigner before rolling out new ones to avoid conflicts between assignments.
+  strategy:
+    type: Recreate
   template:
     spec:
       containers:

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore/deployment.yaml
@@ -3,9 +3,6 @@ kind: Deployment
 metadata:
   name: dhstore
 spec:
-  # Terminate previous assigner before rolling out new ones to avoid conflicts between assignments.
-  strategy:
-    type: Recreate
   template:
     spec:
       topologySpreadConstraints:


### PR DESCRIPTION
Revert changes to `dhstore` done by mistake

Try out deployment strategy `Recreate` on dev only in order to investigate earlier deployment issues.

Relates to:
 - https://github.com/ipni/storetheindex/pull/1172

