### PR TITLE
Update to the latest core

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd
 	github.com/ipld/go-storethehash v0.3.13
 	github.com/ipni/dhstore v0.0.2-0.20230120184057-c54e9d7c72f7
-	github.com/ipni/go-indexer-core v0.7.2-0.20230221145318-9aef8658e4ea
+	github.com/ipni/go-indexer-core v0.7.2
 	github.com/libp2p/go-libp2p v0.23.4
 	github.com/libp2p/go-libp2p-gostream v0.5.0
 	github.com/libp2p/go-libp2p-pubsub v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -716,8 +716,8 @@ github.com/ipld/go-storethehash v0.3.13 h1:1T6kX5K57lAgxbsGitZEaZMAR3RdWch2kO8ok
 github.com/ipld/go-storethehash v0.3.13/go.mod h1:KCYpzmamubnSwm7fvWcCkm0aIwQh4WRNtzrKK4pVhAQ=
 github.com/ipni/dhstore v0.0.2-0.20230120184057-c54e9d7c72f7 h1:w4sIScjReSAME4FKuSPaUT0H6rUi4UxEy42lEi5QKJY=
 github.com/ipni/dhstore v0.0.2-0.20230120184057-c54e9d7c72f7/go.mod h1:CIz5tpqY9GRSTx2ZML3tmvCZzdDCudDuE3DP57R4ZYo=
-github.com/ipni/go-indexer-core v0.7.2-0.20230221145318-9aef8658e4ea h1:hdbpvjYl7ZB7w9eGn8thjsHNhIzUTEgJyrkF4WrEG8Q=
-github.com/ipni/go-indexer-core v0.7.2-0.20230221145318-9aef8658e4ea/go.mod h1:M8xYlU9CwIm+JbS44B2br+qlyoc6Pm3C8u2Vsov6Fzk=
+github.com/ipni/go-indexer-core v0.7.2 h1:LhQ1q0Sb62j5Bosuq8qV2deVeEs4WFK9KaxZyashHIo=
+github.com/ipni/go-indexer-core v0.7.2/go.mod h1:vY8v8ITI2+z3hBaqM1XVFC/z31JyRCa2rWF2IDOfPDU=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=


### PR DESCRIPTION
Update to the latest version of the core that fixes the [bug](https://github.com/ipni/go-indexer-core/pull/141) with second hash calculation.

I'll update this branch to point to the release version once the linked PR is merged. 