### PR TITLE
Expose `caskadht` libp2p node externally needed for peering

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/caskadht/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/caskadht/deployment.yaml
@@ -13,8 +13,12 @@ spec:
         - name: caskadht
           args:
             - '--libp2pIdentityPath=/identity/identity.key'
+            - '--libp2pListenAddrs=/ip4/0.0.0.0/tcp/40090,/ip4/0.0.0.0/udp/40090/quic,/ip4/0.0.0.0/udp/40090/quic-v1,/ip4/0.0.0.0/udp/40090/quic-v1/webtransport'
             # Respond with 404 if `?cascade=ipfs-dht` is not specified as URL query parameter.
             - '--ipniRequireQueryParam'
+          ports:
+            - containerPort: 40090
+              name: libp2p
           volumeMounts:
             - name: identity
               mountPath: /identity

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/caskadht/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/caskadht/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: storetheindex
 
 resources:
   - ../../../../../base/caskadht
+  - service-external.yaml
 
 patchesStrategicMerge:
   - deployment.yaml

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/caskadht/service-external.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/caskadht/service-external.yaml
@@ -1,0 +1,20 @@
+# External facing caskadht, needed by bifrost-infra. See:
+#  - https://github.com/protocol/bifrost-infra/blob/master/ansible/roles/go-ipfs-conf/defaults/main.yml
+#
+kind: Service
+apiVersion: v1
+metadata:
+  name: caskadht-external
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+    external-dns.alpha.kubernetes.io/hostname: caskadht.dev.cid.contact
+spec:
+  ports:
+    - name: libp2p
+      port: 40090
+      targetPort: libp2p
+  selector:
+    app: caskadht
+  externalTrafficPolicy: Local
+  type: LoadBalancer


### PR DESCRIPTION
In order to peer `caskadht` with IPFS bootstrap nodes it needs to be accessible externally.

Test exposure of the libp2p node over `dnsaddr` in `dev`.

