### PR TITLE
Increase max accepted request body size in indexstar

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -19,6 +19,11 @@ spec:
             - '--backends=http://cali-indexer:3000/'
             - '--backends=http://ago-indexer:3000/'
             - '--backends=http://dhstore.internal.dev.cid.contact/'
+          env:
+            # Increase maximum accepted request body to 1 MiB in order to allow batch finds requests
+            # by the `provider verify-ingest` CLI command. 
+            - name: SERVER_MAX_REQUEST_BODY_SIZE
+              value: '1048576'
           resources:
             limits:
               cpu: "3"

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -18,6 +18,11 @@ spec:
             - '--backends=http://dido-indexer:3000/'
             - '--backends=http://oden-indexer:3000/'
             - '--backends=http://kepa-indexer:3000/'
+          env:
+            # Increase maximum accepted request body to 1 MiB in order to allow batch finds requests
+            # by the `provider verify-ingest` CLI command. 
+            - name: SERVER_MAX_REQUEST_BODY_SIZE
+              value: '1048576' 
           resources:
             limits:
               cpu: "3"


### PR DESCRIPTION
To permit `provider verify-ingest` command to execute successfully increase the max accepted body size to the default in popular HTTP servers like nginx, i.e. 1 MiB. The default value of 8 KiB in indexstar seems a bit too conservative.
