### PR TITLE
Omit empty JSON keys to avoid empty values in encrypted response

### DIFF
--- a/api/v0/finder/client/http/dhash_client.go
+++ b/api/v0/finder/client/http/dhash_client.go
@@ -227,7 +227,7 @@ func (pc *providerCache) getResults(ctx context.Context, pid peer.ID, ctxID []by
 	results = append(results, model.ProviderResult{
 		ContextID: ctxID,
 		Metadata:  metadata,
-		Provider:  wrapper.pinfo.AddrInfo,
+		Provider:  &wrapper.pinfo.AddrInfo,
 	})
 
 	// return results if there are no further extended providers to unpack
@@ -260,7 +260,7 @@ func (pc *providerCache) getResults(ctx context.Context, pid peer.ID, ctxID []by
 			results = append(results, model.ProviderResult{
 				ContextID: ctxID,
 				Metadata:  xmd,
-				Provider:  xpinfo,
+				Provider:  &xpinfo,
 			})
 		}
 	}
@@ -287,7 +287,7 @@ func (pc *providerCache) getResults(ctx context.Context, pid peer.ID, ctxID []by
 		results = append(results, model.ProviderResult{
 			ContextID: ctxID,
 			Metadata:  xmd,
-			Provider:  xpinfo,
+			Provider:  &xpinfo,
 		})
 	}
 

