### PR TITLE
Set dhstore http timeout to 20s

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/config.json
@@ -64,7 +64,8 @@
     "DisableWAL": true,
     "VSNoNewMH": true,
     "DHBatchSize": -1,
-    "DHStoreURL": "http://dhstore.internal.dev.cid.contact"
+    "DHStoreURL": "http://dhstore.internal.dev.cid.contact",
+    "DHStoreHttpClientTimeout": "20s"
   },
   "Ingest": {
     "AdvertisementDepthLimit": 33554432,


### PR DESCRIPTION
Ago and dhstore perform well after all recent tunings. The last remaining issue i- s occasional latency spikes that happen due to compactions once in 1 or 2 hours. The default timeout of 10 seconds is not enough to cover for those. Bumping it up to 20s.