### PR TITLE
Disable accelerated DHT on `caskadht` instances

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/caskadht/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/caskadht/deployment.yaml
@@ -19,6 +19,7 @@ spec:
             - '--ipniRequireQueryParam'
             - '--libp2pConMgrLow=200'
             - '--libp2pConMgrHigh=5000'
+            - '--useAcceleratedDHT=false'
           ports:
             - containerPort: 40090
               name: libp2p

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/caskadht/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/caskadht/deployment.yaml
@@ -28,6 +28,7 @@ spec:
             - '--ipniRequireQueryParam'
             - '--libp2pConMgrLow=200'
             - '--libp2pConMgrHigh=5000'
+            - '--useAcceleratedDHT=false'
           ports:
             - containerPort: 40090
               name: libp2p


### PR DESCRIPTION
Spikes of p95th lookup latency at cid.contact correlate to CPU spikes of DHT lookup cascades. The service is already given 30 CPU cores which is a lot. To maintain DHT lookup cascading as a feature we need a more efficient implementation of DHT client mode. Before any further work on optimising the accelerated DHT client, however, we should understand how the non-accelerated version behaves.

Disable accelerated DHT on `dev` and `prod` for `caskadht` instances in order to understand:
* resource consumption between the two
* lookup performance between the two
