### PR TITLE
Move `oden` to CPU optimised worker node group

### DIFF
--- a/deploy/infrastructure/prod/us-east-2/eks.tf
+++ b/deploy/infrastructure/prod/us-east-2/eks.tf
@@ -67,6 +67,20 @@ module "eks" {
         }
       }
     }
+    prod-ue2b-c6a-8xl = {
+      min_size       = 1
+      max_size       = 5
+      desired_size   = 1
+      instance_types = ["c6a.8xlarge"]
+      subnet_ids     = [data.aws_subnet.ue2b2.id]
+      taints = {
+        dedicated = {
+          key    = "dedicated"
+          value  = "c6a-8xl"
+          effect = "NO_SCHEDULE"
+        }
+      }
+    }
   }
 }
 

--- a/deploy/manifests/prod/us-east-2/cluster/kube-system/aws-auth.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/kube-system/aws-auth.yaml
@@ -20,6 +20,11 @@ data:
       - system:nodes
       rolearn: arn:aws:iam::407967248065:role/prod-ue2b-r5b-4xl-eks-node-group
       username: system:node:{{EC2PrivateDNSName}}
+    - groups:
+      - system:bootstrappers
+      - system:nodes
+      rolearn: arn:aws:iam::407967248065:role/prod-ue2b-c6a-8xl-eks-node-group
+      username: system:node:{{EC2PrivateDNSName}}
   mapUsers: |
     - userarn: arn:aws:iam::407967248065:user/masih
       username: masih

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/deployment.yaml
@@ -12,11 +12,11 @@ spec:
               name: data
           resources:
             limits:
-              cpu: "10"
-              memory: 120Gi
+              cpu: "30"
+              memory: 60Gi
             requests:
-              cpu: "10"
-              memory: 120Gi
+              cpu: "30"
+              memory: 60Gi
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -25,7 +25,7 @@ spec:
                   - key: node.kubernetes.io/instance-type
                     operator: In
                     values:
-                      - r5b.4xlarge
+                      - c6a.8xlarge
                   - key: topology.kubernetes.io/zone
                     operator: In
                     values:
@@ -37,5 +37,5 @@ spec:
       tolerations:
         - key: dedicated
           operator: Equal
-          value: r5b-4xl
+          value: c6a-8xl
           effect: NoSchedule


### PR DESCRIPTION
Create `c6a.8xl` worker node group in us-east2b subnet and move oden to it.

note that the memory available is halved as it was unused by oden. It is starving on CPU right now.

Relates to #1310
