### PR TITLE
Deploy fix to webtransport panic on `dev`

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/caskadht/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/caskadht/kustomization.yaml
@@ -24,4 +24,4 @@ configMapGenerator:
 images:
   - name: caskadht
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/caskadht
-    newTag: 20230221163035-cf92b0520184317bec2044432bee26d754a28064
+    newTag: 20230228121423-58580c9970ad3a1d0e3a92e97df7599b23ca0820


### PR DESCRIPTION
Upgrade `caskadht` with latest dependencies that includes fix to webtransport panic.

Test this on `dev` before rolling out to `prod`.

