### PR TITLE
Add dhfind deployment configuration

### DIFF
--- a/deploy/manifests/base/dhfind/deployment.yaml
+++ b/deploy/manifests/base/dhfind/deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dhfind
+spec:
+  selector:
+    matchLabels:
+      app: dhfind
+  template:
+    metadata:
+      labels:
+        app: dhfind
+    spec:
+      containers:
+        - name: dhfind
+          image: dhfind
+          envFrom:
+            - configMapRef:
+                name: dhfind-env-vars
+          ports:
+            - containerPort: 40080
+              name: http
+            - containerPort: 40082
+              name: metrics
+          readinessProbe:
+            httpGet:
+              port: http
+              path: /ready
+            initialDelaySeconds: 3
+            failureThreshold: 3
+            successThreshold: 1
+            timeoutSeconds: 5
+            periodSeconds: 10

--- a/deploy/manifests/base/dhfind/kustomization.yaml
+++ b/deploy/manifests/base/dhfind/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml
+  - pdb.yaml
+
+transformers:
+  - labels.yaml
+
+configMapGenerator:
+  - name: dhfind-env-vars
+    behavior: create
+    literals:
+      - GOLOG_LOG_LEVEL=INFO
+      - GOLOG_LOG_FMT=json

--- a/deploy/manifests/base/dhfind/labels.yaml
+++ b/deploy/manifests/base/dhfind/labels.yaml
@@ -1,0 +1,12 @@
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: labels
+labels:
+  app.kubernetes.io/name: dhfind
+  app.kubernetes.io/component: routing
+  app.kubernetes.io/part-of: ipni
+  app.kubernetes.io/managed-by: kustomization
+fieldSpecs:
+  - path: metadata/labels
+    create: true

--- a/deploy/manifests/base/dhfind/pdb.yaml
+++ b/deploy/manifests/base/dhfind/pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: dhfind
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: dhfind

--- a/deploy/manifests/base/dhfind/service.yaml
+++ b/deploy/manifests/base/dhfind/service.yaml
@@ -1,0 +1,11 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: dhfind
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+  selector:
+    app: dhfind

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhfind/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhfind/deployment.yaml
@@ -17,8 +17,8 @@ spec:
             - '--simulation=true'
           resources:
             limits:
-              cpu: "3"
-              memory: 5Gi
+              cpu: "0.5"
+              memory: 1Gi
             requests:
-              cpu: "3"
-              memory: 5Gi
+              cpu: "0.5"
+              memory: 1Gi

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhfind/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhfind/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dhfind
+spec:
+  template:
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+      containers:
+        - name: dhfind
+          args:
+            - '--dhstoreAddr=http://dhstore.internal.dev.cid.contact/'
+            - '--stiAddr=http://ago-indexer:3000/'
+            - '--simulation=true'
+          resources:
+            limits:
+              cpu: "3"
+              memory: 5Gi
+            requests:
+              cpu: "3"
+              memory: 5Gi

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhfind/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhfind/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - ../../../../../base/dhfind
+  - pod-monitor.yaml
+
+patchesStrategicMerge:
+  - deployment.yaml
+  - service.yaml
+
+images:
+  - name: dhfind
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhfind
+    newTag: 20230308144538-9080365389e74c6dc407feeb178c5d61d35cbf38

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhfind/pod-monitor.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhfind/pod-monitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: dhfind
+  labels:
+    app: dhfind
+spec:
+  selector:
+    matchLabels:
+      app: dhfind
+  namespaceSelector:
+    matchNames:
+      - storetheindex
+  podMetricsEndpoints:
+    - path: /metrics
+      port: metrics

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhfind/service.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhfind/service.yaml
@@ -1,0 +1,18 @@
+# dhfind service is accessible only within K8S cluster VPC via:
+#  - http://dhfind.internal.dev.cid.contact
+#
+# See: https://github.com/ipni/dhfind
+kind: Service
+apiVersion: v1
+metadata:
+  name: dhfind
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internal
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+    external-dns.alpha.kubernetes.io/access: private
+    external-dns.alpha.kubernetes.io/hostname: dhfind.internal.dev.cid.contact
+spec:
+  externalTrafficPolicy: Cluster
+  type: LoadBalancer

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -20,6 +20,7 @@ spec:
             - '--backends=http://cali-indexer:3000/'
             - '--backends=http://ago-indexer:3000/'
             - '--backends=http://dhstore.internal.dev.cid.contact/'
+            - '--backends=http://dhfind.internal.dev.cid.contact/'
             - '--cascadeBackends=http://caskadht.internal.dev.cid.contact/'
           env:
             # Increase maximum accepted request body to 1 MiB in order to allow batch finds requests

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - instances
 - indexstar
 - dhstore
+- dhfind
 - caskadht
 - snapshots
 images:


### PR DESCRIPTION
DHFind is a http facade for dhstore that performs hashing and decryption on behalf of the client.

* deploy `dhfind` on a configuration that is similar to `caskadht`.
* `dhfind` is going to be run in "simulation" mode that is going to return 404 to all requests.
* add `dhfind` as another backend for indexstar.