### PR TITLE
Assign pinata to `kepa`

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/assigner/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/assigner/config.json
@@ -15,7 +15,10 @@
       {
         "AdminURL": "http://kepa-indexer:3002",
         "FindURL": "http://kepa-indexer:3000",
-        "IngestURL": "http://kepa-indexer:3001"
+        "IngestURL": "http://kepa-indexer:3001",
+        "PresetPeers": [
+          "Qma8ddFEQWEU8ijWvdxXm3nxU7oHsRtCykAaVz8WUYhiKn"
+        ]
       },
       {
         "AdminURL": "http://oden-indexer:3002",

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/config.json
@@ -41,7 +41,9 @@
     "LotusGateway": "wss://api.chain.love",
     "Policy": {
       "Allow": true,
-      "Except": null,
+      "Except": [
+        "Qma8ddFEQWEU8ijWvdxXm3nxU7oHsRtCykAaVz8WUYhiKn"
+      ],
       "Publish": true,
       "PublishExcept": null
     },


### PR DESCRIPTION
Both nft.storage and pinata are assigned to the same node `oden`. Explicitly add pinata to `kepa`.

Relates to #1310 