### PR TITLE
Revert "Deploy latest to `dev` environment"

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}
-  newTag: 20230301130635-4d20104425c122afaf70c5dde135cd822857bb7f # {"$imagepolicy": "storetheindex:storetheindex:tag"}
+  newTag: 20230223171347-d23a8e11b899eac7ffa8661caf6108c56beb73f0 # {"$imagepolicy": "storetheindex:storetheindex:tag"}


### PR DESCRIPTION
Reverts ipni/storetheindex#1334

Writing CAR files is not working on ago, so reverting until solved.