### PR TITLE
Run indexer in `dev` on cheaper instance types with less resources

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/eks.tf
+++ b/deploy/infrastructure/dev/us-east-2/eks.tf
@@ -21,7 +21,7 @@ module "eks" {
   }
 
   eks_managed_node_groups = {
-    # Node group used by double hashing indexer nodes
+    # Node group used by double hashing indexer nodes
     dev-ue2a-r6a-xl = {
       min_size       = 0
       max_size       = 3
@@ -29,7 +29,7 @@ module "eks" {
       instance_types = ["r6a.xlarge"]
       subnet_ids     = [data.aws_subnet.ue2a2.id]
     }
-    # Node group used by dhstore nodes
+    # Node group used by dhstore nodes
     dev-ue2c-r6a-xl = {
       min_size       = 0
       max_size       = 3
@@ -37,18 +37,13 @@ module "eks" {
       instance_types = ["r6a.xlarge"]
       subnet_ids     = [data.aws_subnet.ue2c2.id]
     }
+    # TODO: break into node groups per subnet for less cost
     dev-ue2-m4-xl-2 = {
       min_size       = 3
       max_size       = 7
       desired_size   = 3
       instance_types = ["m4.xlarge"]
       subnet_ids     = module.vpc.private_subnets
-    }
-    dev-ue2-r5a-2xl = {
-      min_size       = 0
-      max_size       = 7
-      desired_size   = 1
-      instance_types = ["r5a.2xlarge"]
     }
     # Node group primarily used by autoretrieve with PVC in us-east2a availability zone.
     dev-ue2a-r5a-2xl = {
@@ -72,7 +67,7 @@ module "eks" {
       }
     }
     dev-ue2b-r5b-4xl = {
-      min_size       = 1
+      min_size       = 0
       max_size       = 3
       desired_size   = 1
       instance_types = ["r5b.4xlarge"]
@@ -86,7 +81,7 @@ module "eks" {
       }
     }
     dev-ue2c-r5b-4xl = {
-      min_size       = 1
+      min_size       = 0
       max_size       = 3
       desired_size   = 1
       instance_types = ["r5b.4xlarge"]
@@ -95,6 +90,35 @@ module "eks" {
         dedicated = {
           key    = "dedicated"
           value  = "r5b-4xl"
+          effect = "NO_SCHEDULE"
+        }
+      }
+    }
+
+    dev-ue2b-r5n-2xl = {
+      min_size       = 1
+      max_size       = 3
+      desired_size   = 1
+      instance_types = ["r5n.2xlarge"]
+      subnet_ids     = [data.aws_subnet.ue2b2.id]
+      taints = {
+        dedicated = {
+          key    = "dedicated"
+          value  = "r5n-2xl"
+          effect = "NO_SCHEDULE"
+        }
+      }
+    }
+    dev-ue2c-r5n-2xl = {
+      min_size       = 1
+      max_size       = 3
+      desired_size   = 1
+      instance_types = ["r5n.2xlarge"]
+      subnet_ids     = [data.aws_subnet.ue2c2.id]
+      taints = {
+        dedicated = {
+          key    = "dedicated"
+          value  = "r5n-2xl"
           effect = "NO_SCHEDULE"
         }
       }

--- a/deploy/infrastructure/dev/us-east-2/vpc.tf
+++ b/deploy/infrastructure/dev/us-east-2/vpc.tf
@@ -90,6 +90,23 @@ data "aws_subnet" "ue2b1" {
   }
 }
 
+data "aws_subnet" "ue2b2" {
+  vpc_id = module.vpc.vpc_id
+
+  filter {
+    name   = "availability-zone"
+    values = ["us-east-2b"]
+  }
+  filter {
+    name   = "subnet-id"
+    values = module.vpc.private_subnets
+  }
+  filter {
+    name   = "cidr-block"
+    values = ["20.10.5.0/24"]
+  }
+}
+
 data "aws_subnet" "ue2c1" {
   vpc_id = module.vpc.vpc_id
 

--- a/deploy/manifests/dev/us-east-2/cluster/kube-system/aws-auth.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kube-system/aws-auth.yaml
@@ -44,6 +44,16 @@ data:
       - system:nodes
       rolearn: arn:aws:iam::407967248065:role/dev-ue2c-r5b-4xl-eks-node-group
       username: system:node:{{EC2PrivateDNSName}}
+    - groups:
+      - system:bootstrappers
+      - system:nodes
+      rolearn: arn:aws:iam::407967248065:role/dev-ue2b-r5n-2xl-eks-node-group
+      username: system:node:{{EC2PrivateDNSName}}
+    - groups:
+      - system:bootstrappers
+      - system:nodes
+      rolearn: arn:aws:iam::407967248065:role/dev-ue2c-r5n-2xl-eks-node-group
+      username: system:node:{{EC2PrivateDNSName}}
   mapUsers: |
     - userarn: arn:aws:iam::407967248065:user/masih
       username: masih

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/deployment.yaml
@@ -10,11 +10,11 @@ spec:
         - name: indexer
           resources:
             limits:
-              cpu: "10"
-              memory: 120Gi
+              cpu: "6"
+              memory: 60Gi
             requests:
-              cpu: "10"
-              memory: 120Gi
+              cpu: "6"
+              memory: 60Gi
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -23,7 +23,7 @@ spec:
                   - key: node.kubernetes.io/instance-type
                     operator: In
                     values:
-                      - r5b.4xlarge
+                      - r5n.2xlarge
                   - key: topology.kubernetes.io/zone
                     operator: In
                     values:
@@ -31,5 +31,5 @@ spec:
       tolerations:
         - key: dedicated
           operator: Equal
-          value: r5b-4xl
+          value: r5n-2xl
           effect: NoSchedule

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/deployment.yaml
@@ -10,11 +10,11 @@ spec:
         - name: indexer
           resources:
             limits:
-              cpu: "10"
-              memory: 120Gi
+              cpu: "6"
+              memory: 60Gi
             requests:
-              cpu: "10"
-              memory: 120Gi
+              cpu: "6"
+              memory: 60Gi
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -23,7 +23,7 @@ spec:
                   - key: node.kubernetes.io/instance-type
                     operator: In
                     values:
-                      - r5b.4xlarge
+                      - r5n.2xlarge
                   - key: topology.kubernetes.io/zone
                     operator: In
                     values:
@@ -31,5 +31,5 @@ spec:
       tolerations:
         - key: dedicated
           operator: Equal
-          value: r5b-4xl
+          value: r5n-2xl
           effect: NoSchedule


### PR DESCRIPTION
Reduce the resources given to nodes on `dev` considering the nodes they are assigned to are under utilised over the last month. Half the resources and use a node type that costs half as much.

