### PR TITLE
Increase CPU resources of `caskadht` and adjust logging

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/caskadht/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/caskadht/deployment.yaml
@@ -25,10 +25,10 @@ spec:
               mountPath: /identity
           resources:
             limits:
-              cpu: "0.5"
+              cpu: "2"
               memory: 2Gi
             requests:
-              cpu: "0.5"
+              cpu: "2"
               memory: 2Gi
       volumes:
         - name: identity

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/caskadht/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/caskadht/kustomization.yaml
@@ -16,6 +16,12 @@ secretGenerator:
     files:
       - identity.key=identity.key.encrypted # 12D3KooWAY6nosu5ireZaqo5M3zegzQFd9i1cWDqq7PTiAV4U9SV
 
+configMapGenerator:
+  - name: caskadht-env-vars
+    behavior: merge
+    literals:
+      - GOLOG_LOG_LEVEL="info,net/identify=error"
+
 images:
   - name: caskadht
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/caskadht

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/caskadht/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/caskadht/deployment.yaml
@@ -25,10 +25,10 @@ spec:
               mountPath: /identity
           resources:
             limits:
-              cpu: "0.5"
+              cpu: "2"
               memory: 2Gi
             requests:
-              cpu: "0.5"
+              cpu: "2"
               memory: 2Gi
       volumes:
         - name: identity

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/caskadht/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/caskadht/kustomization.yaml
@@ -16,6 +16,12 @@ secretGenerator:
     files:
       - identity.key=identity.key.encrypted # 12D3KooWANvdTsGoqpHeeYirAQYZToEX4BtrTUW73rsRfvCP6Yd4
 
+configMapGenerator:
+  - name: caskadht-env-vars
+    behavior: merge
+    literals:
+      - GOLOG_LOG_LEVEL="info,net/identify=error"
+
 images:
   - name: caskadht
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/caskadht


### PR DESCRIPTION
`caskadht` is running hot on CPU, increase the limit from the minimal configured.

Disable logging for `net/identify` subsystem as it is very noisy.

