### PR TITLE
Increase capacity to cope with traffic on prod

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/caskadht/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/caskadht/kustomization.yaml
@@ -23,7 +23,7 @@ configMapGenerator:
 
 replicas:
   - name: caskadht
-    count: 3
+    count: 5
 
 images:
   - name: caskadht

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -33,7 +33,7 @@ spec:
             - name: SERVER_RESULT_MAX_WAIT
               value: '2s'
             - name: SERVER_RESULT_STREAM_MAX_WAIT
-              value: '30s'
+              value: '5s'
           resources:
             limits:
               cpu: "3"

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
@@ -13,7 +13,7 @@ patchesStrategicMerge:
 
 replicas:
   - name: indexstar
-    count: 3
+    count: 5
 
 images:
   - name: indexstar


### PR DESCRIPTION
Scale out `caskadht` and `indexstar` to 5 instances, and reduce streaming timeout to 5 seconds to avoid too many lingering connections considering the increase in total traffic since ~0600 UTC.
