### PR TITLE
Add dhstore http timeout configuration option

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -154,6 +154,7 @@ func daemonAction(cctx *cli.Context) error {
 		engine.WithDHBatchSize(cfg.Indexer.DHBatchSize),
 		engine.WithDHStore(cfg.Indexer.DHStoreURL),
 		engine.WithVSNoNewMH(cfg.Indexer.VSNoNewMH),
+		engine.WithHttpClientTimeout(time.Duration(cfg.Indexer.DHStoreHttpClientTimeout)),
 	)
 
 	indexCounts := counter.NewIndexCounts(dstore)

--- a/config/indexer.go
+++ b/config/indexer.go
@@ -23,6 +23,8 @@ type Indexer struct {
 	// DHStoreURL is the base URL for the DHStore service. This option value
 	// tells the indexer core to use a DHStore service, if configured.
 	DHStoreURL string
+	// DHStoreHttpClientTimeout is a timeout for the DHStore http client
+	DHStoreHttpClientTimeout Duration
 	// FreezeAtPercent is the percent used, of the file system that
 	// ValueStoreDir is on, at which to trigger the indexer to enter frozen
 	// mode. A zero value uses the default. A negative value disables freezing.
@@ -95,6 +97,8 @@ func NewIndexer() Indexer {
 		STHBurstRate:        8 * 1024 * 1024,
 		STHFileCacheSize:    512,
 		STHSyncInterval:     Duration(time.Second),
+		// defaulting http timeout to 10 seconds to survive over occasional spikes caused by compaction
+		DHStoreHttpClientTimeout: Duration(10 * time.Second),
 	}
 }
 
@@ -137,5 +141,8 @@ func (c *Indexer) populateUnset() {
 	}
 	if c.STHSyncInterval == 0 {
 		c.STHSyncInterval = def.STHSyncInterval
+	}
+	if c.DHStoreHttpClientTimeout == 0 {
+		c.DHStoreHttpClientTimeout = def.DHStoreHttpClientTimeout
 	}
 }


### PR DESCRIPTION
I observe that some occasional latency spikes that happen due to compaction result into http timeout on ago side. The vast majority (if not all) of them are under 10 seconds. Setting dhstore http timeout to 10 seconds so that such spikes don't result into ingestion errors. 