### PR TITLE
Add ExtendedProviders to the double hashed client

### DIFF
--- a/api/v0/finder/client/http/dhash_client.go
+++ b/api/v0/finder/client/http/dhash_client.go
@@ -1,11 +1,13 @@
 package finderhttpclient
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/ipni/dhstore"
 	"github.com/ipni/go-indexer-core/store/dhash"
@@ -18,12 +20,14 @@ import (
 
 const (
 	metadataPath = "/metadata"
+	pcacheTtl    = 5 * time.Minute
 )
 
 type DHashClient struct {
 	Client
 
 	metadataUrl string
+	pcache      *providerCache
 }
 
 // NewDHashClient instantiates a new client that uses Reader Privacy API for querying data.
@@ -37,6 +41,13 @@ func NewDHashClient(baseURL string, options ...httpclient.Option) (*DHashClient,
 	return &DHashClient{
 		Client:      *c,
 		metadataUrl: baseURL + metadataPath,
+		pcache: &providerCache{
+			ttl:    pcacheTtl,
+			pinfos: make(map[peer.ID]*pinfoWrapper),
+			pinfoFetcher: func(ctx context.Context, pid peer.ID) (*model.ProviderInfo, error) {
+				return c.GetProvider(ctx, pid)
+			},
+		},
 	}, nil
 }
 
@@ -86,8 +97,6 @@ func (c *DHashClient) Find(ctx context.Context, mh multihash.Multihash) (*model.
 // decryptFindResponse decrypts EncMultihashResults and appends the decrypted values to
 // MultihashResults. It also fetches provider info and metadata for each value key.
 func (c *DHashClient) decryptFindResponse(ctx context.Context, resp *model.FindResponse, unhasher map[string]multihash.Multihash) error {
-	pinfoCache := make(map[peer.ID]*model.ProviderInfo)
-
 	// decrypt each value key using the original multihash
 	// then for each decrypted value key fetch provider's addr info
 	for _, encRes := range resp.EncryptedMultihashResults {
@@ -110,27 +119,19 @@ func (c *DHashClient) decryptFindResponse(ctx context.Context, resp *model.FindR
 				return err
 			}
 
-			// fetch provider info to populate peer.AddrInfo
-			pinfo := pinfoCache[pid]
-			if pinfo == nil {
-				pinfo, err = c.GetProvider(ctx, pid)
-				if err != nil {
-					return err
-				}
-				pinfoCache[pid] = pinfo
-			}
-
 			// fetch metadata
 			metadata, err := c.fetchMetadata(ctx, vk)
 			if err != nil {
 				return err
 			}
 
-			mhr.ProviderResults = append(mhr.ProviderResults, model.ProviderResult{
-				ContextID: ctxId,
-				Metadata:  metadata,
-				Provider:  pinfo.AddrInfo,
-			})
+			// fetch provider info alongside extended providers
+			results, err := c.pcache.getResults(ctx, pid, ctxId, metadata)
+			if err != nil {
+				return err
+			}
+
+			mhr.ProviderResults = append(mhr.ProviderResults, results...)
 		}
 		if len(mhr.ProviderResults) > 0 {
 			resp.MultihashResults = append(resp.MultihashResults, mhr)
@@ -171,4 +172,110 @@ func (c *DHashClient) fetchMetadata(ctx context.Context, vk []byte) ([]byte, err
 	}
 
 	return dhash.DecryptMetadata(findResponse.EncryptedMetadata, vk)
+}
+
+// providerCache caches ProviderInfo objects as well as indexes ContextualExtendedProviders by ContextID.
+// ProviderInfos are evicted from the cache after ttl. Missing / expired ProviderInfos are refreshed via
+// pinfoFetcher function.
+//
+// This struct is designed to be independent from double hashed client itself so that it can be used in the libp2p client
+// once it materialises.
+type providerCache struct {
+	ttl          time.Duration
+	pinfos       map[peer.ID]*pinfoWrapper
+	pinfoFetcher func(ctx context.Context, pid peer.ID) (*model.ProviderInfo, error)
+}
+
+type pinfoWrapper struct {
+	ts    time.Time
+	pinfo *model.ProviderInfo
+	cxps  map[string]*model.ContextualExtendedProviders
+}
+
+func (pc *providerCache) getResults(ctx context.Context, pid peer.ID, ctxID []byte, metadata []byte) ([]model.ProviderResult, error) {
+	wrapper := pc.pinfos[pid]
+
+	// If ProviderInfo isn't in the cache or if the record has expired - try to fetch a new ProviderInfo and update the cache
+	if wrapper == nil || time.Since(wrapper.ts) > pc.ttl {
+		pinfo, err := pc.pinfoFetcher(ctx, pid)
+		if err != nil {
+			return nil, err
+		}
+
+		wrapper := &pinfoWrapper{
+			ts:    time.Now(),
+			pinfo: pinfo,
+			cxps:  make(map[string]*model.ContextualExtendedProviders),
+		}
+		pc.pinfos[pinfo.AddrInfo.ID] = wrapper
+		for _, cxp := range pinfo.ExtendedProviders.Contextual {
+			wrapper.cxps[cxp.ContextID] = &cxp
+		}
+	}
+
+	results := make([]model.ProviderResult, 0, 1)
+
+	results = append(results, model.ProviderResult{
+		ContextID: ctxID,
+		Metadata:  metadata,
+		Provider:  wrapper.pinfo.AddrInfo,
+	})
+
+	// If override is set to true at the context level then the chain
+	// level EPs should be ignored for this context ID
+	override := false
+
+	// Adding context-level EPs if they exist
+	if contextualEpRecord, ok := wrapper.cxps[string(ctxID)]; ok {
+		override = contextualEpRecord.Override
+		for i, xpinfo := range contextualEpRecord.Providers {
+			xmd := contextualEpRecord.Metadatas[i]
+			// Skippng the main provider's record if its metadata is
+			// nil or is the same as the one retrieved from the
+			// indexer, because such EP record does not advertise any
+			// new protocol.
+			if xpinfo.ID == wrapper.pinfo.AddrInfo.ID &&
+				(len(xmd) == 0 || bytes.Equal(xmd, metadata)) {
+				continue
+			}
+			// Use metadata from advertisement if one hasn't been specified for the extended provider
+			if xmd == nil {
+				xmd = metadata
+			}
+
+			results = append(results, model.ProviderResult{
+				ContextID: ctxID,
+				Metadata:  xmd,
+				Provider:  xpinfo,
+			})
+		}
+	}
+
+	// If override is true then don't include chain-level EPs
+	if override {
+		return results, nil
+	}
+
+	// Adding chain-level EPs if such exist
+	for i, xpinfo := range wrapper.pinfo.ExtendedProviders.Providers {
+		xmd := wrapper.pinfo.ExtendedProviders.Metadatas[i]
+		// Skippng the main provider's record if its metadata is nil or
+		// is the same as the one retrieved from the indexer, because
+		// such EP record does not advertise any new protocol.
+		if xpinfo.ID == wrapper.pinfo.AddrInfo.ID &&
+			(len(xmd) == 0 || bytes.Equal(xmd, metadata)) {
+			continue
+		}
+		// Use metadata from advertisement if one hasn't been specified for the extended provider
+		if xmd == nil {
+			xmd = metadata
+		}
+		results = append(results, model.ProviderResult{
+			ContextID: ctxID,
+			Metadata:  xmd,
+			Provider:  xpinfo,
+		})
+	}
+
+	return results, nil
 }


### PR DESCRIPTION
* Add Extended Providers to the double hashed client in the same way as they are applied in `finder_handler`;
* Captured an [issue](https://github.com/ipni/storetheindex/issues/1214) to add an e2e for the full double hashed path;
