### PR TITLE
Deploy separation of indexstar cascade backend on `prod`

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -19,7 +19,7 @@ spec:
             - '--backends=http://dido-indexer:3000/'
             - '--backends=http://oden-indexer:3000/'
             - '--backends=http://kepa-indexer:3000/'
-            - '--backends=http://caskadht.internal.prod.cid.contact/'
+            - '--cascadeBackends=http://caskadht.internal.prod.cid.contact/'
           env:
             # Increase maximum accepted request body to 1 MiB in order to allow batch finds requests
             # by the `provider verify-ingest` CLI command. 
@@ -31,7 +31,7 @@ spec:
             - name: SERVER_HTTP_CLIENT_TIMEOUT
               value: '30s'
             - name: SERVER_RESULT_MAX_WAIT
-              value: '5s'
+              value: '2s'
             - name: SERVER_RESULT_STREAM_MAX_WAIT
               value: '30s'
           resources:

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
@@ -18,4 +18,4 @@ replicas:
 images:
   - name: indexstar
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/indexstar/indexstar
-    newTag: 20230222104529-191abd3d2533e420693c73e3659edb8db1e01fff
+    newTag: 20230223161918-5ab5f8f5d060c4af169c9964b9eeb622b03b0e5a


### PR DESCRIPTION
Working on `dev` promoting to `prod`

See:
 - https://github.com/ipni/indexstar/pull/87

