### PR TITLE
Snapshot `prod` node PVC for move to `gp3` storage class

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/snapshots/dido-snapshot.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/snapshots/dido-snapshot.yaml
@@ -6,3 +6,12 @@ spec:
   volumeSnapshotClassName: csi-aws-vsc
   source:
     persistentVolumeClaimName: dido-data
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: dido-20230213
+spec:
+  volumeSnapshotClassName: csi-aws-vsc
+  source:
+    persistentVolumeClaimName: dido-data

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/snapshots/kepa-snapshot.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/snapshots/kepa-snapshot.yaml
@@ -6,3 +6,12 @@ spec:
   volumeSnapshotClassName: csi-aws-vsc
   source:
     persistentVolumeClaimName: kepa-data
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: kepa-20230213
+spec:
+  volumeSnapshotClassName: csi-aws-vsc
+  source:
+    persistentVolumeClaimName: kepa-data

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/snapshots/oden-snapshot.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/snapshots/oden-snapshot.yaml
@@ -6,3 +6,12 @@ spec:
   volumeSnapshotClassName: csi-aws-vsc
   source:
     persistentVolumeClaimName: oden-data
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: oden-20230213
+spec:
+  volumeSnapshotClassName: csi-aws-vsc
+  source:
+    persistentVolumeClaimName: oden-data


### PR DESCRIPTION
Snapshot the PVC of all nodes in prod to prepare for move to the cheaper `gp3` storage class.

Relates to #1042 

