### PR TITLE
Fix a bug where unknown paths always return landing page

### DIFF
--- a/server/finder/http/handler_test.go
+++ b/server/finder/http/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -150,6 +151,13 @@ func TestServer_CORSWithExpectedContentType(t *testing.T) {
 }
 
 func TestServer_StreamingResponse(t *testing.T) {
+	landing := landingRendered
+	if runtime.GOOS == "windows" {
+		// Replace newlines with whatever new line is in the current runtime environment to keep
+		// windows tests happy; cause they render template with `\r\n`.
+		landing = strings.ReplaceAll(landingRendered, "\n", "\r\n")
+	}
+
 	rng := rand.New(rand.NewSource(1413))
 	mhs := util.RandomMultihashes(10, rng)
 	p, err := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
@@ -209,14 +217,14 @@ func TestServer_StreamingResponse(t *testing.T) {
 			name:               "landing",
 			reqURI:             "/",
 			wantContentType:    "text/html; charset=utf-8",
-			wantResponseBody:   landingRendered,
+			wantResponseBody:   landing,
 			wantResponseStatus: http.StatusOK,
 		},
 		{
 			name:               "index.html",
 			reqURI:             "/index.html",
 			wantContentType:    "text/html; charset=utf-8",
-			wantResponseBody:   landingRendered,
+			wantResponseBody:   landing,
 			wantResponseStatus: http.StatusOK,
 		},
 		{


### PR DESCRIPTION
The find server would fallback on landing page on any request for which there was no matching path, because the handler for `/` was not checking path. This meant that requests for paths that are not offered by finder like `/metadata` would result in 200 response of content type text/html.

Instead, find server must check the path requested on fallback mux and only return landing page if either `/` or `/index.html` is requested.

The changes here strictly check the path before returning the landing page and assert it is so in tests.
