### PR TITLE
Set `dev` specific config for `lookout` monitoring service

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/lookout/config.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/lookout/config.yaml
@@ -1,0 +1,44 @@
+checkers:
+  # Check dev endpoint behind cache
+  cid_contact:
+    type: ipni-non-streaming
+    ipniEndpoint: https://dev.cid.contact
+    Timeout: 30s
+    ipfsDhtCascade: false
+    parallelism: 10
+  # Check dev endpoint behind cache with cascade over IPFS DHT enabled
+  cid_contact_with_cascade:
+    type: ipni-non-streaming
+    ipniEndpoint: https://dev.cid.contact
+    Timeout: 30s
+    ipfsDhtCascade: true
+    parallelism: 10
+  # Check dev endpoint without cache
+  indexstar:
+    type: ipni-non-streaming
+    ipniEndpoint: https://indexstar.dev.cid.contact
+    Timeout: 30s
+    ipfsDhtCascade: false
+    parallelism: 10
+  # Check dev endpoint without cache with cascade over IPFS DHT enabled
+  indexstar_with_cascade:
+    type: ipni-non-streaming
+    ipniEndpoint: https://indexstar.dev.cid.contact
+    Timeout: 30s
+    ipfsDhtCascade: true
+    parallelism: 10
+samplers:
+  # List of root CIDs of well known IPFS datasets.
+  # See: 
+  #  - https://awesome.ipfs.io/datasets/
+  'awesome.ipfs.io/datasets':
+    type: awesome-ipfs-datasets
+  # List of top CIDs collected by saturn orchestrator with inner paths stripped.
+  # See:
+  #  - https://orchestrator.strn.pl/top-cids
+  'orchestrator.strn.pl/top-cids':
+    type: saturn-orch-top-cids
+checkInterval: 10m
+checkersParallelism: 10
+samplersParallelism: 10
+metricsListenAddr: 0.0.0.0:40080

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/lookout/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/lookout/deployment.yaml
@@ -7,6 +7,8 @@ spec:
     spec:
       containers:
         - name: lookout
+          args:
+            - '--config=/config/config.yaml'
           resources:
             limits:
               cpu: "0.3"
@@ -14,3 +16,10 @@ spec:
             requests:
               cpu: "0.3"
               memory: 512Mi
+          volumeMounts:
+            - name: config
+              mountPath: /config
+      volumes:
+        - name: config
+          configMap:
+            name: lookout-config

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/lookout/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/lookout/kustomization.yaml
@@ -10,7 +10,13 @@ resources:
 patchesStrategicMerge:
   - deployment.yaml
 
+configMapGenerator:
+  - name: lookout-config
+    behavior: create
+    files:
+      - config.yaml
+
 images:
   - name: lookout
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/lookout
-    newTag: 20230310105018-589a5140cb28bfbafa6f8e1e4740705a50d8e269
+    newTag: 20230310151919-6fe5cfdd18aa6f36f7f2d6470d629e3e33a0599e


### PR DESCRIPTION
Configure the bespoke `dev` monitoring config that checks both cached and uncached endpoints with and without cascading.

