### PR TITLE
Destroy now redundant workgroup on dev to save on cost

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/eks.tf
+++ b/deploy/infrastructure/dev/us-east-2/eks.tf
@@ -21,7 +21,8 @@ module "eks" {
   }
 
   eks_managed_node_groups = {
-    # Node group used by double hashing indexer nodes
+    # Smaller memory optimised node groups primarily used to run indexer and dhstore nodes with
+    # lighter duty work.
     dev-ue2a-r6a-xl = {
       min_size       = 0
       max_size       = 3
@@ -29,20 +30,12 @@ module "eks" {
       instance_types = ["r6a.xlarge"]
       subnet_ids     = [data.aws_subnet.ue2a2.id]
     }
-    # Node group used by dhstore nodes
     dev-ue2c-r6a-xl = {
       min_size       = 0
       max_size       = 3
       desired_size   = 1
       instance_types = ["r6a.xlarge"]
       subnet_ids     = [data.aws_subnet.ue2c2.id]
-    }
-    dev-ue2-m4-xl-2 = {
-      min_size       = 0
-      max_size       = 7
-      desired_size   = 3
-      instance_types = ["m4.xlarge"]
-      subnet_ids     = module.vpc.private_subnets
     }
 
     # General purpose node groups, one per subnet.
@@ -79,20 +72,8 @@ module "eks" {
       instance_types = ["r5a.2xlarge"]
       subnet_ids     = [data.aws_subnet.ue2a1.id]
     }
-    dev-ue2-r5b-xl = {
-      min_size       = 3
-      max_size       = 3
-      desired_size   = 3
-      instance_types = ["r5b.xlarge"]
-      taints         = {
-        dedicated = {
-          key    = "dedicated"
-          value  = "r5b"
-          effect = "NO_SCHEDULE"
-        }
-      }
-    }
-
+    
+    # Memory optimised node groups primarily used to run indexer nodes.
     dev-ue2b-r5n-2xl = {
       min_size       = 1
       max_size       = 3

--- a/deploy/manifests/dev/us-east-2/cluster/kube-system/aws-auth.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kube-system/aws-auth.yaml
@@ -47,11 +47,6 @@ data:
     - groups:
       - system:bootstrappers
       - system:nodes
-      rolearn: arn:aws:iam::407967248065:role/dev-ue2-r5b-xl-eks-node-group
-      username: system:node:{{EC2PrivateDNSName}}
-    - groups:
-      - system:bootstrappers
-      - system:nodes
       rolearn: arn:aws:iam::407967248065:role/dev-ue2b-r5n-2xl-eks-node-group
       username: system:node:{{EC2PrivateDNSName}}
     - groups:


### PR DESCRIPTION
Destroy the old workgroup now that all the pods are manually drained from all the nodes managed by it.

