### PR TITLE
Remove optional metadata query parameter

### DIFF
--- a/api/v0/finder/client/http/client.go
+++ b/api/v0/finder/client/http/client.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 
 	"github.com/ipni/storetheindex/api/v0/finder/model"
 	"github.com/ipni/storetheindex/api/v0/httpclient"
@@ -71,18 +70,12 @@ func (c *Client) FindBatch(ctx context.Context, mhs []multihash.Multihash) (*mod
 	return c.sendRequest(req)
 }
 
-func (c *Client) ListProviders(ctx context.Context, withExtMetadata bool) ([]*model.ProviderInfo, error) {
+func (c *Client) ListProviders(ctx context.Context) ([]*model.ProviderInfo, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.providersURL, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Add("Accept", "application/json")
-
-	if withExtMetadata {
-		q := url.Values{}
-		q.Add("metadata", "true")
-		req.URL.RawQuery = q.Encode()
-	}
 
 	resp, err := c.c.Do(req)
 	if err != nil {

--- a/api/v0/finder/client/interface.go
+++ b/api/v0/finder/client/interface.go
@@ -20,7 +20,7 @@ type Finder interface {
 	// ListPrividers gets information about all providers known to the indexer.
 	// The withExtMetadata requests that extended provider metedata be
 	// included in the response.
-	ListProviders(ctx context.Context, withExtMetadata bool) ([]*model.ProviderInfo, error)
+	ListProviders(ctx context.Context) ([]*model.ProviderInfo, error)
 
 	// GetStats get statistics for indexer.
 	GetStats(context.Context) (*model.Stats, error)

--- a/api/v0/finder/client/interface.go
+++ b/api/v0/finder/client/interface.go
@@ -18,8 +18,6 @@ type Finder interface {
 	// GetProvider gets information about the provider identified by peer.ID.
 	GetProvider(context.Context, peer.ID) (*model.ProviderInfo, error)
 	// ListPrividers gets information about all providers known to the indexer.
-	// The withExtMetadata requests that extended provider metedata be
-	// included in the response.
 	ListProviders(ctx context.Context) ([]*model.ProviderInfo, error)
 
 	// GetStats get statistics for indexer.

--- a/api/v0/finder/client/libp2p/client.go
+++ b/api/v0/finder/client/libp2p/client.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/ipni/storetheindex/api/v0"
+	v0 "github.com/ipni/storetheindex/api/v0"
 	"github.com/ipni/storetheindex/api/v0/finder/model"
 	pb "github.com/ipni/storetheindex/api/v0/finder/pb"
 	"github.com/ipni/storetheindex/api/v0/libp2pclient"
@@ -90,20 +90,9 @@ func (c *Client) GetProvider(ctx context.Context, providerID peer.ID) (*model.Pr
 	return &providerInfo, nil
 }
 
-func (c *Client) ListProviders(ctx context.Context, withExtMetadata bool) ([]*model.ProviderInfo, error) {
+func (c *Client) ListProviders(ctx context.Context) ([]*model.ProviderInfo, error) {
 	req := &pb.FinderMessage{
 		Type: pb.FinderMessage_LIST_PROVIDERS,
-	}
-
-	if withExtMetadata {
-		queryParams := make(map[string]string)
-		queryParams["metadata"] = "true"
-
-		var err error
-		req.Data, err = json.Marshal(queryParams)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	data, err := c.sendRecv(ctx, req, pb.FinderMessage_LIST_PROVIDERS_RESPONSE)

--- a/command/providers.go
+++ b/command/providers.go
@@ -59,7 +59,7 @@ func listProvidersCmd(cctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	provs, err := cl.ListProviders(cctx.Context, false)
+	provs, err := cl.ListProviders(cctx.Context)
 	if err != nil {
 		return err
 	}

--- a/internal/registry/apiconv.go
+++ b/internal/registry/apiconv.go
@@ -10,7 +10,7 @@ import (
 )
 
 // RegToApiProviderInfo converts provider info from registry to api objects.
-func RegToApiProviderInfo(pi *ProviderInfo, indexCount uint64, withExtMetadata bool) *model.ProviderInfo {
+func RegToApiProviderInfo(pi *ProviderInfo, indexCount uint64) *model.ProviderInfo {
 	if pi == nil {
 		return nil
 	}
@@ -42,25 +42,20 @@ func RegToApiProviderInfo(pi *ProviderInfo, indexCount uint64, withExtMetadata b
 		apiPI.FrozenAtTime = pi.FrozenAtTime.Format(time.RFC3339)
 	}
 
-	xpiToApi := func(xpis []ExtendedProviderInfo, withMeta bool) ([]peer.AddrInfo, [][]byte) {
+	xpiToApi := func(xpis []ExtendedProviderInfo) ([]peer.AddrInfo, [][]byte) {
 		if len(xpis) == 0 {
 			return nil, nil
 		}
 
 		apiProvs := make([]peer.AddrInfo, len(xpis))
-		var apiMetas [][]byte
-		if withMeta {
-			apiMetas = make([][]byte, len(xpis))
-		}
+		var apiMetas = make([][]byte, len(xpis))
 
 		for i := range xpis {
 			apiProvs[i] = peer.AddrInfo{
 				ID:    xpis[i].PeerID,
 				Addrs: xpis[i].Addrs,
 			}
-			if withMeta {
-				apiMetas[i] = xpis[i].Metadata
-			}
+			apiMetas[i] = xpis[i].Metadata
 		}
 
 		return apiProvs, apiMetas
@@ -68,14 +63,14 @@ func RegToApiProviderInfo(pi *ProviderInfo, indexCount uint64, withExtMetadata b
 
 	if pi.ExtendedProviders != nil {
 		xp := pi.ExtendedProviders
-		apiProvs, apiMetas := xpiToApi(xp.Providers, withExtMetadata)
+		apiProvs, apiMetas := xpiToApi(xp.Providers)
 
 		var apiCtxProvs []model.ContextualExtendedProviders
 		if len(xp.ContextualProviders) != 0 {
 			apiCtxProvs = make([]model.ContextualExtendedProviders, len(xp.ContextualProviders))
 			var i int
 			for contextID, cxp := range xp.ContextualProviders {
-				provs, metas := xpiToApi(cxp.Providers, withExtMetadata)
+				provs, metas := xpiToApi(cxp.Providers)
 				apiCtxProvs[i] = model.ContextualExtendedProviders{
 					Override:  cxp.Override,
 					ContextID: contextID,

--- a/internal/registry/apiconv_test.go
+++ b/internal/registry/apiconv_test.go
@@ -79,7 +79,7 @@ func TestRegToApiProviderInfo(t *testing.T) {
 		FrozenAtTime: frozenAtTime,
 	}
 
-	apiPI := RegToApiProviderInfo(&regPI, indexCount, true)
+	apiPI := RegToApiProviderInfo(&regPI, indexCount)
 	require.NotNil(t, apiPI)
 
 	require.Equal(t, regPI.AddrInfo, apiPI.AddrInfo)
@@ -124,6 +124,6 @@ func TestRegToApiProviderInfo(t *testing.T) {
 
 	require.Equal(t, regPI, *regPI2)
 
-	require.Nil(t, RegToApiProviderInfo(nil, 0, false))
+	require.Nil(t, RegToApiProviderInfo(nil, 0))
 	require.Nil(t, apiToRegProviderInfo(nil))
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -796,7 +796,7 @@ func (r *Registry) Handoff(ctx context.Context, publisherID, frozenID peer.ID, f
 	if err != nil {
 		return err
 	}
-	provs, err := cl.ListProviders(ctx, true)
+	provs, err := cl.ListProviders(ctx)
 	if err != nil {
 		return err
 	}
@@ -861,7 +861,7 @@ func (r *Registry) ImportProviders(ctx context.Context, fromURL *url.URL) (int, 
 		return 0, err
 	}
 
-	provs, err := cl.ListProviders(ctx, true)
+	provs, err := cl.ListProviders(ctx)
 	if err != nil {
 		return 0, err
 	}

--- a/server/finder/handler/finder_handler.go
+++ b/server/finder/handler/finder_handler.go
@@ -171,7 +171,7 @@ func (h *FinderHandler) fetchProviderInfo(provID peer.ID,
 	return pinfo
 }
 
-func (h *FinderHandler) ListProviders(withExtMetadata bool) ([]byte, error) {
+func (h *FinderHandler) ListProviders() ([]byte, error) {
 	infos := h.registry.AllProviderInfo()
 
 	responses := make([]model.ProviderInfo, len(infos))
@@ -184,7 +184,7 @@ func (h *FinderHandler) ListProviders(withExtMetadata bool) ([]byte, error) {
 				log.Errorw("Could not get provider index count", "err", err)
 			}
 		}
-		responses[i] = *registry.RegToApiProviderInfo(pInfo, indexCount, withExtMetadata)
+		responses[i] = *registry.RegToApiProviderInfo(pInfo, indexCount)
 	}
 
 	return json.Marshal(responses)
@@ -204,7 +204,7 @@ func (h *FinderHandler) GetProvider(providerID peer.ID) ([]byte, error) {
 			log.Errorw("Could not get provider index count", "err", err)
 		}
 	}
-	rsp := registry.RegToApiProviderInfo(info, indexCount, false)
+	rsp := registry.RegToApiProviderInfo(info, indexCount)
 	return json.Marshal(rsp)
 }
 

--- a/server/finder/http/handler.go
+++ b/server/finder/http/handler.go
@@ -119,13 +119,7 @@ func (h *httpHandler) getIndexes(w http.ResponseWriter, mhs []multihash.Multihas
 
 // GET /providers",
 func (h *httpHandler) listProviders(w http.ResponseWriter, r *http.Request) {
-	var withExtMetadata bool
-	vars := mux.Vars(r)
-	if len(vars) != 0 {
-		withExtMetadata = vars["metadata"] == "true"
-	}
-
-	data, err := h.finderHandler.ListProviders(withExtMetadata)
+	data, err := h.finderHandler.ListProviders()
 	if err != nil {
 		log.Errorw("cannot list providers", "err", err)
 		http.Error(w, "", http.StatusInternalServerError)

--- a/server/finder/libp2p/handler.go
+++ b/server/finder/libp2p/handler.go
@@ -122,19 +122,7 @@ func (h *libp2pHandler) find(ctx context.Context, p peer.ID, msg *pb.FinderMessa
 }
 
 func (h *libp2pHandler) listProviders(ctx context.Context, p peer.ID, msg *pb.FinderMessage) ([]byte, error) {
-	var withExtMetadata bool
-	data := msg.GetData()
-	if data != nil {
-		var queryParams map[string]string
-		err := json.Unmarshal(data, &queryParams)
-		if err != nil {
-			log.Errorw("error unmarshalling ListProviders request", "err", err)
-			return nil, v0.NewError(errors.New("cannot decode request"), http.StatusBadRequest)
-		}
-		withExtMetadata = queryParams["metadata"] == "true"
-	}
-
-	data, err := h.finderHandler.ListProviders(withExtMetadata)
+	data, err := h.finderHandler.ListProviders()
 	if err != nil {
 		log.Errorw("cannot list providers", "err", err)
 		return nil, v0.NewError(nil, http.StatusInternalServerError)

--- a/server/finder/test/test.go
+++ b/server/finder/test/test.go
@@ -278,7 +278,7 @@ func ListProvidersTest(t *testing.T, c client.Finder, providerID peer.ID) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	providers, err := c.ListProviders(ctx, false)
+	providers, err := c.ListProviders(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/finder/test/test.go
+++ b/server/finder/test/test.go
@@ -304,6 +304,7 @@ func verifyProviderInfo(t *testing.T, provInfo *model.ProviderInfo) {
 				Addrs: provInfo.ExtendedProviders.Providers[0].Addrs,
 			},
 		},
+		Metadatas: [][]byte{nil},
 		Contextual: []model.ContextualExtendedProviders{
 			{
 				Override:  true,
@@ -314,6 +315,7 @@ func verifyProviderInfo(t *testing.T, provInfo *model.ProviderInfo) {
 						Addrs: provInfo.ExtendedProviders.Contextual[0].Providers[0].Addrs,
 					},
 				},
+				Metadatas: [][]byte{nil},
 			},
 		},
 	})


### PR DESCRIPTION
Remove metadata query parameter that changed behaviour of whether metadata has been included into extended provider results. Including metadata is required so that the client can correctly assemble extended provider results.