### PR TITLE
Update ago config

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/config.json
@@ -63,9 +63,9 @@
     "ValueStoreType": "pebble",
     "DisableWAL": true,
     "VSNoNewMH": true,
-    "DHBatchSize": -1,
+    "DHBatchSize": 5000,
     "DHStoreURL": "http://dhstore.internal.dev.cid.contact",
-    "DHStoreHttpClientTimeout": "20s"
+    "DHStoreHttpClientTimeout": "30s"
   },
   "Ingest": {
     "AdvertisementDepthLimit": 33554432,
@@ -81,7 +81,7 @@
     "HttpSyncRetryWaitMax": "30s",
     "HttpSyncRetryWaitMin": "1s",
     "HttpSyncTimeout": "10s",
-    "IngestWorkerCount": 12,
+    "IngestWorkerCount": 10,
     "KeepAdvertisements":true,
     "PubSubTopic": "/indexer/ingest/mainnet",
     "RateLimit": {


### PR DESCRIPTION
Ago doesn't seem to be able to cope with 12 concurrent workers. There have been a few timeouts overnight (which means that a single put took longer than 20 seconds to complete). In this commit set number of concurrent workers back to 10 (as ago showed stable performance with that number), increase batch size from 1024 to 5000 to see whether ingestion rate would improve and increase http timeout to 30s to reduce timeout rate.