### PR TITLE
Take dhstore snapshot

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/snapshots/dhstore-snapshot.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/snapshots/dhstore-snapshot.yaml
@@ -1,0 +1,8 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: dhstore-20230303
+spec:
+  volumeSnapshotClassName: csi-aws-vsc
+  source:
+    persistentVolumeClaimName: dhstore-data

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/snapshots/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/snapshots/kustomization.yaml
@@ -6,3 +6,4 @@ namespace: storetheindex
 resources:
   - ber-snapshot.yaml
   - cali-snapshot.yaml
+  - dhstore-snapshot.yaml


### PR DESCRIPTION
Take snapshot before wiping out PVC and restarting re-ingestion due to a recently discovered bug in calculation of second hash.