### PR TITLE
Option to compress CAR files (defaults to use gzip compression)

### DIFF
--- a/carstore/carreader_test.go
+++ b/carstore/carreader_test.go
@@ -29,7 +29,8 @@ func TestRead(t *testing.T) {
 
 	fileStore, err := filestore.New(cfg)
 	require.NoError(t, err)
-	carw := carstore.NewWriter(dstore, fileStore)
+	carw, err := carstore.NewWriter(dstore, fileStore, carstore.WithCompress(testCompress))
+	require.NoError(t, err)
 
 	adLink, ad, _, _, _ := storeRandomIndexAndAd(t, entBlockCount, metadata, nil, dstore)
 	adCid := adLink.(cidlink.Link).Cid
@@ -42,7 +43,8 @@ func TestRead(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create reader.
-	carr := carstore.NewReader(fileStore)
+	carr, err := carstore.NewReader(fileStore, carstore.WithCompress(testCompress))
+	require.NoError(t, err)
 
 	// Read and read CAR file.
 	adBlock, err := carr.Read(ctx, adCid, false)

--- a/carstore/carreader_test.go
+++ b/carstore/carreader_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ipfs/go-datastore"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipni/storetheindex/carstore"
-	"github.com/ipni/storetheindex/config"
 	"github.com/ipni/storetheindex/filestore"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
@@ -20,14 +19,7 @@ func TestRead(t *testing.T) {
 	metadata := []byte("car-test-metadata")
 
 	carDir := t.TempDir()
-	cfg := config.FileStore{
-		Type: "local",
-		Local: config.LocalFileStore{
-			BasePath: carDir,
-		},
-	}
-
-	fileStore, err := filestore.New(cfg)
+	fileStore, err := filestore.NewLocal(carDir)
 	require.NoError(t, err)
 	carw, err := carstore.NewWriter(dstore, fileStore, carstore.WithCompress(testCompress))
 	require.NoError(t, err)

--- a/carstore/carwriter_test.go
+++ b/carstore/carwriter_test.go
@@ -16,7 +16,6 @@ import (
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipni/storetheindex/api/v0/ingest/schema"
 	"github.com/ipni/storetheindex/carstore"
-	"github.com/ipni/storetheindex/config"
 	"github.com/ipni/storetheindex/filestore"
 	"github.com/ipni/storetheindex/test/util"
 	crypto "github.com/libp2p/go-libp2p/core/crypto"
@@ -43,14 +42,7 @@ func TestWrite(t *testing.T) {
 	metadata := []byte("car-test-metadata")
 
 	carDir := t.TempDir()
-	cfg := config.FileStore{
-		Type: "local",
-		Local: config.LocalFileStore{
-			BasePath: carDir,
-		},
-	}
-
-	fileStore, err := filestore.New(cfg)
+	fileStore, err := filestore.NewLocal(carDir)
 	require.NoError(t, err)
 	carw, err := carstore.NewWriter(dstore, fileStore, carstore.WithCompress(testCompress))
 	require.NoError(t, err)
@@ -173,13 +165,7 @@ func TestWriteToExistingAdCar(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok)
 
-	cfg := config.FileStore{
-		Type: "local",
-		Local: config.LocalFileStore{
-			BasePath: t.TempDir(),
-		},
-	}
-	fileStore, err := filestore.New(cfg)
+	fileStore, err := filestore.NewLocal(t.TempDir())
 	require.NoError(t, err)
 
 	fileName := adCid.String() + carstore.CarFileSuffix
@@ -213,14 +199,7 @@ func TestWriteChain(t *testing.T) {
 	metadata := []byte("car-test-metadata")
 
 	carDir := t.TempDir()
-	cfg := config.FileStore{
-		Type: "local",
-		Local: config.LocalFileStore{
-			BasePath: carDir,
-		},
-	}
-
-	fileStore, err := filestore.New(cfg)
+	fileStore, err := filestore.NewLocal(carDir)
 	require.NoError(t, err)
 	carw, err := carstore.NewWriter(dstore, fileStore, carstore.WithCompress(testCompress))
 	require.NoError(t, err)
@@ -266,13 +245,7 @@ func TestWriteExistingAdsInStore(t *testing.T) {
 	require.True(t, ok)
 
 	carDir := t.TempDir()
-	cfg := config.FileStore{
-		Type: "local",
-		Local: config.LocalFileStore{
-			BasePath: carDir,
-		},
-	}
-	fileStore, err := filestore.New(cfg)
+	fileStore, err := filestore.NewLocal(carDir)
 	require.NoError(t, err)
 
 	carw, err := carstore.NewWriter(dstore, fileStore, carstore.WithCompress(testCompress))

--- a/carstore/carwriter_test.go
+++ b/carstore/carwriter_test.go
@@ -85,6 +85,7 @@ func TestWrite(t *testing.T) {
 		require.NoError(t, err)
 		var ungzBuf bytes.Buffer
 		_, err = io.Copy(&ungzBuf, gzr)
+		require.NoError(t, err)
 		gzr.Close()
 		buf = ungzBuf
 	}

--- a/carstore/const.go
+++ b/carstore/const.go
@@ -1,6 +1,13 @@
 package carstore
 
+// File suffixes.
 const (
 	CarFileSuffix  = ".car"
+	GzipFileSuffix = ".gz"
 	HeadFileSuffix = ".head"
+)
+
+// Compression methods.
+const (
+	Gzip = "gzip"
 )

--- a/carstore/option.go
+++ b/carstore/option.go
@@ -1,0 +1,39 @@
+package carstore
+
+import (
+	"fmt"
+)
+
+// config contains all options for the server.
+type config struct {
+	compAlg string
+}
+
+// Option is a function that sets a value in a config.
+type Option func(*config) error
+
+// getOpts creates a config and applies Options to it.
+func getOpts(opts []Option) (config, error) {
+	var cfg config
+	for i, opt := range opts {
+		if err := opt(&cfg); err != nil {
+			return config{}, fmt.Errorf("option %d error: %s", i, err)
+		}
+	}
+	return cfg, nil
+}
+
+// WithCompress configures file compression.
+func WithCompress(alg string) Option {
+	return func(c *config) error {
+		switch alg {
+		case Gzip, "gz":
+			c.compAlg = Gzip
+		case "", "none", "nil", "null":
+			c.compAlg = ""
+		default:
+			return fmt.Errorf("unsupported compression: %s", alg)
+		}
+		return nil
+	}
+}

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -78,6 +78,9 @@ type Ingest struct {
 
 // FileStore configures a particular file store implementation.
 type FileStore struct {
+	// Compress specifies how to compress files. One of: "gzip", "none".
+	// Defaults to "gzip" if unspecified.
+	Compress string
 	// Type of file store to use: "", "local", "s3"
 	Type string
 	// Configuration for storing files in local filesystem.
@@ -109,17 +112,20 @@ type S3FileStore struct {
 func NewIngest() Ingest {
 	return Ingest{
 		AdvertisementDepthLimit: 33554432,
-		EntriesDepthLimit:       65536,
-		HttpSyncRetryMax:        4,
-		HttpSyncRetryWaitMax:    Duration(30 * time.Second),
-		HttpSyncRetryWaitMin:    Duration(1 * time.Second),
-		HttpSyncTimeout:         Duration(10 * time.Second),
-		IngestWorkerCount:       10,
-		PubSubTopic:             "/indexer/ingest/mainnet",
-		RateLimit:               NewRateLimit(),
-		StoreBatchSize:          4096,
-		SyncSegmentDepthLimit:   2_000,
-		SyncTimeout:             Duration(2 * time.Hour),
+		CarMirrorDestination: FileStore{
+			Compress: "gzip",
+		},
+		EntriesDepthLimit:     65536,
+		HttpSyncRetryMax:      4,
+		HttpSyncRetryWaitMax:  Duration(30 * time.Second),
+		HttpSyncRetryWaitMin:  Duration(1 * time.Second),
+		HttpSyncTimeout:       Duration(10 * time.Second),
+		IngestWorkerCount:     10,
+		PubSubTopic:           "/indexer/ingest/mainnet",
+		RateLimit:             NewRateLimit(),
+		StoreBatchSize:        4096,
+		SyncSegmentDepthLimit: 2_000,
+		SyncTimeout:           Duration(2 * time.Hour),
 	}
 }
 
@@ -129,6 +135,9 @@ func (c *Ingest) populateUnset() {
 
 	if c.AdvertisementDepthLimit == 0 {
 		c.AdvertisementDepthLimit = def.AdvertisementDepthLimit
+	}
+	if c.CarMirrorDestination.Compress == "" {
+		c.CarMirrorDestination.Compress = def.CarMirrorDestination.Compress
 	}
 	if c.EntriesDepthLimit == 0 {
 		c.EntriesDepthLimit = def.EntriesDepthLimit

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/config.json
@@ -69,7 +69,8 @@
   },
   "Ingest": {
     "AdvertisementDepthLimit": 33554432,
-    "CarMirrorDestination": {                                                                                                            
+    "CarMirrorDestination": {
+      "Compress": "gzip",
       "Type": "s3",
       "S3": {
         "BucketName": "dev-sti-adstore"

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -308,8 +308,9 @@ func TestEndToEndWithReferenceProvider(t *testing.T) {
 	dir.Close()
 	require.NoError(t, err)
 	var carCount, headCount int
+	carSuffix := carstore.CarFileSuffix + carstore.GzipFileSuffix
 	for _, name := range names {
-		if strings.HasSuffix(name, carstore.CarFileSuffix) && strings.HasPrefix(name, "baguqeera") {
+		if strings.HasSuffix(name, carSuffix) && strings.HasPrefix(name, "baguqeera") {
 			carCount++
 		} else if strings.HasSuffix(name, carstore.HeadFileSuffix) {
 			headCount++

--- a/filestore/filestore.go
+++ b/filestore/filestore.go
@@ -3,11 +3,8 @@ package filestore
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"time"
-
-	"github.com/ipni/storetheindex/config"
 )
 
 // File contains information about a stored file.
@@ -41,17 +38,4 @@ type Interface interface {
 	Put(ctx context.Context, path string, reader io.Reader) (*File, error)
 	// Type returns the file store type.
 	Type() string
-}
-
-// Create a new storage system of the configured type.
-func New(cfg config.FileStore) (Interface, error) {
-	switch cfg.Type {
-	case "local":
-		return newLocal(cfg.Local)
-	case "s3":
-		return newS3(cfg.S3)
-	case "", "none":
-		return nil, nil
-	}
-	return nil, fmt.Errorf("unsupported file storage type: %s", cfg.Type)
 }

--- a/filestore/option.go
+++ b/filestore/option.go
@@ -1,0 +1,46 @@
+package filestore
+
+import (
+	"fmt"
+)
+
+type s3Config struct {
+	endpoint  string
+	region    string
+	accessKey string
+	secretKey string
+}
+
+type S3Option func(*s3Config) error
+
+func getOpts(opts []S3Option) (s3Config, error) {
+	var cfg s3Config
+	for i, opt := range opts {
+		if err := opt(&cfg); err != nil {
+			return s3Config{}, fmt.Errorf("option %d error: %s", i, err)
+		}
+	}
+	return cfg, nil
+}
+
+func WithEndpoint(ep string) S3Option {
+	return func(c *s3Config) error {
+		c.endpoint = ep
+		return nil
+	}
+}
+
+func WithRegion(region string) S3Option {
+	return func(c *s3Config) error {
+		c.region = region
+		return nil
+	}
+}
+
+func WithKeys(accessKey, secretKey string) S3Option {
+	return func(c *s3Config) error {
+		c.accessKey = accessKey
+		c.secretKey = secretKey
+		return nil
+	}
+}


### PR DESCRIPTION
There is a new config option, `Ingest.CarMirrorDestination.Compress`, to compress CAR files. If unspecified, this value defaults to "gzip". Carfiles will be compressed and be named with the suffix `.car.gz`

Other changes:
- filestore package should not depend on sti config. The filestore package is available outside of storetheindex. To be more generally useful, it should not depend on storetheindex configuration.
- Convert ads from datastore to cars without reading all ad cids first.  This will be used later when migrating from a separate ad datastore.
