### PR TITLE
Deploy separation of indexstar cascade backend on `dev`

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -20,7 +20,7 @@ spec:
             - '--backends=http://cali-indexer:3000/'
             - '--backends=http://ago-indexer:3000/'
             - '--backends=http://dhstore.internal.dev.cid.contact/'
-            - '--backends=http://caskadht.internal.dev.cid.contact/'
+            - '--cascadeBackends=http://caskadht.internal.dev.cid.contact/'
           env:
             # Increase maximum accepted request body to 1 MiB in order to allow batch finds requests
             # by the `provider verify-ingest` CLI command. 
@@ -30,9 +30,9 @@ spec:
             - name: SERVER_CASCADE_LABELS
               value: 'ipfs-dht'
             - name: SERVER_HTTP_CLIENT_TIMEOUT
-              value: '10s'
+              value: '30s'
             - name: SERVER_RESULT_MAX_WAIT
-              value: '5s'
+              value: '2s'
             - name: SERVER_RESULT_STREAM_MAX_WAIT
               value: '30s'
           resources:

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
@@ -18,4 +18,4 @@ replicas:
 images:
   - name: indexstar
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/indexstar/indexstar
-    newTag: 20230222104529-191abd3d2533e420693c73e3659edb8db1e01fff
+    newTag: 20230223161918-5ab5f8f5d060c4af169c9964b9eeb622b03b0e5a


### PR DESCRIPTION
Fix client timeout to be maximum of streamin/nonstreaming timeout.

Reduce non-streaming timeout to 2 seconds in order to reduce downstream timeouts for clients. If a backend is slower than 2 seconds it is already too slow and users should use streaming response instead.

See:
 - https://github.com/ipni/indexstar/pull/87

