### PR TITLE
Deploy `indexstar` fix to encrypted result response check

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
@@ -18,4 +18,4 @@ replicas:
 images:
   - name: indexstar
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/indexstar/indexstar
-    newTag:  20230120191239-878e5bcd5f2a8bb3bd5af6eb2f0971769fe27cbe
+    newTag:  20230122104340-5fb62f0d12ebaf7671d999870a4812ec9990c669


### PR DESCRIPTION
Deploy latest fixes to `indexstar` on `dev` that returns response to found encrypted multihash results.

Relates to:
 - https://github.com/ipni/indexstar/issues/61

