### PR TITLE
Deploy translation of all non-streaming lookups to streaming on `dev`

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -13,6 +13,7 @@ spec:
         - name: indexstar
           args:
             - '--translateReframe'
+            - 'translateNonStreaming'
             # Use service names local to the namespace over HTTP to avoid
             # TLS handshake overhead.
             - '--backends=http://ber-indexer:3000/'
@@ -28,6 +29,12 @@ spec:
             # The service provided by caskadht.
             - name: SERVER_CASCADE_LABELS
               value: 'ipfs-dht'
+            - name: SERVER_HTTP_CLIENT_TIMEOUT
+              value: '30s'
+            - name: SERVER_RESULT_MAX_WAIT
+              value: '30s'
+            - name: SERVER_RESULT_STREAM_MAX_WAIT
+              value: '30s'
           resources:
             limits:
               cpu: "3"

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
@@ -18,4 +18,4 @@ replicas:
 images:
   - name: indexstar
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/indexstar/indexstar
-    newTag: 20230217145522-ed02130e6a416200e0c54d9667446c20c6ba6a15
+    newTag: 20230220184111-8052cfee24c32c3e262f919729e07b5ecc21dd78


### PR DESCRIPTION
Deploy the latest `indexstar` that introduces translation of all non-streaming lookups into streaming backend requests.

Increase backend call timeouts so that the chances of at least cache getting updated even if client times out earlier.

In the case of lassie the timeout is set to 1 minute, and short timeout on server side results in false-negative 404s.

Once tested on `dev` will be rolling out to `prod`.