--- a/api/v0/finder/model/model.go
+++ b/api/v0/finder/model/model.go
@@ -19,11 +19,11 @@ type FindRequest struct {
 // provider of indexed context.
 type ProviderResult struct {
 	// ContextID identifies the metadata that is part of this value.
-	ContextID []byte
+	ContextID []byte `json:"ContextID,omitempty"`
 	// Metadata contains information for the provider to use to retrieve data.
-	Metadata []byte
+	Metadata []byte `json:"Metadata,omitempty"`
 	// Provider is the peer ID and addresses of the provider.
-	Provider peer.AddrInfo
+	Provider *peer.AddrInfo `json:"Provider,omitempty"`
 }
 
 // MultihashResult aggregates all values for a single multihash.
@@ -34,16 +34,16 @@ type MultihashResult struct {
 
 // FindResponse used to answer client queries/requests
 type FindResponse struct {
-	MultihashResults          []MultihashResult
-	EncryptedMultihashResults []EncryptedMultihashResult
+	MultihashResults          []MultihashResult          `json:"MultihashResults,omitempty"`
+	EncryptedMultihashResults []EncryptedMultihashResult `json:"EncryptedMultihashResults,omitempty"`
 	// NOTE: This feature is not enabled yet.
 	// Signature []byte	// Providers signature.
 }
 
 // EncryptedMultihashResult aggregates all encrypted value keys for a single multihash
 type EncryptedMultihashResult struct {
-	Multihash          multihash.Multihash
-	EncryptedValueKeys [][]byte
+	Multihash          multihash.Multihash `json:"Multihash,omitempty"`
+	EncryptedValueKeys [][]byte            `json:"EncryptedValueKeys,omitempty"`
 }
 
 // Equal compares ProviderResult values to determine if they are equal. The

--- a/api/v0/finder/model/model_test.go
+++ b/api/v0/finder/model/model_test.go
@@ -55,7 +55,7 @@ func TestMarshal(t *testing.T) {
 	providerResult := ProviderResult{
 		ContextID: ctxID,
 		Metadata:  metadata,
-		Provider: peer.AddrInfo{
+		Provider: &peer.AddrInfo{
 			ID:    p,
 			Addrs: []multiaddr.Multiaddr{m1, m2},
 		},

--- a/server/finder/handler/finder_handler.go
+++ b/server/finder/handler/finder_handler.go
@@ -228,7 +228,7 @@ func providerResultFromValue(provID peer.ID, contextID []byte, metadata []byte, 
 	return model.ProviderResult{
 		ContextID: contextID,
 		Metadata:  metadata,
-		Provider: peer.AddrInfo{
+		Provider: &peer.AddrInfo{
 			ID:    provID,
 			Addrs: addrs,
 		},

--- a/server/finder/http/handler_test.go
+++ b/server/finder/http/handler_test.go
@@ -137,7 +137,7 @@ func TestServer_StreamingResponse(t *testing.T) {
 			reqURI:           "/multihash/" + mhs[3].B58String(),
 			reqAccept:        "ext/html,  application/json",
 			wantContentType:  "application/json; charset=utf-8",
-			wantResponseBody: `{"MultihashResults":[{"Multihash":"EiCtVzjVYlU7UrB20GmR2mqk59dl7fk+Ann4CmsLfQfT+g==","ProviderResults":[{"ContextID":"ZmlzaA==","Metadata":"bG9ic3Rlcg==","Provider":{"ID":"12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA","Addrs":["/ip4/127.0.0.1/tcp/9999"]}}]}],"EncryptedMultihashResults":null}`,
+			wantResponseBody: `{"MultihashResults":[{"Multihash":"EiCtVzjVYlU7UrB20GmR2mqk59dl7fk+Ann4CmsLfQfT+g==","ProviderResults":[{"ContextID":"ZmlzaA==","Metadata":"bG9ic3Rlcg==","Provider":{"ID":"12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA","Addrs":["/ip4/127.0.0.1/tcp/9999"]}}]}]}`,
 		},
 		{
 			name:            "mutlihash ndjson",
@@ -153,7 +153,7 @@ func TestServer_StreamingResponse(t *testing.T) {
 			reqURI:           "/cid/" + cid.NewCidV1(cid.Raw, mhs[0]).String(),
 			reqAccept:        "application/json,ext/html,  application/xhtml+xml,application/xml;q=0.9",
 			wantContentType:  "application/json; charset=utf-8",
-			wantResponseBody: `{"MultihashResults":[{"Multihash":"EiC44Rthii367t9Nb5PD6C0XT49Ub14+f0iF7gA4Xgr/6A==","ProviderResults":[{"ContextID":"ZmlzaA==","Metadata":"bG9ic3Rlcg==","Provider":{"ID":"12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA","Addrs":["/ip4/127.0.0.1/tcp/9999"]}}]}],"EncryptedMultihashResults":null}`,
+			wantResponseBody: `{"MultihashResults":[{"Multihash":"EiC44Rthii367t9Nb5PD6C0XT49Ub14+f0iF7gA4Xgr/6A==","ProviderResults":[{"ContextID":"ZmlzaA==","Metadata":"bG9ic3Rlcg==","Provider":{"ID":"12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA","Addrs":["/ip4/127.0.0.1/tcp/9999"]}}]}]}`,
 		},
 		{
 			name:            "cid ndjson",

--- a/server/finder/test/test.go
+++ b/server/finder/test/test.go
@@ -180,7 +180,7 @@ func FindIndexTest(ctx context.Context, t *testing.T, c client.Finder, ind index
 
 	provResult := model.ProviderResult{
 		ContextID: v.ContextID,
-		Provider: peer.AddrInfo{
+		Provider: &peer.AddrInfo{
 			ID:    v.ProviderID,
 			Addrs: provider.Addrs,
 		},
@@ -361,7 +361,7 @@ func RemoveProviderTest(ctx context.Context, t *testing.T, c client.Finder, ind 
 
 	provResult := model.ProviderResult{
 		ContextID: v.ContextID,
-		Provider: peer.AddrInfo{
+		Provider: &peer.AddrInfo{
 			ID:    v.ProviderID,
 			Addrs: provider.Addrs,
 		},

--- a/server/finder/test/test_extended_providers.go
+++ b/server/finder/test/test_extended_providers.go
@@ -43,7 +43,7 @@ func ProvidersShouldBeUnaffectedByExtendedProvidersOfEachOtherTest(ctx context.C
 	err = checkResponse(resp, mhs2[:10], []model.ProviderResult{
 		{
 			ContextID: ctxId2,
-			Provider: peer.AddrInfo{
+			Provider: &peer.AddrInfo{
 				ID:    prov2,
 				Addrs: addrs2,
 			},
@@ -93,7 +93,7 @@ func ExtendedProviderShouldHaveOwnMetadataTest(ctx context.Context, t *testing.T
 	err = checkResponse(resp, mhs1, []model.ProviderResult{
 		{
 			ContextID: ctxId1,
-			Provider: peer.AddrInfo{
+			Provider: &peer.AddrInfo{
 				ID:    prov1,
 				Addrs: addrs1,
 			},
@@ -101,7 +101,7 @@ func ExtendedProviderShouldHaveOwnMetadataTest(ctx context.Context, t *testing.T
 		},
 		{
 			ContextID: ctxId1,
-			Provider: peer.AddrInfo{
+			Provider: &peer.AddrInfo{
 				ID:    ep2,
 				Addrs: ep2Addrs,
 			},
@@ -109,7 +109,7 @@ func ExtendedProviderShouldHaveOwnMetadataTest(ctx context.Context, t *testing.T
 		},
 		{
 			ContextID: ctxId1,
-			Provider: peer.AddrInfo{
+			Provider: &peer.AddrInfo{
 				ID:    ep1,
 				Addrs: ep1Addrs,
 			},
@@ -155,7 +155,7 @@ func ExtendedProviderShouldInheritMetadataOfMainProviderTest(ctx context.Context
 	err = checkResponse(resp, mhs1, []model.ProviderResult{
 		{
 			ContextID: ctxId1,
-			Provider: peer.AddrInfo{
+			Provider: &peer.AddrInfo{
 				ID:    prov1,
 				Addrs: addrs1,
 			},
@@ -163,7 +163,7 @@ func ExtendedProviderShouldInheritMetadataOfMainProviderTest(ctx context.Context
 		},
 		{
 			ContextID: ctxId1,
-			Provider: peer.AddrInfo{
+			Provider: &peer.AddrInfo{
 				ID:    ep2,
 				Addrs: ep2Addrs,
 			},
@@ -171,7 +171,7 @@ func ExtendedProviderShouldInheritMetadataOfMainProviderTest(ctx context.Context
 		},
 		{
 			ContextID: ctxId1,
-			Provider: peer.AddrInfo{
+			Provider: &peer.AddrInfo{
 				ID:    ep1,
 				Addrs: ep1Addrs,
 			},
@@ -227,7 +227,7 @@ func ContextualExtendedProvidersShouldUnionUpWithChainLevelOnesTest(ctx context.
 	err = checkResponse(resp, mhs1, []model.ProviderResult{
 		{
 			ContextID: ctxId1,
-			Provider: peer.AddrInfo{
+			Provider: &peer.AddrInfo{
 				ID:    prov1,
 				Addrs: addrs1,
 			},
@@ -235,7 +235,7 @@ func ContextualExtendedProvidersShouldUnionUpWithChainLevelOnesTest(ctx context.
 		},
 		{
 			ContextID: ctxId1,
-			Provider: peer.AddrInfo{
+			Provider: &peer.AddrInfo{
 				ID:    ep2,
 				Addrs: ep2Addrs,
 			},
@@ -243,7 +243,7 @@ func ContextualExtendedProvidersShouldUnionUpWithChainLevelOnesTest(ctx context.
 		},
 		{
 			ContextID: ctxId1,
-			Provider: peer.AddrInfo{
+			Provider: &peer.AddrInfo{
 				ID:    ep1,
 				Addrs: ep1Addrs,
 			},
@@ -258,7 +258,7 @@ func ContextualExtendedProvidersShouldUnionUpWithChainLevelOnesTest(ctx context.
 	err = checkResponse(resp, mhs2, []model.ProviderResult{
 		{
 			ContextID: ctxId2,
-			Provider: peer.AddrInfo{
+			Provider: &peer.AddrInfo{
 				ID:    prov1,
 				Addrs: addrs1,
 			},
@@ -266,7 +266,7 @@ func ContextualExtendedProvidersShouldUnionUpWithChainLevelOnesTest(ctx context.
 		},
 		{
 			ContextID: ctxId2,
-			Provider: peer.AddrInfo{
+			Provider: &peer.AddrInfo{
 				ID:    ep1,
 				Addrs: ep1Addrs,
 			},
@@ -312,7 +312,7 @@ func ContextualExtendedProvidersShouldOverrideChainLevelOnesTest(ctx context.Con
 	err = checkResponse(resp, mhs1, []model.ProviderResult{
 		{
 			ContextID: ctxId1,
-			Provider: peer.AddrInfo{
+			Provider: &peer.AddrInfo{
 				ID:    prov1,
 				Addrs: addrs1,
 			},
@@ -320,7 +320,7 @@ func ContextualExtendedProvidersShouldOverrideChainLevelOnesTest(ctx context.Con
 		},
 		{
 			ContextID: ctxId1,
-			Provider: peer.AddrInfo{
+			Provider: &peer.AddrInfo{
 				ID:    ep2,
 				Addrs: ep2Addrs,
 			},
@@ -363,7 +363,7 @@ func MainProviderChainRecordIsIncludedIfItsMetadataIsDifferentTest(ctx context.C
 	err = checkResponse(resp, mhs1, []model.ProviderResult{
 		{
 			ContextID: ctxId1,
-			Provider: peer.AddrInfo{
+			Provider: &peer.AddrInfo{
 				ID:    providerId,
 				Addrs: addrs,
 			},
@@ -371,7 +371,7 @@ func MainProviderChainRecordIsIncludedIfItsMetadataIsDifferentTest(ctx context.C
 		},
 		{
 			ContextID: ctxId1,
-			Provider: peer.AddrInfo{
+			Provider: &peer.AddrInfo{
 				ID:    providerId,
 				Addrs: chainAddrs,
 			},
@@ -414,7 +414,7 @@ func MainProviderContextRecordIsIncludedIfItsMetadataIsDifferentTest(ctx context
 	err = checkResponse(resp, mhs1, []model.ProviderResult{
 		{
 			ContextID: ctxId1,
-			Provider: peer.AddrInfo{
+			Provider: &peer.AddrInfo{
 				ID:    providerId,
 				Addrs: addrs,
 			},
@@ -422,7 +422,7 @@ func MainProviderContextRecordIsIncludedIfItsMetadataIsDifferentTest(ctx context
 		},
 		{
 			ContextID: ctxId1,
-			Provider: peer.AddrInfo{
+			Provider: &peer.AddrInfo{
 				ID:    providerId,
 				Addrs: contextAddrs,
 			},

--- a/server/reframe/reframe.go
+++ b/server/reframe/reframe.go
@@ -52,7 +52,7 @@ func (x *ReframeService) FindProviders(ctx context.Context, key cid.Cid) (<-chan
 		return nil, err
 	}
 	ch := make(chan client.FindProvidersAsyncResult, 1)
-	peerAddrs := []peer.AddrInfo{}
+	var peerAddrs []peer.AddrInfo
 	for _, mhr := range fr.MultihashResults {
 		if !bytes.Equal(mhr.Multihash, mh) {
 			continue
@@ -61,7 +61,7 @@ func (x *ReframeService) FindProviders(ctx context.Context, key cid.Cid) (<-chan
 			if !containsTransportBitswap(pr.Metadata) {
 				continue
 			}
-			peerAddrs = append(peerAddrs, pr.Provider)
+			peerAddrs = append(peerAddrs, *pr.Provider)
 		}
 	}
 	go func() {


### PR DESCRIPTION
Explicitly tag fields in response `structs` such that empty values are omitted. The struct types are used by `indexstar` which in the case of aggregation results in empty fields in JSON.

