### PR TITLE
Wrap the data transfer datastore to remove the need for FSM migration

### DIFF
--- a/dagsync/subscriber.go
+++ b/dagsync/subscriber.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/namespace"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
@@ -169,6 +170,7 @@ func NewSubscriber(host host.Host, ds datastore.Batching, lsys ipld.LinkSystem, 
 		}
 		dtSync, err = dtsync.NewSyncWithDT(host, opts.dtManager, opts.graphExchange, &lsys, blockHook)
 	} else {
+		ds := namespace.Wrap(ds, datastore.NewKey("data-transfer-v2"))
 		dtSync, err = dtsync.NewSync(host, ds, lsys, blockHook)
 	}
 	if err != nil {


### PR DESCRIPTION
Wrap the data store passed to data transfer manager with a namespace, such that it starts fresh and remove the need for migrating the old FSM to v2.

Relates to:
 - https://github.com/ipni/storetheindex/issues/1371
