### PR TITLE
Override default rolling update strategy in assigner

### DIFF
--- a/deploy/manifests/base/assigner/deployment.yaml
+++ b/deploy/manifests/base/assigner/deployment.yaml
@@ -8,6 +8,14 @@ spec:
   selector:
     matchLabels:
       app: assigner
+  # Terminate previous assigner before rolling out new ones to avoid conflicts between assignments.
+  strategy:
+    type: Recreate
+    # Explicitly override the default rolling update configuration. Otherwise, the manifest will be 
+    # invalid when strategy.type is set to Recreate.
+    # See:
+    #  - https://github.com/kubernetes/kubernetes/issues/24198
+    rollingUpdate: null
   template:
     metadata:
       labels:

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/assigner/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/assigner/deployment.yaml
@@ -3,9 +3,6 @@ kind: Deployment
 metadata:
   name: assigner
 spec:
-  # Terminate previous assigner before rolling out new ones to avoid conflicts between assignments.
-  strategy:
-    type: Recreate
   template:
     spec:
       containers:


### PR DESCRIPTION
The assigner service should always run as a singular instance. By default, deployment objects use a rolling update strategy with 25% surge. This means when the assigner service is redeployed a pod is started first and until that pod is not `READY` the old one won't be terminated.

Kubernetes also supports a `Recreate` strategy, where pods are explicitly terminated before new ones are created, which is the one we are looking for. However, because the default keys for strategy are populated we end up with an invalid manifest if only `type` is set to `Recreate`, where we have both rolling update config and type recreate.

To avoid this, explicitly override `rollingUpdate` config to `null`. See inline code comments for related K8S issue.

The changes here fixes this for assigner overlay at `base` which should apply to both `dev` and `prod` environments.

Relates to:
 - https://github.com/ipni/storetheindex/pull/1172

