### PR TITLE
Destroy redundant r5b 4xl node groups

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/eks.tf
+++ b/deploy/infrastructure/dev/us-east-2/eks.tf
@@ -66,34 +66,6 @@ module "eks" {
         }
       }
     }
-    dev-ue2b-r5b-4xl = {
-      min_size       = 0
-      max_size       = 3
-      desired_size   = 1
-      instance_types = ["r5b.4xlarge"]
-      subnet_ids     = [data.aws_subnet.ue2b1.id]
-      taints = {
-        dedicated = {
-          key    = "dedicated"
-          value  = "r5b-4xl"
-          effect = "NO_SCHEDULE"
-        }
-      }
-    }
-    dev-ue2c-r5b-4xl = {
-      min_size       = 0
-      max_size       = 3
-      desired_size   = 1
-      instance_types = ["r5b.4xlarge"]
-      subnet_ids     = [data.aws_subnet.ue2c1.id]
-      taints = {
-        dedicated = {
-          key    = "dedicated"
-          value  = "r5b-4xl"
-          effect = "NO_SCHEDULE"
-        }
-      }
-    }
 
     dev-ue2b-r5n-2xl = {
       min_size       = 1

--- a/deploy/manifests/dev/us-east-2/cluster/kube-system/aws-auth.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kube-system/aws-auth.yaml
@@ -37,16 +37,6 @@ data:
     - groups:
       - system:bootstrappers
       - system:nodes
-      rolearn: arn:aws:iam::407967248065:role/dev-ue2b-r5b-4xl-eks-node-group
-      username: system:node:{{EC2PrivateDNSName}}
-    - groups:
-      - system:bootstrappers
-      - system:nodes
-      rolearn: arn:aws:iam::407967248065:role/dev-ue2c-r5b-4xl-eks-node-group
-      username: system:node:{{EC2PrivateDNSName}}
-    - groups:
-      - system:bootstrappers
-      - system:nodes
       rolearn: arn:aws:iam::407967248065:role/dev-ue2b-r5n-2xl-eks-node-group
       username: system:node:{{EC2PrivateDNSName}}
     - groups:


### PR DESCRIPTION
Now that dev indexer instance are migrated to smaller nodes destroy the old node groups.
