### PR TITLE
Scale ago ingest worker count back to 10

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/config.json
@@ -73,7 +73,7 @@
     "HttpSyncRetryWaitMax": "30s",
     "HttpSyncRetryWaitMin": "1s",
     "HttpSyncTimeout": "10s",
-    "IngestWorkerCount": 7,
+    "IngestWorkerCount": 10,
     "KeepAdvertisements":true,
     "PubSubTopic": "/indexer/ingest/mainnet",
     "RateLimit": {


### PR DESCRIPTION
dhstore has caught up with compactions, all metrics are back to normal, CPU is underutilised. Scale back worker count to 10. 