### PR TITLE
Reduce sync result timeout back to 5 seconds on indexstar

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -32,7 +32,7 @@ spec:
             - name: SERVER_HTTP_CLIENT_TIMEOUT
               value: '10s'
             - name: SERVER_RESULT_MAX_WAIT
-              value: '30s'
+              value: '5s'
             - name: SERVER_RESULT_STREAM_MAX_WAIT
               value: '30s'
           resources:

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -31,7 +31,7 @@ spec:
             - name: SERVER_HTTP_CLIENT_TIMEOUT
               value: '30s'
             - name: SERVER_RESULT_MAX_WAIT
-              value: '10s'
+              value: '5s'
             - name: SERVER_RESULT_STREAM_MAX_WAIT
               value: '30s'
           resources:


### PR DESCRIPTION
It was bumped to see the behaviour of caskadht at the face of json requests. But it impacts service performace across indexstar and this should serve as encouragement for users of DHT cascadeing to move to streaming requests.
