### PR TITLE
Create private ECR repo for `caskadht`

### DIFF
--- a/deploy/infrastructure/common/ecr.tf
+++ b/deploy/infrastructure/common/ecr.tf
@@ -9,6 +9,7 @@ module "ecr_ue2" {
     "indexstar/indexstar",
     "ipni/heyfil",
     "ipni/dhstore",
+    "ipni/caskadht",
   ]
   tags = local.tags
 }


### PR DESCRIPTION
Create a private ECR repo for `caskadht` in preparation for pushing containers and deployment.

See: https://github.com/ipni/caskadht

