### PR TITLE
Disable WAL in dhstore to investigate put metadata latency spike

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore/deployment.yaml
@@ -13,6 +13,7 @@ spec:
         - name: dhstore
           args:
             - '--storePath=/data'
+            - '--disableWAL'
           volumeMounts:
             - name: data
               mountPath: /data


### PR DESCRIPTION
Put metadata latency spikes sporadically. Disable WAL to see if the spikes continue.

