### PR TITLE
Use correct datastore for carwriter

### DIFF
--- a/carstore/carwriter.go
+++ b/carstore/carwriter.go
@@ -232,12 +232,13 @@ func (cw *CarWriter) WriteExisting(ctx context.Context) <-chan int {
 	}
 
 	if len(adCids) == 0 {
+		log.Infow("Did not find existing advertisements to write to CAR files")
 		close(done)
 		return done
 	}
 
 	go func() {
-		log.Infof("Writing %d advertisements from datastore to CAR files", len(adCids))
+		log.Infow("Writing existing advertisements from datastore to CAR files", "count", len(adCids))
 		var count int
 		for _, adCid := range adCids {
 			if ctx.Err() != nil {


### PR DESCRIPTION
It is possible to configure using a sepatate datastore instance for keeping ad data in. The carwriter needs to use this.

Testing did not catch this because this is only used on ago instance.

Also fix a possible panic if an advertisement has a nil Entries value.
