### PR TITLE
Remove custom image tag for ago

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore/deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   name: dhstore
 spec:
+  replicas: 0
   template:
     spec:
       topologySpreadConstraints:

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   name: indexer
 spec:
+  replicas: 0
   template:
     spec:
       serviceAccountName: storetheindex

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/kustomization.yaml
@@ -28,8 +28,3 @@ configMapGenerator:
 
 patchesStrategicMerge:
   - deployment.yaml
-
-images:
-- name: storetheindex
-  newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-  newTag: 20230302182835-4b10309b175ba8a78d78298864adfb4cc66ad375


### PR DESCRIPTION
Remove custom image tag so that ago gets updated to the latest version in dev. Also reduce number of replicas for dhstore and ago to zero as ingestion will have to be started again. 
