### PR TITLE
Deploy `lookout` the new monitoring service on `dev`

### DIFF
--- a/deploy/manifests/base/lookout/deployment.yaml
+++ b/deploy/manifests/base/lookout/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lookout
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: lookout
+  template:
+    metadata:
+      labels:
+        app: lookout
+    spec:
+      containers:
+        - name: lookout
+          image: lookout
+          env:
+            - name: GOLOG_LOG_LEVEL
+              value: INFO
+            - name: GOLOG_LOG_FMT
+              value: json
+          ports:
+            - containerPort: 40080
+              name: metrics

--- a/deploy/manifests/base/lookout/kustomization.yaml
+++ b/deploy/manifests/base/lookout/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+
+commonLabels:
+  app: lookout

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - dhstore
 - caskadht
 - snapshots
+- lookout
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/lookout/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/lookout/deployment.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lookout
+spec:
+  template:
+    spec:
+      containers:
+        - name: lookout
+          resources:
+            limits:
+              cpu: "0.3"
+              memory: 512Mi
+            requests:
+              cpu: "0.3"
+              memory: 512Mi

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/lookout/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/lookout/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - ../../../../../base/lookout
+  - pod-monitor.yaml
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: lookout
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/lookout
+    newTag: 20230310105018-589a5140cb28bfbafa6f8e1e4740705a50d8e269

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/lookout/pod-monitor.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/lookout/pod-monitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: lookout
+  labels:
+    app: lookout
+spec:
+  selector:
+    matchLabels:
+      app: lookout
+  namespaceSelector:
+    matchNames:
+      - storetheindex
+  podMetricsEndpoints:
+    - path: /metrics
+      port: metrics


### PR DESCRIPTION
Define base manifests and deploy `lookout` on `dev`. See:
 - https://github.com/ipni/lookout
