### PR TITLE
Include dhstore into e2e test

### DIFF
--- a/command/flags.go
+++ b/command/flags.go
@@ -206,6 +206,11 @@ var initFlags = []cli.Flag{
 		Usage:    "Configure the indexer to work with an assigner service",
 		Required: false,
 	},
+	&cli.StringFlag{
+		Name:     "dhstore",
+		Usage:    "Url of DHStore for double hashed index",
+		Required: false,
+	},
 }
 
 var providersGetFlags = []cli.Flag{

--- a/command/init.go
+++ b/command/init.go
@@ -139,5 +139,12 @@ func initCommand(cctx *cli.Context) error {
 		cfg.Discovery.UseAssigner = true
 	}
 
+	dhstoreUrl := cctx.String("dhstore")
+	if dhstoreUrl != "" {
+		log.Infow("dhstoreUrl", dhstoreUrl)
+		cfg.Indexer.DHStoreURL = dhstoreUrl
+		cfg.Indexer.DHBatchSize = -1
+	}
+
 	return cfg.Save(configFile)
 }


### PR DESCRIPTION
* fix a bug in the double hashed client that caused an invalid memory access if extended providers are nil;
* add a new flag to `storetheindex` to specify `dhstore` url on initialisation;
* include `dhstore` and double hashed client into e2e test;
* allow specifying different urls for `dhstore` and `storetheindex` in the double hashed client so that the client can work without indexstar running in front.

Fixes https://github.com/ipni/storetheindex/issues/1214