### PR TITLE
Bump up Ago ingest worker count

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/config.json
@@ -81,7 +81,7 @@
     "HttpSyncRetryWaitMax": "30s",
     "HttpSyncRetryWaitMin": "1s",
     "HttpSyncTimeout": "10s",
-    "IngestWorkerCount": 10,
+    "IngestWorkerCount": 12,
     "KeepAdvertisements":true,
     "PubSubTopic": "/indexer/ingest/mainnet",
     "RateLimit": {


### PR DESCRIPTION
Bump up Ago worker count as dhstore runs underutilised on both machine as well as db fronts
