### PR TITLE
Do not wait for worker availability when shutdown

### DIFF
--- a/command/loadgen.go
+++ b/command/loadgen.go
@@ -24,7 +24,7 @@ var loadGenCmd = &cli.Command{
 
 var loadGenVerifyCmd = &cli.Command{
 	Name:   "loadgen-verify",
-	Usage:  "Generate fake provider load for the indexer",
+	Usage:  "Verify fake data generated for the indexer",
 	Flags:  loadGenVerifyFlags,
 	Action: loadGenVerifyAction,
 }

--- a/dagsync/subscriber_test.go
+++ b/dagsync/subscriber_test.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	testTopic     = "/dagsync/testtopic"
-	updateTimeout = 1 * time.Second
+	updateTimeout = 3 * time.Second
 )
 
 type pubMeta struct {

--- a/filestore/filestore_test.go
+++ b/filestore/filestore_test.go
@@ -250,7 +250,7 @@ func testDelete(t *testing.T, fs filestore.Interface) {
 	_, err = fs.Put(ctx, fileName3, strings.NewReader(data3))
 	require.NoError(t, err)
 
-	// File exists before delet.
+	// File exists before delete.
 	_, err = fs.Head(ctx, fileName1)
 	require.NoError(t, err)
 
@@ -270,6 +270,18 @@ func testDelete(t *testing.T, fs filestore.Interface) {
 
 	err = fs.Delete(ctx, fileName3)
 	require.NoError(t, err)
+
+	// Verify nothing in subdir.
+	fileCh, errCh := fs.List(context.Background(), fileName3, false)
+	var count int
+	var name string
+	for fileInfo := range fileCh {
+		count++
+		name = fileInfo.Path
+	}
+	err = <-errCh
+	require.NoError(t, err)
+	require.Zero(t, count, "file exists:", name)
 
 	// Delete empty directory should be ok.
 	err = fs.Delete(ctx, subdir)


### PR DESCRIPTION
Goroutines may be waiting for worker availability when shutdown, which causes unnecessary delay in shutting down and may even lead to a forced shutdown. This PR fixes this by also waiting on a shutdown signal when waiting for an available worker.

Include minor command description fix.
