### PR TITLE
support json HTTP announce

### DIFF
--- a/server/ingest/handler/ingest_handler.go
+++ b/server/ingest/handler/ingest_handler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/ipfs/go-cid"
@@ -124,13 +123,7 @@ func (h *IngestHandler) IndexContent(ctx context.Context, data []byte) error {
 	return nil
 }
 
-func (h *IngestHandler) Announce(r io.Reader) error {
-	// Decode CID and originator addresses from message.
-	an := message.Message{}
-	if err := an.UnmarshalCBOR(r); err != nil {
-		return err
-	}
-
+func (h *IngestHandler) Announce(an message.Message) error {
 	if len(an.Addrs) == 0 {
 		return fmt.Errorf("must specify location to fetch on direct announcments")
 	}

--- a/server/ingest/http/server.go
+++ b/server/ingest/http/server.go
@@ -82,9 +82,9 @@ func (s *Server) putAnnounce(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	defer r.Body.Close()
 
-	an := message.Message{}
-
+	var an message.Message
 	var err error
+
 	if r.Header.Get("Content-Type") == "application/json" {
 		err = json.NewDecoder(r.Body).Decode(&an)
 	} else {
@@ -95,7 +95,7 @@ func (s *Server) putAnnounce(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.ingestHandler.Announce(an); err != nil {
+	if err = s.ingestHandler.Announce(an); err != nil {
 		httpserver.HandleError(w, err, "announce")
 		return
 	}

--- a/server/ingest/http/server.go
+++ b/server/ingest/http/server.go
@@ -84,16 +84,15 @@ func (s *Server) putAnnounce(w http.ResponseWriter, r *http.Request) {
 
 	an := message.Message{}
 
+	var err error
 	if r.Header.Get("Content-Type") == "application/json" {
-		if err := json.NewDecoder(r.Body).Decode(&an); err != nil {
-			httpserver.HandleError(w, err, "announce")
-			return
-		}
+		err = json.NewDecoder(r.Body).Decode(&an)
 	} else {
-		if err := an.UnmarshalCBOR(r.Body); err != nil {
-			httpserver.HandleError(w, err, "announce")
-			return
-		}
+		err = an.UnmarshalCBOR(r.Body)
+	}
+	if err != nil {
+		httpserver.HandleError(w, err, "announce")
+		return
 	}
 
 	if err := s.ingestHandler.Announce(an); err != nil {

--- a/server/ingest/http/server.go
+++ b/server/ingest/http/server.go
@@ -81,9 +81,8 @@ func (s *Server) putAnnounce(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	var b io.Reader
 	defer r.Body.Close()
-	
+
 	if r.Header.Get("Content-Type") == "application/json" {
 		am := message.Message{}
 		err := json.NewDecoder(r.Body).Decode(&am)
@@ -97,15 +96,17 @@ func (s *Server) putAnnounce(w http.ResponseWriter, r *http.Request) {
 			httpserver.HandleError(w, err, "announce")
 			return
 		}
-		b = buff
+		err = s.ingestHandler.Announce(buff)
+		if err != nil {
+			httpserver.HandleError(w, err, "announce")
+			return
+		}
 	} else {
-		b = r.Body
-	}
-
-	err := s.ingestHandler.Announce(b)
-	if err != nil {
-		httpserver.HandleError(w, err, "announce")
-		return
+		err := s.ingestHandler.Announce(r.Body)
+		if err != nil {
+			httpserver.HandleError(w, err, "announce")
+			return
+		}
 	}
 	w.WriteHeader(http.StatusNoContent)
 }


### PR DESCRIPTION
## Context
Fixes https://github.com/ipni/storetheindex/issues/1093

## Proposed Changes
Instead of only accepting CBOR:

Read the request Content-Type header
if it is JSON,
parse the body as JSON
convert to CBOR
and pass onto the indexer internal handlers
Otherwise, fallback on CBOR decoding as it is working currently.

## Tests
TestJSONSend

## Revert Strategy
Change is safe to revert.
