### PR TITLE
Run containers with latest code on `ago` and `dhstore`

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore/kustomization.yaml
@@ -14,4 +14,4 @@ patchesStrategicMerge:
 images:
   - name: dhstore
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
-    newTag: 20230118112018-58dfcad7aae9c172c68237dad25494625d8ac160
+    newTag: 20230120164631-7685266c6c2e2ae3eb7a17f1bc2df28595d977fc

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/kustomization.yaml
@@ -29,3 +29,7 @@ patchesStrategicMerge:
   - deployment.yaml
   - pvc_data.yaml
 
+images:
+  - name: storetheindex
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
+    newTag: 20230120104254-ce3bb6c48f9e431c634d2eeb722d465328f9be77


### PR DESCRIPTION
Run the latest version of the code that recognises dhstore config and adds extra logging for debugging purposes.

