### PR TITLE
Add unassign command

### DIFF
--- a/assigner/server/server_test.go
+++ b/assigner/server/server_test.go
@@ -191,9 +191,7 @@ func TestAssignOnAnnounce(t *testing.T) {
 	// Check assignment
 	outProvider := e.run(indexer, "admin", "list-assigned", "--indexer", cfg.IndexerPool[0].AdminURL)
 	expect := peerID.String()
-	if !strings.Contains(string(outProvider), expect) {
-		t.Errorf("expected provider to contains %q, got %q", expect, string(outProvider))
-	}
+	require.Contains(t, string(outProvider), expect)
 
 	e.stop(cmdIndexer, 5*time.Second)
 
@@ -205,9 +203,13 @@ func TestAssignOnAnnounce(t *testing.T) {
 		t.Fatal("timed out waiting for indexer to start")
 	}
 	outProvider = e.run(indexer, "admin", "list-assigned", "--indexer", cfg.IndexerPool[0].AdminURL)
-	if !strings.Contains(string(outProvider), expect) {
-		t.Errorf("expected provider to contains %q, got %q", expect, string(outProvider))
-	}
+	require.Contains(t, string(outProvider), expect)
+
+	outProvider = e.run(indexer, "admin", "unassign", "--indexer", cfg.IndexerPool[0].AdminURL, "-p", peerID.String())
+	require.Contains(t, string(outProvider), expect)
+
+	outProvider = e.run(indexer, "admin", "list-assigned", "--indexer", cfg.IndexerPool[0].AdminURL)
+	require.NotContains(t, string(outProvider), expect)
 
 	e.stop(cmdIndexer, 5*time.Second)
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -314,7 +314,8 @@ func TestDatastore(t *testing.T) {
 	}
 
 	require.ErrorIs(t, r.AssignPeer(pubID), ErrNoAssigner)
-	require.ErrorIs(t, r.UnassignPeer(pubID), ErrNoAssigner)
+	_, err = r.UnassignPeer(pubID)
+	require.ErrorIs(t, err, ErrNoAssigner)
 
 	// Check that extended provider missing address is caught.
 	prevAddrs := extProviders.Providers[0].Addrs
@@ -360,11 +361,15 @@ func TestDatastore(t *testing.T) {
 	require.Equal(t, 1, len(assigned))
 
 	// Unassign peer and check that it is not assigned.
-	err = r.UnassignPeer(preferred[0])
+	ok, err := r.UnassignPeer(preferred[0])
 	require.NoError(t, err)
+	require.True(t, ok)
 	assigned, _, err = r.ListAssignedPeers()
 	require.NoError(t, err)
 	require.Zero(t, len(assigned))
+	ok, err = r.UnassignPeer(preferred[0])
+	require.NoError(t, err)
+	require.False(t, ok)
 
 	// Should not be able to assign blocked peer.
 	require.True(t, r.BlockPeer(preferred[0]))

--- a/server/admin/http/handler.go
+++ b/server/admin/http/handler.go
@@ -197,7 +197,7 @@ func (h *adminHandler) unassignPeer(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	err := h.reg.UnassignPeer(peerID)
+	ok, err := h.reg.UnassignPeer(peerID)
 	if err != nil {
 		log.Infow("Cannot unassign peer from indexer", "peer", peerID.String())
 		if errors.Is(err, registry.ErrNoAssigner) {
@@ -207,8 +207,12 @@ func (h *adminHandler) unassignPeer(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	log.Infow("Unassigned publisher from indexer", "publisher", peerID)
+	if !ok {
+		http.Error(w, "peer was not assigned", http.StatusNotFound)
+		return
+	}
 
+	log.Infow("Unassigned publisher from indexer", "publisher", peerID)
 	w.WriteHeader(http.StatusOK)
 }
 


### PR DESCRIPTION
Unassign command removes a publisher assignment from an indexer. Restarting the assigner service is required, as a separate action, to see the assignment removal.
