### PR TITLE
Reduce ago ingest worker count

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/config.json
@@ -73,7 +73,7 @@
     "HttpSyncRetryWaitMax": "30s",
     "HttpSyncRetryWaitMin": "1s",
     "HttpSyncTimeout": "10s",
-    "IngestWorkerCount": 20,
+    "IngestWorkerCount": 10,
     "KeepAdvertisements":true,
     "PubSubTopic": "/indexer/ingest/mainnet",
     "RateLimit": {


### PR DESCRIPTION
From the latest metrics observations I can correlate latency spikes with:
* peak in read amplification
* bottom in flush count
* peak in compaction estimated debt

As per the [official docs](https://www.cockroachlabs.com/docs/stable/common-issues-to-monitor.html#lsm-health) that means that pebble has an imbalanced LSM tree and falls behind on compactions. That can be either due to high concurrency or low IOPS. The latter doesn't seem to be an issue, so we need to tweak the former and see the impact.