### PR TITLE
Revert "Disable accelerated DHT on `caskadht` instances"

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/caskadht/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/caskadht/deployment.yaml
@@ -19,7 +19,6 @@ spec:
             - '--ipniRequireQueryParam'
             - '--libp2pConMgrLow=200'
             - '--libp2pConMgrHigh=5000'
-            - '--useAcceleratedDHT=false'
           ports:
             - containerPort: 40090
               name: libp2p

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/caskadht/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/caskadht/deployment.yaml
@@ -28,7 +28,6 @@ spec:
             - '--ipniRequireQueryParam'
             - '--libp2pConMgrLow=200'
             - '--libp2pConMgrHigh=5000'
-            - '--useAcceleratedDHT=false'
           ports:
             - containerPort: 40090
               name: libp2p


### PR DESCRIPTION
Reverts ipni/storetheindex#1358

Observed behaviour for an hour; findings:
* cid.contact lookup latency is worse at p75th and above.
* memory usage is significantly less (4% utilisied, cpared to ~35%)  
* CPU usage is as spiky with with similar utilisation level, which combinded with the smaller routing state results in negative impact on the lookup latency.

<img width="1169" alt="image" src="https://user-images.githubusercontent.com/301855/223465940-4d06ce5b-a129-470a-90e2-b00a5013e852.png">

[Grafana](https://protocollabs.grafana.net/d/CTbNTGbVk/ipni-lookup-metrics?orgId=1&from=1678197182168&to=1678202252398)