### PR TITLE
Rollout the latest fixes to caskadht and indexstar on `prod`

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -30,7 +30,7 @@ spec:
             - name: SERVER_CASCADE_LABELS
               value: 'ipfs-dht'
             - name: SERVER_HTTP_CLIENT_TIMEOUT
-              value: '30s'
+              value: '10s'
             - name: SERVER_RESULT_MAX_WAIT
               value: '30s'
             - name: SERVER_RESULT_STREAM_MAX_WAIT

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/caskadht/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/caskadht/deployment.yaml
@@ -17,6 +17,8 @@ spec:
             - '--useResourceManager=false'
             # Respond with 404 if `?cascade=ipfs-dht` is not specified as URL query parameter.
             - '--ipniRequireQueryParam'
+            - '--libp2pConMgrLow=200'
+            - '--libp2pConMgrHigh=5000'
           ports:
             - containerPort: 40090
               name: libp2p

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/caskadht/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/caskadht/kustomization.yaml
@@ -25,4 +25,4 @@ configMapGenerator:
 images:
   - name: caskadht
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/caskadht
-    newTag: 20230217131726-9c35827bb3e33edc22cc2daab5f6fc19609d8974
+    newTag: 20230221163035-cf92b0520184317bec2044432bee26d754a28064

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -31,7 +31,7 @@ spec:
             - name: SERVER_HTTP_CLIENT_TIMEOUT
               value: '30s'
             - name: SERVER_RESULT_MAX_WAIT
-              value: '30s'
+              value: '10s'
             - name: SERVER_RESULT_STREAM_MAX_WAIT
               value: '30s'
           resources:

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
@@ -18,4 +18,4 @@ replicas:
 images:
   - name: indexstar
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/indexstar/indexstar
-    newTag: 20230220184111-8052cfee24c32c3e262f919729e07b5ecc21dd78
+    newTag: 20230221183426-9723ee6472d24a94fc5f0eb435bf2d4be1cab0df


### PR DESCRIPTION
Roll out fixes to async peer routing and indexstar to prod.

Reduce timeouts for nonstreaming down to 10 seconds.

