### PR TITLE
Print commands tree

### DIFF
--- a/command/commands.go
+++ b/command/commands.go
@@ -1,0 +1,20 @@
+package command
+
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+)
+
+//go:embed tree.txt
+var commandTree string
+
+var CommandsCmd = &cli.Command{
+	Name:  "commands",
+	Usage: "Print tree of commands and subcommands",
+	Action: func(_ *cli.Context) error {
+		fmt.Println(commandTree)
+		return nil
+	},
+}

--- a/command/loadgen.go
+++ b/command/loadgen.go
@@ -24,7 +24,7 @@ var loadGenCmd = &cli.Command{
 
 var loadGenVerifyCmd = &cli.Command{
 	Name:   "loadgen-verify",
-	Usage:  "Generate fake provider load for the indexer",
+	Usage:  "Verify fake provider data generated for the indexer",
 	Flags:  loadGenVerifyFlags,
 	Action: loadGenVerifyAction,
 }

--- a/command/tree.txt
+++ b/command/tree.txt
@@ -1,0 +1,32 @@
+|-- admin           Perform admin activities with an indexer
+|   |-- allow             Allow advertisements and content from peer
+|   |-- block             Block advertisements and content from peer
+|   |-- freeze            Put indexer into frozen mode
+|   |-- import-providers  Import provider information from another indexer
+|   |-- list-assigned     List assigned peers when configured to work with assigner service
+|   |-- list-preferred    List unassigned peers that indexer has retrieved content from
+|   |-- reload-config     Reload various settings from the configuration file
+|   |-- status            Show indexer status
+|   |-- sync              Sync indexer with provider
+|   `-- unassign          Un-assign a publisher from the indexer
+|-- assigner        Assigner service
+|   |-- daemon            Start assigner service daemon
+|   `-- init              Initialize or upgrade config file
+|-- commands        Print tree of commands and subcommands
+|-- daemon          Start an indexer daemon, accepting http requests
+|-- find            Find value by CID or multihash in indexer
+|-- import          Imports data directly into indexer, bypassing ingestion process
+|   |-- cidlist           Import indexer data from cidList
+|   |-- car               Import indexer data from car
+|   `-- manifest          Import manifest of CID aggregator
+|-- init            Initialize or upgrade indexer node config file
+|-- loadtest
+|   |-- synthetic         Generate synthetic load to import in indexer
+|   |-- loadgen           Generate fake provider load for the indexer
+|   `-- loadgen-verify    Generate fake provider load for the indexer
+|-- log             Show log subsystems and modify log levels
+|   |-- getsubsys         Lists the available logging subsystems
+|   `-- setlevel          Sets log level for logging subsystems
+`-- providers       Commands to get provider information
+    |-- get               Show information about a specific provider
+    `-- list              Show information about all known providers

--- a/command/tree.txt
+++ b/command/tree.txt
@@ -27,6 +27,7 @@
 |-- log             Show log subsystems and modify log levels
 |   |-- getsubsys         Lists the available logging subsystems
 |   `-- setlevel          Sets log level for logging subsystems
-`-- providers       Commands to get provider information
-    |-- get               Show information about a specific provider
-    `-- list              Show information about all known providers
+|-- providers       Commands to get provider information
+|    |-- get               Show information about a specific provider
+|    `-- list              Show information about all known providers
+`-- spaddr          Get storage provider p2p ID and address from lotus gateway

--- a/command/tree.txt
+++ b/command/tree.txt
@@ -23,7 +23,7 @@
 |-- loadtest
 |   |-- synthetic         Generate synthetic load to import in indexer
 |   |-- loadgen           Generate fake provider load for the indexer
-|   `-- loadgen-verify    Generate fake provider load for the indexer
+|   `-- loadgen-verify    Verify fake provider data generated for the indexer
 |-- log             Show log subsystems and modify log levels
 |   |-- getsubsys         Lists the available logging subsystems
 |   `-- setlevel          Sets log level for logging subsystems

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ func main() {
 			command.AdminCmd,
 			command.AssignerCmd,
 			command.DaemonCmd,
+			command.CommandsCmd,
 			command.FindCmd,
 			command.ImportCmd,
 			command.InitCmd,


### PR DESCRIPTION
Provide a new `commands` command that prints a tree view of the available commands. This helps users see what commands are available and where to find them.  The tree is static text and can be seen in the diffs for this PR.
