### PR TITLE
Fix cascade labels for indexstar `OPTIONS` on dev

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -25,6 +25,9 @@ spec:
             # by the `provider verify-ingest` CLI command. 
             - name: SERVER_MAX_REQUEST_BODY_SIZE
               value: '1048576'
+            # The service provided by caskadht.
+            - name: SERVER_CASCADE_LABELS
+              value: 'ipfs-dht'
           resources:
             limits:
               cpu: "3"

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
@@ -18,4 +18,4 @@ replicas:
 images:
   - name: indexstar
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/indexstar/indexstar
-    newTag:  20230201190758-f61e21138983efaf2e1b2cb63df624c57ca045a4
+    newTag:  20230202152025-954d1fb82efdd902224e28718a7f79c304bd1d2f


### PR DESCRIPTION
Configure indexstar to return `ipfs-dht` on `OPTIONS` request as allowed cascade label.

