### PR TITLE
No separate ads datastore

### DIFF
--- a/config/datastore.go
+++ b/config/datastore.go
@@ -6,12 +6,6 @@ type Datastore struct {
 	// absolute path then the location is relative to the indexer repo
 	// directory.
 	Dir string
-	// DirAdvertisements specifies to keep advertisements in a separate
-	// datastore directory, using a separate datastore instance. If this is not
-	// set or is set to the same value as Dir, then the same datastore instance
-	// is used to store advertisements. If this is not an absolute path then
-	// the location is relative to the indexer repo directory.
-	DirAdvertisements string
 	// Type is the type of datastore.
 	Type string
 }

--- a/dagsync/announce_test.go
+++ b/dagsync/announce_test.go
@@ -75,7 +75,7 @@ func TestAnnounceReplace(t *testing.T) {
 		pendingCid = hnd.pendingCid
 		hnd.qlock.Unlock()
 		return pendingCid == cid.Undef
-	}, 2*time.Second, 10*time.Millisecond)
+	}, 2*time.Second, 100*time.Millisecond)
 
 	// Announce two more times.
 	c := chainLnks[1].(cidlink.Link).Cid
@@ -100,7 +100,7 @@ func TestAnnounceReplace(t *testing.T) {
 		pendingCid = hnd.pendingCid
 		hnd.qlock.Unlock()
 		return pendingCid == lastCid
-	}, 2*time.Second, 10*time.Millisecond)
+	}, 2*time.Second, 100*time.Millisecond)
 
 	// Unblock the first handler goroutine
 	hnd.syncMutex.Unlock()
@@ -182,7 +182,7 @@ func TestAnnounce_LearnsHttpPublisherAddr(t *testing.T) {
 	watcher, cncl := sub.OnSyncFinished()
 	defer cncl()
 	select {
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(updateTimeout):
 		t.Fatal("timed out waiting for sync to finish")
 	case <-watcher:
 	}

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -411,7 +411,7 @@ func (ing *Ingester) ingestHamtFromPublisher(ctx context.Context, ad schema.Adve
 	if !ing.mirror.canWrite() {
 		defer func() {
 			for _, c := range hamtCids {
-				err := ing.dsAds.Delete(ctx, datastore.NewKey(c.String()))
+				err := ing.ds.Delete(ctx, datastore.NewKey(c.String()))
 				if err != nil {
 					log.Errorw("Error deleting HAMT cid from datastore", "cid", c, "err", err)
 				}
@@ -625,7 +625,7 @@ func (ing *Ingester) ingestEntryChunk(ctx context.Context, ad schema.Advertiseme
 	err := ing.indexAdMultihashes(ad, providerID, chunk.Entries, log)
 	if !ing.mirror.canWrite() {
 		// Done processing entries chunk, so remove from datastore.
-		if err := ing.dsAds.Delete(ctx, datastore.NewKey(entryChunkCid.String())); err != nil {
+		if err := ing.ds.Delete(ctx, datastore.NewKey(entryChunkCid.String())); err != nil {
 			log.Errorw("Error deleting index from datastore", "err", err)
 		}
 	}
@@ -728,7 +728,7 @@ func (ing *Ingester) loadHamt(c cid.Cid) (*hamt.Node, error) {
 
 func (ing *Ingester) loadNode(c cid.Cid, prototype ipld.NodePrototype) (ipld.Node, error) {
 	key := datastore.NewKey(c.String())
-	val, err := ing.dsAds.Get(context.Background(), key)
+	val, err := ing.ds.Get(context.Background(), key)
 	if err != nil {
 		return nil, fmt.Errorf("cannot fetch the node from datastore: %w", err)
 	}

--- a/internal/ingest/option.go
+++ b/internal/ingest/option.go
@@ -3,14 +3,12 @@ package ingest
 import (
 	"fmt"
 
-	"github.com/ipfs/go-datastore"
 	"github.com/ipni/storetheindex/internal/counter"
 )
 
 // configIngest contains all options for the ingester.
 type configIngest struct {
 	idxCounts *counter.IndexCounts
-	dsAds     datastore.Batching
 }
 
 // Option is a function that sets a value in a config.
@@ -25,14 +23,6 @@ func getOpts(opts []Option) (configIngest, error) {
 		}
 	}
 	return cfg, nil
-}
-
-// WithAdsDatastore configures a separate datastore for advertizements.
-func WithAdsDatastore(ds datastore.Batching) Option {
-	return func(c *configIngest) error {
-		c.dsAds = ds
-		return nil
-	}
 }
 
 // WithIndexCounts configures counting indexes using an IndexCounts instance.


### PR DESCRIPTION
## Context
Before the content advertisement mirrors were available, the indexer could be made to keep advertisements and entries data in a separate datastore from the one that other indexer state data is kept in. This datastore could then be copied to other indexers that were starting up to quickly bootstrap indexing.

Now that advertisement mirrors are available as an alternate source of index data, building up advertisements in a datastore is no longer necessary. Any existing ad datastores are no longer needed and can be discarded.

## Proposed changes
Do not use a separate datastore for temporary ad data

- Use the same datastore instance for temporary data and indexer state
- Remove configuration for separate ad datastore