### PR TITLE
Further reduce number of concurrent workers

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/config.json
@@ -73,7 +73,7 @@
     "HttpSyncRetryWaitMax": "30s",
     "HttpSyncRetryWaitMin": "1s",
     "HttpSyncTimeout": "10s",
-    "IngestWorkerCount": 10,
+    "IngestWorkerCount": 7,
     "KeepAdvertisements":true,
     "PubSubTopic": "/indexer/ingest/mainnet",
     "RateLimit": {


### PR DESCRIPTION
After reducing the number of concurrent workers from 20 to 10 yesterday I can observe a significant improvement in latencies. There are some occasional spikes though and some of the parameters such as number of L0 open files (high thousands) and read amplifications (>50) are still elevated to what they should be. However there is a huge improvement. 

I suspect that pebble is still trying to crunch through the accumulated compaction debt that causes these occasional spikes. 

Reducing the number of concurrent workers further to give pebble some breathing room while still doing the work. 