### PR TITLE
Move `cali` to `gp3` volume type on dev

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/deployment.yaml
@@ -28,6 +28,10 @@ spec:
                     operator: In
                     values:
                       - us-east-2c
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: cali-data-gp3
       tolerations:
         - key: dedicated
           operator: Equal

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ../../../../../../base/storetheindex-single
   - ingress.yaml
   - dido-snapshot.yaml
+  - pvc-gp3.yaml
 
 namePrefix: cali-
 

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/pvc-gp3.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/pvc-gp3.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data-gp3
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Ti
+  dataSource:
+    name: cali-20230204
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+  storageClassName: gp3


### PR DESCRIPTION
Now that `ber` is happy; move `cali` to the cheaper `gp3` volume type instantiated from snapshot taken few days ago.

