### PR TITLE
Update indexstar on dev with separate stream timeout config

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
@@ -18,4 +18,4 @@ replicas:
 images:
   - name: indexstar
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/indexstar/indexstar
-    newTag:  20230201180813-a6793f971b3749b0585482e9d499701531e56b9f
+    newTag:  20230201190758-f61e21138983efaf2e1b2cb63df624c57ca045a4


### PR DESCRIPTION
Deploy the latest indexstar on dev that introduces a separate config for timeout value of streaming responses.

