### PR TITLE
Track index lag for each provider

### DIFF
--- a/api/v0/finder/model/provider_info.go
+++ b/api/v0/finder/model/provider_info.go
@@ -11,6 +11,7 @@ type ProviderInfo struct {
 	AddrInfo              peer.AddrInfo
 	LastAdvertisement     cid.Cid            `json:",omitempty"`
 	LastAdvertisementTime string             `json:",omitempty"`
+	Lag                   int                `json:",omitempty"`
 	Publisher             *peer.AddrInfo     `json:",omitempty"`
 	IndexCount            uint64             `json:",omitempty"`
 	ExtendedProviders     *ExtendedProviders `json:",omitempty"`

--- a/command/providers.go
+++ b/command/providers.go
@@ -86,6 +86,9 @@ func showProviderInfo(pinfo *model.ProviderInfo) {
 	}
 	fmt.Println("    LastAdvertisement:", adCidStr)
 	fmt.Println("    LastAdvertisementTime:", timeStr)
+	if adCidStr != "" {
+		fmt.Println("    Lag:", pinfo.Lag)
+	}
 	fmt.Println("    Publisher:", pinfo.Publisher.ID)
 	fmt.Println("        Publisher Addrs:", pinfo.Publisher.Addrs)
 	if pinfo.FrozenAt.Defined() {

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -1075,13 +1075,15 @@ func (ing *Ingester) ingestWorkerLogic(ctx context.Context, provider peer.ID) {
 			entsCid = ai.ad.Entries.(cidlink.Link).Cid.String()
 		}
 
+		lag := splitAtIndex - count
 		log.Infow("Processing advertisement",
 			"adCid", ai.cid,
 			"entriesCid", entsCid,
 			"publisher", assignment.publisher,
-			"progress", fmt.Sprintf("%d of %d", count, splitAtIndex))
+			"progress", fmt.Sprintf("%d of %d", count, splitAtIndex),
+			"lag", lag)
 
-		err := ing.ingestAd(assignment.publisher, ai.cid, ai.ad, ai.resync, frozen)
+		err := ing.ingestAd(assignment.publisher, ai.cid, ai.ad, ai.resync, frozen, lag)
 		if err == nil {
 			// No error at all, this ad was processed successfully.
 			stats.Record(context.Background(), metrics.AdIngestSuccessCount.M(1))

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -254,6 +254,10 @@ func TestFailDuringResync(t *testing.T) {
 	// We still have the mhs from the head ad.
 	requireIndexedEventually(t, te.ingester.indexer, te.pubHost.ID(), allMHs[1:])
 
+	pinfo, ok := te.reg.ProviderInfo(te.pubHost.ID())
+	require.True(t, ok)
+	require.Equal(t, 1, pinfo.Lag)
+
 	latestSync, err := te.ingester.GetLatestSync(te.pubHost.ID())
 	require.NoError(t, err)
 	require.Equal(t, adHead.(cidlink.Link).Cid, latestSync)

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -139,7 +139,7 @@ func verifyAdvertisement(n ipld.Node, reg *registry.Registry) (peer.ID, error) {
 // source of the indexed content, the provider is where content can be
 // retrieved from. It is the provider ID that needs to be stored by the
 // indexer.
-func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Advertisement, resync, frozen bool) error {
+func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Advertisement, resync, frozen bool, lag int) error {
 	stats.Record(context.Background(), metrics.IngestChange.M(1))
 	var mhCount int
 	var entsSyncStart time.Time
@@ -251,7 +251,7 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 		}
 	}
 
-	err = ing.reg.Update(ctx, provider, publisher, adCid, extendedProviders)
+	err = ing.reg.Update(ctx, provider, publisher, adCid, extendedProviders, lag)
 	if err != nil {
 		return adIngestError{adIngestRegisterProviderErr, fmt.Errorf("could not register/update provider info: %w", err)}
 	}

--- a/internal/registry/apiconv.go
+++ b/internal/registry/apiconv.go
@@ -18,6 +18,7 @@ func RegToApiProviderInfo(pi *ProviderInfo, indexCount uint64, withExtMetadata b
 	apiPI := &model.ProviderInfo{
 		AddrInfo:   pi.AddrInfo,
 		IndexCount: indexCount,
+		Lag:        pi.Lag,
 	}
 	if pi.LastAdvertisement != cid.Undef {
 		apiPI.LastAdvertisement = pi.LastAdvertisement

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -83,6 +83,9 @@ type ProviderInfo struct {
 	LastAdvertisement cid.Cid `json:",omitempty"`
 	// LastAdvertisementTime is the time the latest advertisement was received.
 	LastAdvertisementTime time.Time
+	// Lag is how far the indexer is behing in processing the ad chain.
+	Lag int `json:",omitempty"`
+
 	// Publisher contains the ID of the provider info publisher.
 	Publisher peer.ID `json:",omitempty"`
 	// PublisherAddr contains the last seen publisher multiaddr.
@@ -612,7 +615,7 @@ func (r *Registry) FilterIPsEnabled() bool {
 // Update attempts to update the registry's provider information. If publisher
 // has a valid ID, then the supplied publisher data replaces the provider's
 // previous publisher information.
-func (r *Registry) Update(ctx context.Context, provider, publisher peer.AddrInfo, adCid cid.Cid, extendedProviders *ExtendedProviders) error {
+func (r *Registry) Update(ctx context.Context, provider, publisher peer.AddrInfo, adCid cid.Cid, extendedProviders *ExtendedProviders, lag int) error {
 	// Do not accept update if provider is not allowed.
 	if !r.policy.Allowed(provider.ID) {
 		return ErrNotAllowed
@@ -703,6 +706,7 @@ func (r *Registry) Update(ctx context.Context, provider, publisher peer.AddrInfo
 	if adCid != info.LastAdvertisement && adCid != cid.Undef {
 		info.LastAdvertisement = adCid
 		info.LastAdvertisementTime = now
+		info.Lag = lag
 	}
 	info.lastContactTime = now
 

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -110,7 +110,7 @@ func TestNewRegistryDiscovery(t *testing.T) {
 		Addrs: []multiaddr.Multiaddr{pubAddr},
 	}
 
-	err = r.Update(ctx, provider, publisher, cid.Undef, nil)
+	err = r.Update(ctx, provider, publisher, cid.Undef, nil, 0)
 	require.NoError(t, err)
 
 	r.Close()
@@ -153,7 +153,7 @@ func TestDiscoveryAllowed(t *testing.T) {
 	}
 	publisher := peer.AddrInfo{}
 
-	err = r.Update(ctx, provider, publisher, cid.Undef, nil)
+	err = r.Update(ctx, provider, publisher, cid.Undef, nil, 0)
 	require.NoError(t, err)
 
 	require.True(t, r.IsRegistered(peerID), "peer is not registered")
@@ -264,13 +264,13 @@ func TestDatastore(t *testing.T) {
 	require.NoError(t, err)
 	t.Log("created new registry with datastore")
 
-	err = r.Update(ctx, provider1, peer.AddrInfo{}, cid.Undef, nil)
+	err = r.Update(ctx, provider1, peer.AddrInfo{}, cid.Undef, nil, 0)
 	require.NoError(t, err)
 
 	mh, err := multihash.Sum([]byte("somedata"), multihash.SHA2_256, -1)
 	require.NoError(t, err)
 	adCid := cid.NewCidV1(cid.Raw, mh)
-	err = r.Update(ctx, provider2, publisher, adCid, extProviders)
+	err = r.Update(ctx, provider2, publisher, adCid, extProviders, 0)
 	require.NoError(t, err)
 
 	pinfo, allowed := r.ProviderInfo(provID1)
@@ -392,7 +392,7 @@ func TestAllowed(t *testing.T) {
 		Addrs: []multiaddr.Multiaddr{pubAddr},
 	}
 
-	err = r.Update(ctx, provider, publisher, cid.Undef, nil)
+	err = r.Update(ctx, provider, publisher, cid.Undef, nil, 0)
 	require.NoError(t, err)
 
 	// Check that provider is allowed.
@@ -475,7 +475,7 @@ func TestPollProvider(t *testing.T) {
 	pub := peer.AddrInfo{
 		ID: pubID,
 	}
-	err = r.Update(ctx, prov, pub, cid.Undef, nil)
+	err = r.Update(ctx, prov, pub, cid.Undef, nil, 0)
 	require.NoError(t, err)
 
 	poll := polling{
@@ -583,7 +583,7 @@ func TestPollProviderOverrides(t *testing.T) {
 	pub := peer.AddrInfo{
 		ID: pubID,
 	}
-	err = r.Update(ctx, prov, pub, cid.Undef, nil)
+	err = r.Update(ctx, prov, pub, cid.Undef, nil, 0)
 	if err != nil {
 		t.Fatal("failed to register directly:", err)
 	}
@@ -663,14 +663,14 @@ func TestRegistry_RegisterOrUpdateToleratesEmptyPublisherAddrs(t *testing.T) {
 		ID:    provId,
 		Addrs: []multiaddr.Multiaddr{ma},
 	}
-	err = subject.Update(ctx, provider, peer.AddrInfo{}, cid.Undef, nil)
+	err = subject.Update(ctx, provider, peer.AddrInfo{}, cid.Undef, nil, 0)
 	require.NoError(t, err)
 
 	// Assert that updating publisher for the registered provider with empty addrs does not panic.
 	mh, err := multihash.Sum([]byte("fish"), multihash.SHA2_256, -1)
 	require.NoError(t, err)
 	c := cid.NewCidV1(cid.Raw, mh)
-	err = subject.Update(ctx, provider, peer.AddrInfo{ID: publisherID}, c, nil)
+	err = subject.Update(ctx, provider, peer.AddrInfo{ID: publisherID}, c, nil, 0)
 	require.NoError(t, err)
 
 	info, _ := subject.ProviderInfo(provId)
@@ -679,7 +679,7 @@ func TestRegistry_RegisterOrUpdateToleratesEmptyPublisherAddrs(t *testing.T) {
 
 	// Register a publisher that has no addresses, but publisherID is same as
 	// provider. Registry should use provider's address as publisher.
-	err = subject.Update(ctx, provider, peer.AddrInfo{ID: provId}, c, nil)
+	err = subject.Update(ctx, provider, peer.AddrInfo{ID: provId}, c, nil, 0)
 	info, _ = subject.ProviderInfo(provId)
 	require.NoError(t, err)
 	require.NotNil(t, info)
@@ -720,7 +720,7 @@ func TestFilterIPs(t *testing.T) {
 		ID:    pubID,
 		Addrs: []multiaddr.Multiaddr{maddrPvt, pubAddr, maddrLocal},
 	}
-	err = reg.Update(ctx, provider, publisher, cid.Undef, nil)
+	err = reg.Update(ctx, provider, publisher, cid.Undef, nil, 0)
 	require.NoError(t, err)
 	reg.Close()
 
@@ -741,7 +741,7 @@ func TestFilterIPs(t *testing.T) {
 	require.Nil(t, pinfo.PublisherAddr)
 
 	// Check the Update filters IPs.
-	err = reg.Update(ctx, provider, publisher, cid.Undef, nil)
+	err = reg.Update(ctx, provider, publisher, cid.Undef, nil, 0)
 	require.NoError(t, err)
 	pinfo, _ = reg.ProviderInfo(provID)
 	require.NotNil(t, pinfo)
@@ -754,7 +754,7 @@ func TestFilterIPs(t *testing.T) {
 		Addrs: []multiaddr.Multiaddr{maddrPvt, pubAddr, maddrLocal},
 	}
 	// Check the Register filters IPs.
-	err = reg.Update(ctx, provider2, peer.AddrInfo{}, cid.Undef, nil)
+	err = reg.Update(ctx, provider2, peer.AddrInfo{}, cid.Undef, nil, 0)
 	require.NoError(t, err)
 	pinfo, _ = reg.ProviderInfo(pubID)
 	require.NotNil(t, pinfo)
@@ -812,7 +812,7 @@ func TestFreezeUnfreeze(t *testing.T) {
 	require.NoError(t, err)
 	adCid := cid.NewCidV1(cid.Raw, mh)
 
-	err = r.Update(ctx, prov, pub, adCid, nil)
+	err = r.Update(ctx, prov, pub, adCid, nil, 0)
 	require.NoError(t, err)
 
 	require.False(t, r.Frozen())
@@ -849,7 +849,7 @@ func TestFreezeUnfreeze(t *testing.T) {
 	require.NoError(t, err)
 	adCid2 := cid.NewCidV1(cid.Raw, mh)
 
-	err = r.Update(ctx, prov2, pub2, adCid2, nil)
+	err = r.Update(ctx, prov2, pub2, adCid2, nil, 0)
 	require.ErrorIs(t, err, ErrFrozen)
 
 	// Stop and restart registry and check providers are still frozen.

--- a/server/finder/http/handler_test.go
+++ b/server/finder/http/handler_test.go
@@ -57,7 +57,7 @@ func TestServer_CORSWithExpectedContentType(t *testing.T) {
 		Addrs: []multiaddr.Multiaddr{a},
 	}
 
-	err = reg.Update(context.Background(), provider, peer.AddrInfo{}, cid.Undef, nil)
+	err = reg.Update(context.Background(), provider, peer.AddrInfo{}, cid.Undef, nil, 0)
 	require.NoError(t, err)
 
 	tests := []struct {

--- a/server/finder/test/test.go
+++ b/server/finder/test/test.go
@@ -126,7 +126,7 @@ func ReframeFindIndexTest(ctx context.Context, t *testing.T, c client.Finder, rc
 		ID:    p,
 		Addrs: []multiaddr.Multiaddr{a},
 	}
-	err = reg.Update(ctx, provider, peer.AddrInfo{}, cid.Undef, nil)
+	err = reg.Update(ctx, provider, peer.AddrInfo{}, cid.Undef, nil, 0)
 	if err != nil {
 		t.Fatal("could not register provider info:", err)
 	}
@@ -166,7 +166,7 @@ func FindIndexTest(ctx context.Context, t *testing.T, c client.Finder, ind index
 		ID:    p,
 		Addrs: []multiaddr.Multiaddr{a},
 	}
-	err = reg.Update(ctx, provider, peer.AddrInfo{}, cid.Undef, nil)
+	err = reg.Update(ctx, provider, peer.AddrInfo{}, cid.Undef, nil, 0)
 	if err != nil {
 		t.Fatal("could not register provider info:", err)
 	}
@@ -343,7 +343,7 @@ func RemoveProviderTest(ctx context.Context, t *testing.T, c client.Finder, ind 
 		ID:    p,
 		Addrs: []multiaddr.Multiaddr{a},
 	}
-	err = reg.Update(ctx, provider, peer.AddrInfo{}, cid.Undef, nil)
+	err = reg.Update(ctx, provider, peer.AddrInfo{}, cid.Undef, nil, 0)
 	if err != nil {
 		t.Fatal("could not register provider info:", err)
 	}
@@ -459,7 +459,7 @@ func Register(ctx context.Context, t *testing.T, reg *registry.Registry) peer.ID
 		},
 	}
 
-	err = reg.Update(ctx, provider, peer.AddrInfo{}, cid.Undef, extProviders)
+	err = reg.Update(ctx, provider, peer.AddrInfo{}, cid.Undef, extProviders, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/finder/test/test_extended_providers.go
+++ b/server/finder/test/test_extended_providers.go
@@ -448,7 +448,7 @@ func createProviderAndPopulateIndexer(t *testing.T, ctx context.Context, ind ind
 		Addrs: addrs,
 	}
 
-	err := reg.Update(ctx, provider, peer.AddrInfo{}, cid.Undef, extendedProviders)
+	err := reg.Update(ctx, provider, peer.AddrInfo{}, cid.Undef, extendedProviders, 0)
 	require.NoError(t, err, "could not register provider info: %v", err)
 
 	return providerID, mhs

--- a/server/ingest/handler/ingest_handler.go
+++ b/server/ingest/handler/ingest_handler.go
@@ -68,7 +68,7 @@ func (h *IngestHandler) RegisterProvider(ctx context.Context, data []byte) error
 	}
 	publisher := peer.AddrInfo{}
 
-	return h.registry.Update(ctx, provider, publisher, cid.Undef, nil)
+	return h.registry.Update(ctx, provider, publisher, cid.Undef, nil, 0)
 }
 
 // IndexContent handles an IngestRequest
@@ -103,7 +103,7 @@ func (h *IngestHandler) IndexContent(ctx context.Context, data []byte) error {
 	}
 
 	// Register provider if not registered, or update addreses if already registered
-	err = h.registry.Update(ctx, provider, peer.AddrInfo{}, cid.Undef, nil)
+	err = h.registry.Update(ctx, provider, peer.AddrInfo{}, cid.Undef, nil, 0)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In the provider info, track how far behind the current sync the indexer is.

This can be seen in the output of the providers command:
```
$ ./storetheindex providers list
Provider 12D3KooWEDBLgMaCr6ZFwjDXr7eMXzb7s7SnHJHrYRYWYbQSxMif
    Addresses: [/ip4/147.75.63.129/tcp/4001 /ip4/147.75.63.129/tcp/4002/ws /ip4/147.75.63.129/udp/4001/quic /ip6/2604:1380:45f1:d800::3/tcp/4001 /ip6/2604:1380:45f1:d800::3/tcp/4002/ws /ip6/2604:1380:45f1:d800::3/udp/4001/quic]
    LastAdvertisement: baguqeerasgthifu4x7fk2tp4cj37jgzcajuqe64ad22ceis36ud42i3rzhoq
    LastAdvertisementTime: 2023-01-26T20:01:41Z
    Lag: 884
    Publisher: 12D3KooWQGDoQTwQPjWZzkJLWPErdTCPscF9bQBZB73yf8wpu9VZ
        Publisher Addrs: [/ip4/147.75.63.129/tcp/3103]
    IndexCount: 2300000
```

