### PR TITLE
Do not use carwriter if using separate datastore for ad data

### DIFF
--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -190,7 +190,8 @@ func NewIngester(cfg config.Ingest, h host.Host, idxr indexer.Interface, reg *re
 
 	ing.workersCtx, ing.cancelWorkers = context.WithCancel(context.Background())
 
-	if cfg.CarMirrorDestination.Type != "" {
+	// Only use carstore if not using separate ad datastore.
+	if ing.dsAds == ing.ds && cfg.CarMirrorDestination.Type != "" {
 		fileStore, err := filestore.New(cfg.CarMirrorDestination)
 		if err != nil {
 			return nil, fmt.Errorf("cannot create file store for car failes: %w", err)

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -1126,11 +1126,11 @@ func (ing *Ingester) ingestWorkerLogic(ctx context.Context, provider peer.ID) {
 				"adCid", ai.cid,
 				"progress", fmt.Sprintf("%d of %d", count, splitAtIndex))
 
-			keep := ing.carWriter != nil
+			keep := ing.carWriter != nil || ing.dsAds != ing.ds
 			if markErr := ing.markAdProcessed(assignment.publisher, ai.cid, frozen, keep); markErr != nil {
 				log.Errorw("Failed to mark ad as processed", "err", markErr)
 			}
-			if !frozen && keep {
+			if !frozen && ing.carWriter != nil {
 				// Write the advertisement to a CAR file, but omit the entries.
 				carInfo, err := ing.carWriter.Write(ctx, ai.cid, true)
 				if err != nil {
@@ -1209,12 +1209,12 @@ func (ing *Ingester) ingestWorkerLogic(ctx context.Context, provider peer.ID) {
 			return
 		}
 
-		keep := ing.carWriter != nil
+		keep := ing.carWriter != nil || ing.dsAds != ing.ds
 		if markErr := ing.markAdProcessed(assignment.publisher, ai.cid, frozen, keep); markErr != nil {
 			log.Errorw("Failed to mark ad as processed", "err", markErr)
 		}
 
-		if !frozen && keep {
+		if !frozen && ing.carWriter != nil {
 			carInfo, err := ing.carWriter.Write(ctx, ai.cid, false)
 			if err != nil {
 				// Log the error, but do not return. Continue on to save the procesed ad.

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -363,7 +363,7 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 		gatherCids := func(_ peer.ID, c cid.Cid, _ dagsync.SegmentSyncActions) {
 			hamtCids = append(hamtCids, c)
 		}
-		if ing.carWriter == nil {
+		if ing.carWriter == nil && ing.dsAds == ing.ds {
 			defer func() {
 				for _, c := range hamtCids {
 					err := ing.dsAds.Delete(ctx, datastore.NewKey(c.String()))
@@ -530,7 +530,7 @@ func (ing *Ingester) ingestAd(publisherID peer.ID, adCid cid.Cid, ad schema.Adve
 // operation. This function is used as a scoped block hook, and is called for
 // each block that is received.
 func (ing *Ingester) ingestEntryChunk(ctx context.Context, ad schema.Advertisement, entryChunkCid cid.Cid, chunk schema.EntryChunk, log *zap.SugaredLogger) error {
-	if ing.carWriter == nil {
+	if ing.carWriter == nil && ing.dsAds == ing.ds {
 		defer func() {
 			// Remove the content block from the data store now that processing it
 			// has finished. This prevents storing redundant information in several


### PR DESCRIPTION
If using a separate ad datastore, as ago does, then keep ad data there and do not move it into car files.