### PR TITLE
Move `caskadht` to CPU optimised worker nodes

### DIFF
--- a/deploy/infrastructure/prod/us-east-2/eks.tf
+++ b/deploy/infrastructure/prod/us-east-2/eks.tf
@@ -67,12 +67,40 @@ module "eks" {
         }
       }
     }
+    prod-ue2a-c6a-8xl = {
+      min_size       = 0
+      max_size       = 5
+      desired_size   = 1
+      instance_types = ["c6a.8xlarge"]
+      subnet_ids     = [data.aws_subnet.ue2a2.id]
+      taints = {
+        dedicated = {
+          key    = "dedicated"
+          value  = "c6a-8xl"
+          effect = "NO_SCHEDULE"
+        }
+      }
+    }
     prod-ue2b-c6a-8xl = {
-      min_size       = 1
+      min_size       = 0
       max_size       = 5
       desired_size   = 1
       instance_types = ["c6a.8xlarge"]
       subnet_ids     = [data.aws_subnet.ue2b2.id]
+      taints = {
+        dedicated = {
+          key    = "dedicated"
+          value  = "c6a-8xl"
+          effect = "NO_SCHEDULE"
+        }
+      }
+    }
+    prod-ue2c-c6a-8xl = {
+      min_size       = 0
+      max_size       = 5
+      desired_size   = 1
+      instance_types = ["c6a.8xlarge"]
+      subnet_ids     = [data.aws_subnet.ue2c2.id]
       taints = {
         dedicated = {
           key    = "dedicated"

--- a/deploy/manifests/prod/us-east-2/cluster/kube-system/aws-auth.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/kube-system/aws-auth.yaml
@@ -23,7 +23,17 @@ data:
     - groups:
       - system:bootstrappers
       - system:nodes
+      rolearn: arn:aws:iam::407967248065:role/prod-ue2a-c6a-8xl-eks-node-group
+      username: system:node:{{EC2PrivateDNSName}}
+    - groups:
+      - system:bootstrappers
+      - system:nodes
       rolearn: arn:aws:iam::407967248065:role/prod-ue2b-c6a-8xl-eks-node-group
+      username: system:node:{{EC2PrivateDNSName}}
+    - groups:
+      - system:bootstrappers
+      - system:nodes
+      rolearn: arn:aws:iam::407967248065:role/prod-ue2c-c6a-8xl-eks-node-group
       username: system:node:{{EC2PrivateDNSName}}
   mapUsers: |
     - userarn: arn:aws:iam::407967248065:user/masih

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/caskadht/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/caskadht/deployment.yaml
@@ -9,6 +9,15 @@ spec:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone
           whenUnsatisfiable: ScheduleAnyway
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.kubernetes.io/instance-type
+                    operator: In
+                    values:
+                      - c6a.8xlarge
       containers:
         - name: caskadht
           args:
@@ -27,12 +36,17 @@ spec:
               mountPath: /identity
           resources:
             limits:
-              cpu: "3"
-              memory: 5Gi
+              cpu: "30"
+              memory: 58Gi
             requests:
-              cpu: "3"
-              memory: 5Gi
+              cpu: "30"
+              memory: 58Gi
       volumes:
         - name: identity
           secret:
             secretName: caskadht-identity
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: c6a-8xl
+          effect: NoSchedule


### PR DESCRIPTION
Instantiate two other worker nodes with cpu optimised instance types to have one per AZ in addition to the pre-existing one.

Move caskadht to run on those worker nodes with as much CPU and RAM we can give it.

This should help identify the limits at which the accelerated DHT starts behaving until fixes deeper in libp2p stack are made.

Relates to:
 - https://github.com/ipni/caskadht/issues/28

