### PR TITLE
Do not use a separate datastore for temporary ad data

### DIFF
--- a/carstore/carwriter.go
+++ b/carstore/carwriter.go
@@ -253,7 +253,7 @@ func (cw *CarWriter) WriteExisting(ctx context.Context) error {
 		if isAdvertisement(node) {
 			_, err = cw.Write(ctx, adCid, false)
 			if err != nil {
-				log.Errorw("Cannot write advertisement to CAR file", "err", err)
+				log.Errorw("Cannot write saved advertisement to CAR file", "err", err, "adCid", adCid)
 				var werr *WriteError
 				if errors.As(err, &werr) {
 					// Error writing to car file; stop writing ads.
@@ -265,7 +265,7 @@ func (cw *CarWriter) WriteExisting(ctx context.Context) error {
 			count++
 		}
 	}
-	log.Infow("Wrote advertisements from datastore to CAR files", "count", count)
+	log.Infow("Wrote saved advertisements from datastore to CAR files", "count", count)
 
 	return nil
 }

--- a/carstore/carwriter_test.go
+++ b/carstore/carwriter_test.go
@@ -260,9 +260,9 @@ func TestWriteExistingAdsInStore(t *testing.T) {
 
 	carw := carstore.NewWriter(dstore, fileStore)
 
-	countChan := carw.WriteExisting(ctx)
-	n := <-countChan
-	require.Equal(t, 1, n)
+	err = carw.WriteExisting(ctx)
+	require.NoError(t, err)
+
 	carName := adCid.String() + carstore.CarFileSuffix
 	var carFound bool
 	fc, ec := fileStore.List(ctx, "", false)

--- a/config/datastore.go
+++ b/config/datastore.go
@@ -6,6 +6,8 @@ type Datastore struct {
 	// absolute path then the location is relative to the indexer repo
 	// directory.
 	Dir string
+	// TODO: Remove after ago-indexer migrated.
+	//
 	// DirAdvertisements specifies to keep advertisements in a separate
 	// datastore directory, using a separate datastore instance. If this is not
 	// set or is set to the same value as Dir, then the same datastore instance

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -366,7 +366,7 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 		if ing.carWriter == nil {
 			defer func() {
 				for _, c := range hamtCids {
-					err := ing.dsAds.Delete(ctx, datastore.NewKey(c.String()))
+					err := ing.ds.Delete(ctx, datastore.NewKey(c.String()))
 					if err != nil {
 						log.Errorw("Error deleting HAMT cid from datastore", "cid", c, "err", err)
 					}
@@ -536,7 +536,7 @@ func (ing *Ingester) ingestEntryChunk(ctx context.Context, ad schema.Advertiseme
 			// has finished. This prevents storing redundant information in several
 			// datastores.
 			entryChunkKey := datastore.NewKey(entryChunkCid.String())
-			err := ing.dsAds.Delete(ctx, entryChunkKey)
+			err := ing.ds.Delete(ctx, entryChunkKey)
 			if err != nil {
 				log.Errorw("Error deleting index from datastore", "err", err)
 			}
@@ -648,7 +648,7 @@ func (ing *Ingester) loadHamt(c cid.Cid) (*hamt.Node, error) {
 
 func (ing *Ingester) loadNode(c cid.Cid, prototype ipld.NodePrototype) (ipld.Node, error) {
 	key := datastore.NewKey(c.String())
-	val, err := ing.dsAds.Get(context.Background(), key)
+	val, err := ing.ds.Get(context.Background(), key)
 	if err != nil {
 		return nil, fmt.Errorf("cannot fetch the node from datastore: %w", err)
 	}

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -599,7 +599,7 @@ func (ing *Ingester) indexAdMultihashes(ad schema.Advertisement, mhs []multihash
 	// No code path should ever allow this, so it is a programming error if
 	// this ever happens.
 	if ad.IsRm {
-		panic("removing individual multihashes no allowed")
+		panic("removing individual multihashes not allowed")
 	}
 
 	if err = ing.indexer.Put(value, mhs...); err != nil {


### PR DESCRIPTION
Use the same datastore instance for temporary data. Read any existing ad data from the ad datastore, if configured, and write to CAR files. Then, stop using the ad datastore.
