### PR TITLE
Skip metadata not found errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/ipld/go-ipld-prime v0.19.0
 	github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd
 	github.com/ipld/go-storethehash v0.3.13
-	github.com/ipni/go-indexer-core v0.7.1-0.20230120184340-38cba41d97e3
+	github.com/ipni/go-indexer-core v0.7.1-0.20230122165842-8feed957168a
 	github.com/libp2p/go-libp2p v0.23.4
 	github.com/libp2p/go-libp2p-gostream v0.5.0
 	github.com/libp2p/go-libp2p-pubsub v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -667,8 +667,8 @@ github.com/ipld/go-storethehash v0.3.13 h1:1T6kX5K57lAgxbsGitZEaZMAR3RdWch2kO8ok
 github.com/ipld/go-storethehash v0.3.13/go.mod h1:KCYpzmamubnSwm7fvWcCkm0aIwQh4WRNtzrKK4pVhAQ=
 github.com/ipni/dhstore v0.0.2-0.20230120184057-c54e9d7c72f7 h1:w4sIScjReSAME4FKuSPaUT0H6rUi4UxEy42lEi5QKJY=
 github.com/ipni/dhstore v0.0.2-0.20230120184057-c54e9d7c72f7/go.mod h1:CIz5tpqY9GRSTx2ZML3tmvCZzdDCudDuE3DP57R4ZYo=
-github.com/ipni/go-indexer-core v0.7.1-0.20230120184340-38cba41d97e3 h1:XBqu/fzwzmOmH1U5mBm9DrP28EwlTZ8a8yyIAq/k2xc=
-github.com/ipni/go-indexer-core v0.7.1-0.20230120184340-38cba41d97e3/go.mod h1:UluJCGNLKAWzxDgHX6zVD+hqpKQxEyuj+wkcAc9j4Po=
+github.com/ipni/go-indexer-core v0.7.1-0.20230122165842-8feed957168a h1:Oqx3NW0kEsMYAqPVuFVfQ1Dy8d7l7hvCJ0xVp791pJI=
+github.com/ipni/go-indexer-core v0.7.1-0.20230122165842-8feed957168a/go.mod h1:UluJCGNLKAWzxDgHX6zVD+hqpKQxEyuj+wkcAc9j4Po=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=


### PR DESCRIPTION
* If metadata has not been found as a part of Reader's Privacy workflow it won't result into an error. IPFS multihashes are missing metadata as they assume bitswap by default.
* Fix metadata http lookup path
* Update to the latest version of go-indexer-core that fixes `SplitValueKey` bug
