### PR TITLE
Disable webtransport protocol on `caskadht` due to panic bug

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/caskadht/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/caskadht/deployment.yaml
@@ -13,7 +13,7 @@ spec:
         - name: caskadht
           args:
             - '--libp2pIdentityPath=/identity/identity.key'
-            - '--libp2pListenAddrs=/ip4/0.0.0.0/tcp/40090,/ip4/0.0.0.0/udp/40090/quic,/ip4/0.0.0.0/udp/40090/quic-v1,/ip4/0.0.0.0/udp/40090/quic-v1/webtransport'
+            - '--libp2pListenAddrs=/ip4/0.0.0.0/tcp/40090,/ip4/0.0.0.0/udp/40090/quic,/ip4/0.0.0.0/udp/40090/quic-v1'
             - '--useResourceManager=false'
             # Respond with 404 if `?cascade=ipfs-dht` is not specified as URL query parameter.
             - '--ipniRequireQueryParam'

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/caskadht/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/caskadht/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - name: caskadht
           args:
             - '--libp2pIdentityPath=/identity/identity.key'
-            - '--libp2pListenAddrs=/ip4/0.0.0.0/tcp/40090,/ip4/0.0.0.0/udp/40090/quic,/ip4/0.0.0.0/udp/40090/quic-v1,/ip4/0.0.0.0/udp/40090/quic-v1/webtransport'
+            - '--libp2pListenAddrs=/ip4/0.0.0.0/tcp/40090,/ip4/0.0.0.0/udp/40090/quic,/ip4/0.0.0.0/udp/40090/quic-v1'
             - '--useResourceManager=false'
             # Respond with 404 if `?cascade=ipfs-dht` is not specified as URL query parameter.
             - '--ipniRequireQueryParam'


### PR DESCRIPTION
It seems there is an issue in webtransport session management that causes a panic and crashes the nodes. This was observed in one of the prod nodes at 1220 UTC.

Until fixed, disable webtransport protocol to limit exposure.

See:
 - https://github.com/quic-go/webtransport-go/issues/66

