### PR TITLE
Deploy latest to ago

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/kustomization.yaml
@@ -32,4 +32,4 @@ patchesStrategicMerge:
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-  newTag: 20230301194645-e903046d499e0f01cd01cfeb9315bf1c31328459
+  newTag: 20230302182835-4b10309b175ba8a78d78298864adfb4cc66ad375


### PR DESCRIPTION
This will keep ads in the ad datastore and not move them into car files.