### PR TITLE
Increase max instance counts for general purpose nodegroup

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/cloudfront.tf
+++ b/deploy/infrastructure/dev/us-east-2/cloudfront.tf
@@ -65,9 +65,6 @@ resource "aws_cloudfront_distribution" "cdn" {
 
     compress               = true
     viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 86400
   }
 
   ordered_cache_behavior {
@@ -79,9 +76,6 @@ resource "aws_cloudfront_distribution" "cdn" {
     target_origin_id       = local.indexstar_origin_id
     cache_policy_id        = aws_cloudfront_cache_policy.reframe.id
     viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 0
-    default_ttl            = 0
-    max_ttl                = 0
   }
 
   ordered_cache_behavior {

--- a/deploy/infrastructure/prod/us-east-2/cloudfront.tf
+++ b/deploy/infrastructure/prod/us-east-2/cloudfront.tf
@@ -86,9 +86,6 @@ resource "aws_cloudfront_distribution" "cdn" {
     target_origin_id       = local.indexstar_origin_id
     cache_policy_id        = aws_cloudfront_cache_policy.reframe.id
     viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 0
-    default_ttl            = 0
-    max_ttl                = 0
   }
 
   ordered_cache_behavior {
@@ -102,9 +99,6 @@ resource "aws_cloudfront_distribution" "cdn" {
 
     compress               = true
     viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 86400
   }
 
   ordered_cache_behavior {
@@ -116,9 +110,6 @@ resource "aws_cloudfront_distribution" "cdn" {
 
     compress               = true
     viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 86400
   }
 
   ordered_cache_behavior {

--- a/deploy/infrastructure/prod/us-east-2/eks.tf
+++ b/deploy/infrastructure/prod/us-east-2/eks.tf
@@ -29,7 +29,7 @@ module "eks" {
     # General purpose node-group.
     prod-ue2-m4-xl-2 = {
       min_size       = 3
-      max_size       = 10
+      max_size       = 15
       desired_size   = 3
       subnet_ids     = local.secondary_private_subnet_ids
       instance_types = ["m4.xlarge"]


### PR DESCRIPTION
This is so that we can accommodate the scaleup of `caskadht` on prod.

Clean up terraform files by removing redundant ttls in cloudfront config that resutls in noop updates. The ttls should only be specified in cloudfront policy if one is associated to the origin.
