### PR TITLE
Deploy k6 operator to `dev`

### DIFF
--- a/deploy/manifests/base/k6-operator/kustomization.yaml
+++ b/deploy/manifests/base/k6-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - github.com/grafana/k6-operator/config/default?ref=v0.0.8

--- a/deploy/manifests/dev/us-east-2/cluster/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kustomization.yaml
@@ -17,3 +17,4 @@ resources:
   - index-provider
   - external-snapshotter
   - snapshots
+  - ../../../base/k6-operator

--- a/deploy/manifests/dev/us-east-2/cluster/monitoring/prometheus-patch.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/monitoring/prometheus-patch.yaml
@@ -7,6 +7,8 @@ spec:
   # Do not include prometheus_replica label in metrics. Because, running more than one replicas
   # results in duplicate metrics.
   replicaExternalLabelName: ""
+  enableFeatures:
+    - remote-write-receiver
   remoteWrite:
     - url: https://aps-workspaces.us-east-2.amazonaws.com/workspaces/ws-324f25cd-3624-4250-9b66-96d36addd73f/api/v1/remote_write
       sigv4:


### PR DESCRIPTION
Deploy `k6` operator to `dev` environment to streamline load testing for Bedrock team. This is to be demoed later at Bedrock colo.
