### PR TITLE
Add gp3 storage class to `dev`

### DIFF
--- a/deploy/manifests/dev/us-east-2/cluster/kube-system/io2-storage-class.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kube-system/io2-storage-class.yaml
@@ -34,3 +34,15 @@ parameters:
   type: io2
   iopsPerGB: "3"
   allowAutoIOPSPerGBIncrease: "true"
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gp3
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: ebs.csi.aws.com
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  type: gp3


### PR DESCRIPTION
Configure `gp3` storage class on dev in preparation to move io2 type indexer volumes to it.

Set it as the default volume type for the cluster.

