### PR TITLE
Deploy streaming fixes to indexstar on `dev` and upgrade `ago`

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
@@ -18,4 +18,4 @@ replicas:
 images:
   - name: indexstar
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/indexstar/indexstar
-    newTag:  20230201145329-83dd756ad67be0612e40c069f7d49622effca072
+    newTag:  20230201171255-cdf48e06d8767c6329fcc75121d85a555bfbfc06

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/kustomization.yaml
@@ -32,4 +32,4 @@ patchesStrategicMerge:
 images:
   - name: storetheindex
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-    newTag: 20230128095820-bfd17232f409d6805f31f6e385f01bd968f538ab
+    newTag: 20230201155321-7a726cb5e36a937cde80ee0ac95fcd222e409d93


### PR DESCRIPTION
Deploy fixes to stream handling on `indexstar` in dev and upgrade `ago` to run on the same instance as other nodes.
