### PR TITLE
Test out `gp3` volume types on `ber` in `dev`

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/deployment.yaml
@@ -28,6 +28,10 @@ spec:
                     operator: In
                     values:
                       - us-east-2b
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: ber-data-gp3
       tolerations:
         - key: dedicated
           operator: Equal

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ../../../../../../base/storetheindex-single
   - ingress.yaml
   - dido-snapshot.yaml
+  - pvc-gp3.yaml
 
 namePrefix: ber-
 

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/pvc-gp3.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/pvc-gp3.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data-gp3
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Ti
+  dataSource:
+    name: ber-20230204
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+  storageClassName: gp3


### PR DESCRIPTION
Test that `gp3` volume types instantiate correctly from the snapshot on `ber` in `dev` environment before rolling out to the other node and removing the existing `io2` volume.

