### PR TITLE
Add extra logging to improve visibility into initialisation hanging

### DIFF
--- a/dagsync/dtsync/util.go
+++ b/dagsync/dtsync/util.go
@@ -112,13 +112,17 @@ func makeDataTransfer(host host.Host, ds datastore.Batching, lsys ipld.LinkSyste
 		cancel()
 		return nil, nil, nil, fmt.Errorf("failed to start datatransfer: %w", err)
 	}
+	log.Info("Started data transfer manager successfully.")
 
 	// Wait for datatransfer to be ready.
+	log.Info("Awaiting data transfer manager to become ready...")
 	err = <-dtReady
 	if err != nil {
+		log.Errorw("Failed while waiting for data transfer manager to become ready", "err", err)
 		cancel()
 		return nil, nil, nil, err
 	}
+	log.Info("Data transfer manager is read.")
 
 	closeFunc := func() error {
 		var err, errs error

--- a/dagsync/subscriber.go
+++ b/dagsync/subscriber.go
@@ -326,9 +326,13 @@ func (s *Subscriber) doClose() error {
 func (s *Subscriber) OnSyncFinished() (<-chan SyncFinished, context.CancelFunc) {
 	// Channel is buffered to prevent distribute() from blocking if a reader is
 	// not reading the channel immediately.
+	log.Info("Configuring subscriber OnSyncFinished...")
 	ch := make(chan SyncFinished, 1)
 	s.outEventsMutex.Lock()
-	defer s.outEventsMutex.Unlock()
+	defer func() {
+		s.outEventsMutex.Unlock()
+		log.Info("Subscriber OnSyncFinished configured.")
+	}()
 
 	s.outEventsChans = append(s.outEventsChans, ch)
 	cncl := func() {


### PR DESCRIPTION
Add logs to check that:
 * DT manager starts up fully.
 * onSyncFinished hooks don't deadlock on mutex.

Relates to:
 - https://github.com/ipni/storetheindex/issues/1371

