### PR TITLE
Revert "fix: lower 404 ttl to decrease end user failures"

### DIFF
--- a/deploy/infrastructure/prod/us-east-2/cloudfront.tf
+++ b/deploy/infrastructure/prod/us-east-2/cloudfront.tf
@@ -53,7 +53,7 @@ resource "aws_cloudfront_distribution" "cdn" {
 
   custom_error_response {
     error_code            = 404
-    error_caching_min_ttl = 5
+    error_caching_min_ttl = 300
   }
 
   default_cache_behavior {


### PR DESCRIPTION
Reverts ipni/storetheindex#1344

Experimented with for ~20 minutes at prod, observed the following:

* Resulted it significant increase in find latency at p75th and above

<img width="589" alt="image" src="https://user-images.githubusercontent.com/301855/223420478-c206b6e1-6b7d-45b0-8cd8-bf9ba29cd39d.png">


* Did not increase 200s returned by cid.contat. just 404s shooting up

<img width="389" alt="image" src="https://user-images.githubusercontent.com/301855/223420710-916c815f-bc96-4869-919d-464090f7799d.png">

* High client latency observed by hydras

<img width="582" alt="image" src="https://user-images.githubusercontent.com/301855/223420879-8fd5474f-5e41-4560-bc24-a0a522efc052.png">

* No change in Caboose 404 fetch  errors

<img width="583" alt="image" src="https://user-images.githubusercontent.com/301855/223421077-8a566105-7661-4940-83a4-df59a54ca56c.png">


Cc @lidel  @willscott 