### PR TITLE
Deploy dhstore to larger instance

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore/deployment.yaml
@@ -35,7 +35,7 @@ spec:
                   - key: node.kubernetes.io/instance-type
                     operator: In
                     values:
-                      - r6a.xlarge
+                      - r5n.2xlarge
                   - key: topology.kubernetes.io/zone
                     operator: In
                     values:


### PR DESCRIPTION
* Currently dhstore runs on `r6a.xlarge` at close to 100% CPU load
* `r5n.2xlarge` will give us 8 vCPUs (vs 4 currently) as well as 64GiB RAM (vs 32 currently)
* Compute optimised instances with 8 vCPUs have less than 32GiB RAM. Compute optimised instances with 16 vCPUs and 32 GiB RAM are at least as expensive as `r5n.2xlarge`. 