### PR TITLE
More consistent use of test library

### DIFF
--- a/assigner/server/server_test.go
+++ b/assigner/server/server_test.go
@@ -41,17 +41,13 @@ const pubsubTopic = "/indexer/ingest/mainnet"
 
 func setupServer(t *testing.T, assigner *core.Assigner) *server.Server {
 	s, err := server.New("127.0.0.1:0", assigner)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return s
 }
 
 func setupClient(t *testing.T, host string) *client.Client {
 	c, err := client.New(host)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return c
 }
 
@@ -176,9 +172,8 @@ func TestAssignOnAnnounce(t *testing.T) {
 	assignChan, cancel := assigner.OnAssignment(peerID)
 	defer cancel()
 
-	if err := cl.Announce(context.Background(), ai, cid.NewCidV1(22, mhs[0])); err != nil {
-		t.Fatalf("Failed to announce to %s: %s", s.URL(), err)
-	}
+	err = cl.Announce(context.Background(), ai, cid.NewCidV1(22, mhs[0]))
+	require.NoErrorf(t, err, "Failed to announce to %s", s.URL())
 
 	select {
 	case indexerNum := <-assignChan:
@@ -231,9 +226,7 @@ func initAssigner(t *testing.T, trustedID string) (*core.Assigner, config.Assign
 		PubSubTopic: pubsubTopic,
 	}
 	assigner, err := core.NewAssigner(context.Background(), cfg, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	return assigner, cfg
 }

--- a/carstore/carwriter_test.go
+++ b/carstore/carwriter_test.go
@@ -262,11 +262,8 @@ func TestWriteExistingAdsInStore(t *testing.T) {
 	var carFound bool
 	fc, ec := fileStore.List(ctx, "", false)
 	for fileInfo := range fc {
-		if fileInfo.Path == carName {
-			carFound = true
-		} else {
-			t.Fatal("unexpected file")
-		}
+		require.Equal(t, carName, fileInfo.Path, "unexpected file")
+		carFound = true
 	}
 	err = <-ec
 	require.NoError(t, err)

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/ipni/storetheindex/config"
+	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
 )
 
@@ -34,19 +35,13 @@ func TestInit(t *testing.T) {
 	)
 
 	err := app.RunContext(ctx, []string{"storetheindex", "init", "-listen-admin", badAddr})
-	if err == nil {
-		t.Fatal("expected error")
-	}
+	require.Error(t, err)
 
 	err = app.RunContext(ctx, []string{"storetheindex", "init", "-listen-finder", badAddr})
-	if err == nil {
-		t.Fatal("expected error")
-	}
+	require.Error(t, err)
 
 	err = app.RunContext(ctx, []string{"storetheindex", "init", "-listen-ingest", badAddr})
-	if err == nil {
-		t.Fatal("expected error")
-	}
+	require.Error(t, err)
 
 	args := []string{
 		"storetheindex", "init",
@@ -57,33 +52,17 @@ func TestInit(t *testing.T) {
 		"-store", storeType,
 	}
 	err = app.RunContext(ctx, args)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	cfg, err := config.Load("")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if cfg.Addresses.Finder != goodAddr {
-		t.Error("finder listen address was not configured")
-	}
-	if cfg.Addresses.Ingest != goodAddr2 {
-		t.Error("ingest listen address was not configured")
-	}
-	if cfg.Indexer.CacheSize != cacheSize {
-		t.Error("cache size was tno configured")
-	}
-	if cfg.Indexer.ValueStoreType != storeType {
-		t.Error("value store type was not configured")
-	}
-	if cfg.Ingest.PubSubTopic != topicName {
-		t.Errorf("expected %s for pubsub topic, got %s", topicName, cfg.Ingest.PubSubTopic)
-	}
-	if cfg.Version != config.Version {
-		t.Error("did not init config with correct version")
-	}
+	require.Equal(t, goodAddr, cfg.Addresses.Finder, "finder listen address was not configured")
+	require.Equal(t, goodAddr2, cfg.Addresses.Ingest, "ingest listen address was not configured")
+	require.Equal(t, cacheSize, cfg.Indexer.CacheSize, "cache size was tno configured")
+	require.Equal(t, storeType, cfg.Indexer.ValueStoreType, "value store type was not configured")
+	require.Equal(t, topicName, cfg.Ingest.PubSubTopic)
+	require.Equal(t, config.Version, cfg.Version)
 
 	t.Log(cfg.String())
 }

--- a/config/bootstrap_test.go
+++ b/config/bootstrap_test.go
@@ -3,6 +3,8 @@ package config
 import (
 	"sort"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 var testBootstrapAddresses = []string{
@@ -19,9 +21,7 @@ func TestBoostrapPeers(t *testing.T) {
 		Peers: testBootstrapAddresses,
 	}
 	addrs, err := b.PeerAddrs()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	var b2 Bootstrap
 	b2.SetPeers(addrs)
@@ -29,8 +29,6 @@ func TestBoostrapPeers(t *testing.T) {
 	sort.Strings(b.Peers)
 
 	for i := range b2.Peers {
-		if b2.Peers[i] != b.Peers[i] {
-			t.Fatalf("expected %s, %s", b.Peers[i], b2.Peers[i])
-		}
+		require.Equal(t, b2.Peers[i], b.Peers[i])
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,6 +4,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestPath(t *testing.T) {
@@ -17,32 +19,18 @@ func TestPath(t *testing.T) {
 	}
 
 	path, err := Path("", dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	configRoot, err := PathRoot()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if path != filepath.Join(configRoot, dir) {
-		t.Fatalf("wrong path %s:", path)
-	}
+	require.Equal(t, filepath.Join(configRoot, dir), path)
 
 	path, err = Path("altroot", dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if path != filepath.Join("altroot", dir) {
-		t.Fatalf("wrong path %s:", path)
-	}
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join("altroot", dir), path)
 
 	path, err = Path("altroot", absdir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if path != filepath.Clean(absdir) {
-		t.Fatalf("wrong path %s:", path)
-	}
+	require.NoError(t, err)
+	require.Equal(t, filepath.Clean(absdir), path)
 }

--- a/config/init_test.go
+++ b/config/init_test.go
@@ -8,83 +8,53 @@ import (
 	"testing"
 
 	crypto_pb "github.com/libp2p/go-libp2p/core/crypto/pb"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateIdentity(t *testing.T) {
 	id, err := CreateIdentity(io.Discard)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	pk, err := id.DecodePrivateKey("")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if pk.Type() != crypto_pb.KeyType_Ed25519 {
-		t.Fatal("unexpected type:", pk.Type())
-	}
+	require.NoError(t, err)
+	require.Equal(t, crypto_pb.KeyType_Ed25519, pk.Type())
 }
 
 func TestMarshalUnmarshal(t *testing.T) {
 	cfg, err := Init(io.Discard)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	b, err := json.MarshalIndent(&cfg, "  ", "  ")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	t.Log("default config:\n", string(b))
 
 	cfg2 := Config{}
-	if err = json.Unmarshal(b, &cfg2); err != nil {
-		t.Fatal(err)
-	}
+	err = json.Unmarshal(b, &cfg2)
+	require.NoError(t, err)
 
-	if cfg.Identity.PeerID != cfg2.Identity.PeerID {
-		t.Fatal("identity no same")
-	}
-	if cfg.Identity.PrivKey != cfg2.Identity.PrivKey {
-		t.Fatal("private key not same")
-	}
+	require.Equal(t, cfg.Identity.PeerID, cfg2.Identity.PeerID)
+	require.Equal(t, cfg.Identity.PrivKey, cfg2.Identity.PrivKey)
 }
 
 func TestSaveLoad(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfgFile, err := Filename(tmpDir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if filepath.Dir(cfgFile) != tmpDir {
-		t.Fatal("wrong root dir", cfgFile)
-	}
+	require.Equal(t, tmpDir, filepath.Dir(cfgFile), "wrong root dir")
 
 	cfg, err := Init(io.Discard)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	cfgBytes, err := Marshal(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	err = cfg.Save(cfgFile)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	cfg2, err := Load(cfgFile)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	cfg2Bytes, err := Marshal(cfg2)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if !bytes.Equal(cfgBytes, cfg2Bytes) {
-		t.Fatal("config data different after being loaded")
-	}
+	require.True(t, bytes.Equal(cfgBytes, cfg2Bytes), "config data different after being loaded")
 }

--- a/dagsync/httpsync/maconv/convert_test.go
+++ b/dagsync/httpsync/maconv/convert_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRoundtrip(t *testing.T) {
@@ -19,22 +20,12 @@ func TestRoundtrip(t *testing.T) {
 	for _, s := range samples {
 		u, _ := url.Parse(s)
 		mu, err := ToMultiaddr(u)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		u2, err := ToURL(mu)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if u2.Scheme != u.Scheme {
-			t.Fatalf("scheme didn't roundtrip. got %s expected %s", u2.Scheme, u.Scheme)
-		}
-		if u2.Host != u.Host {
-			t.Fatalf("host didn't roundtrip. got %s, expected %s", u2.Host, u.Host)
-		}
-		if u2.Path != u.Path {
-			t.Fatalf("path didn't roundtrip. got %s, expected %s", u2.Path, u.Path)
-		}
+		require.NoError(t, err)
+		require.Equal(t, u.Scheme, u2.Scheme, "scheme didn't roundtrip")
+		require.Equal(t, u.Host, u2.Host, "host didn't roundtrip")
+		require.Equal(t, u.Path, u2.Path, "path didn't roundtrip")
 	}
 }
 
@@ -59,16 +50,10 @@ func TestTLSProtos(t *testing.T) {
 
 	for i := range samples {
 		m, err := multiaddr.NewMultiaddr(samples[i])
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		u, err := ToURL(m)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if u.String() != expect[i] {
-			t.Fatalf("expected %s to convert to url %s, got %s", m.String(), expect[i], u.String())
-		}
+		require.NoError(t, err)
+		require.Equal(t, expect[i], u.String(), "Did not convert to expected URL")
 	}
 }

--- a/dagsync/sync_test.go
+++ b/dagsync/sync_test.go
@@ -44,15 +44,11 @@ func TestLatestSyncSuccess(t *testing.T) {
 	defer pub.Close()
 
 	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, nil, dagsync.Topic(topics[1]))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer sub.Close()
 
 	err = test.WaitForPublisher(dstHost, topics[0].String(), srcHost.ID())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	watcher, cncl := sub.OnSyncFinished()
 	defer cncl()
@@ -61,17 +57,11 @@ func TestLatestSyncSuccess(t *testing.T) {
 	chainLnks := test.MkChain(srcLnkS, true)
 
 	err = newUpdateTest(pub, sub, dstStore, watcher, srcHost.ID(), chainLnks[2], false, chainLnks[2].(cidlink.Link).Cid)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	err = newUpdateTest(pub, sub, dstStore, watcher, srcHost.ID(), chainLnks[1], false, chainLnks[1].(cidlink.Link).Cid)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	err = newUpdateTest(pub, sub, dstStore, watcher, srcHost.ID(), chainLnks[0], false, chainLnks[0].(cidlink.Link).Cid)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
 func TestSyncFn(t *testing.T) {
@@ -307,9 +297,7 @@ func TestLatestSyncFailure(t *testing.T) {
 	defer srcHost.Close()
 	srcLnkS := test.MkLinkSystem(srcStore)
 	pub, err := dtsync.NewPublisher(srcHost, srcStore, srcLnkS, testTopic)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer pub.Close()
 
 	chainLnks := test.MkChain(srcLnkS, true)
@@ -324,54 +312,39 @@ func TestLatestSyncFailure(t *testing.T) {
 	t.Log("targer host:", dstHost.ID())
 
 	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer sub.Close()
 
-	if err := srcHost.Connect(context.Background(), dstHost.Peerstore().PeerInfo(dstHost.ID())); err != nil {
-		t.Fatal(err)
-	}
+	err = srcHost.Connect(context.Background(), dstHost.Peerstore().PeerInfo(dstHost.ID()))
+	require.NoError(t, err)
 
 	err = sub.SetLatestSync(srcHost.ID(), chainLnks[3].(cidlink.Link).Cid)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	err = test.WaitForPublisher(dstHost, testTopic, srcHost.ID())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	watcher, cncl := sub.OnSyncFinished()
 
 	t.Log("Testing sync fail when the other end does not have the data")
 	err = newUpdateTest(pub, sub, dstStore, watcher, srcHost.ID(), cidlink.Link{Cid: cid.Undef}, true, chainLnks[3].(cidlink.Link).Cid)
 	cncl()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	sub.Close()
 
 	dstStore = dssync.MutexWrap(datastore.NewMapDatastore())
 	sub2, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer sub2.Close()
 
 	err = sub2.SetLatestSync(srcHost.ID(), chainLnks[3].(cidlink.Link).Cid)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	watcher, cncl = sub2.OnSyncFinished()
 
 	t.Log("Testing sync fail when not able to run the full exchange")
 	err = newUpdateTest(pub, sub2, dstStore, watcher, srcHost.ID(), chainLnks[2], true, chainLnks[3].(cidlink.Link).Cid)
 	cncl()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
 func TestAnnounce(t *testing.T) {
@@ -388,21 +361,15 @@ func TestAnnounce(t *testing.T) {
 	dstLnkS := test.MkLinkSystem(dstStore)
 
 	pub, err := dtsync.NewPublisher(srcHost, srcStore, srcLnkS, testTopic)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer pub.Close()
 
 	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer sub.Close()
 
 	err = test.WaitForPublisher(dstHost, testTopic, srcHost.ID())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	watcher, cncl := sub.OnSyncFinished()
 	defer cncl()
@@ -411,17 +378,11 @@ func TestAnnounce(t *testing.T) {
 	chainLnks := test.MkChain(srcLnkS, true)
 
 	err = newAnnounceTest(pub, sub, dstStore, watcher, srcHost.ID(), srcHost.Addrs(), chainLnks[2], chainLnks[2].(cidlink.Link).Cid)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	err = newAnnounceTest(pub, sub, dstStore, watcher, srcHost.ID(), srcHost.Addrs(), chainLnks[1], chainLnks[1].(cidlink.Link).Cid)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	err = newAnnounceTest(pub, sub, dstStore, watcher, srcHost.ID(), srcHost.Addrs(), chainLnks[0], chainLnks[0].(cidlink.Link).Cid)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
 func newAnnounceTest(pub dagsync.Publisher, sub *dagsync.Subscriber, dstStore datastore.Batching, watcher <-chan dagsync.SyncFinished, peerID peer.ID, peerAddrs []multiaddr.Multiaddr, lnk ipld.Link, expectedSync cid.Cid) error {

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -1211,9 +1211,7 @@ func TestRecursionDepthLimitsEntriesSync(t *testing.T) {
 	for err == nil && lcid == cid.Undef {
 		// May not have marked ad as processed yet, retry.
 		time.Sleep(time.Second)
-		if ctx.Err() != nil {
-			t.Fatal("sync timeout")
-		}
+		require.NoError(t, ctx.Err(), "sync timeout")
 		lcid, err = ing.GetLatestSync(pubHost.ID())
 	}
 
@@ -1594,9 +1592,7 @@ func mkRegistry(t *testing.T) *registry.Registry {
 		PollInterval: config.Duration(time.Minute),
 	}
 	reg, err := registry.New(context.Background(), discoveryCfg, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return reg
 }
 
@@ -1643,9 +1639,8 @@ func mkIngestWithConfig(t *testing.T, h host.Host, cfg config.Ingest) (*Ingester
 func connectHosts(t *testing.T, srcHost, dstHost host.Host) {
 	srcHost.Peerstore().AddAddrs(dstHost.ID(), dstHost.Addrs(), time.Hour)
 	dstHost.Peerstore().AddAddrs(srcHost.ID(), srcHost.Addrs(), time.Hour)
-	if err := srcHost.Connect(context.Background(), dstHost.Peerstore().PeerInfo(dstHost.ID())); err != nil {
-		t.Fatal(err)
-	}
+	err := srcHost.Connect(context.Background(), dstHost.Peerstore().PeerInfo(dstHost.ID()))
+	require.NoError(t, err)
 }
 
 func newRandomLinkedList(t *testing.T, lsys ipld.LinkSystem, size int) (ipld.Link, []multihash.Multihash) {

--- a/internal/registry/policy/policy_test.go
+++ b/internal/registry/policy/policy_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ipni/storetheindex/config"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -38,41 +39,29 @@ func TestNewPolicy(t *testing.T) {
 	}
 
 	_, err := New(policyCfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	policyCfg.Allow = true
 	_, err = New(policyCfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	policyCfg.Allow = false
 	policyCfg.PublishExcept = append(policyCfg.PublishExcept, "bad ID")
 	_, err = New(policyCfg)
-	if err == nil {
-		t.Error("expected error with bad PublishExcept ID")
-	}
+	require.Error(t, err, "expected error with bad PublishExcept ID")
 	policyCfg.PublishExcept = nil
 
 	policyCfg.Except = append(policyCfg.Except, "bad ID")
 	_, err = New(policyCfg)
-	if err == nil {
-		t.Error("expected error with bad except ID")
-	}
+	require.Error(t, err, "expected error with bad except ID")
 	policyCfg.Except = nil
 
 	_, err = New(policyCfg)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	policyCfg.Allow = true
 	_, err = New(policyCfg)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 }
 
 func TestPolicyAccess(t *testing.T) {
@@ -84,95 +73,49 @@ func TestPolicyAccess(t *testing.T) {
 	}
 
 	p, err := New(policyCfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if p.Allowed(otherID) {
-		t.Error("peer ID should not be allowed by policy")
-	}
-	if !p.Allowed(exceptID) {
-		t.Error("peer ID should be allowed")
-	}
+	require.False(t, p.Allowed(otherID), "peer ID should not be allowed by policy")
+	require.True(t, p.Allowed(exceptID), "peer ID should be allowed")
 
-	if p.PublishAllowed(otherID, exceptID) {
-		t.Error("peer ID should not be allowed to publish")
-	}
-	if !p.PublishAllowed(otherID, otherID) {
-		t.Error("should be allowed to publish to self")
-	}
-	if p.PublishAllowed(exceptID, otherID) {
-		t.Error("should not be allowed to publish to blocked peer")
-	}
+	require.False(t, p.PublishAllowed(otherID, exceptID), "peer ID should not be allowed to publish")
+	require.True(t, p.PublishAllowed(otherID, otherID), "should be allowed to publish to self")
+	require.False(t, p.PublishAllowed(exceptID, otherID), "should not be allowed to publish to blocked peer")
 
 	p.Allow(otherID)
-	if !p.Allowed(otherID) {
-		t.Error("peer ID should be allowed by policy")
-	}
+	require.True(t, p.Allowed(otherID), "peer ID should be allowed by policy")
 
 	p.Block(exceptID)
-	if p.Allowed(exceptID) {
-		t.Error("peer ID should not be allowed")
-	}
+	require.False(t, p.Allowed(exceptID), "peer ID should not be allowed")
 
 	policyCfg.Allow = true
 	policyCfg.Publish = true
 
 	newPol, err := New(policyCfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	p.Copy(newPol)
 
-	if !p.Allowed(otherID) {
-		t.Error("peer ID should be allowed by policy")
-	}
-	if p.Allowed(exceptID) {
-		t.Error("peer ID should not be allowed")
-	}
+	require.True(t, p.Allowed(otherID), "peer ID should be allowed by policy")
+	require.False(t, p.Allowed(exceptID), "peer ID should not be allowed")
 
-	if p.PublishAllowed(otherID, exceptID) {
-		t.Error("should not be allowed to publish to blocked peer")
-	}
-	if p.PublishAllowed(exceptID, otherID) {
-		t.Error("peer ID should not be allowed to publish")
-	}
-	if !p.PublishAllowed(exceptID, exceptID) {
-		t.Error("peer ID be allowed to publish to self")
-	}
+	require.False(t, p.PublishAllowed(otherID, exceptID), "should not be allowed to publish to blocked peer")
+	require.False(t, p.PublishAllowed(exceptID, otherID), "peer ID should not be allowed to publish")
+	require.True(t, p.PublishAllowed(exceptID, exceptID), "peer ID be allowed to publish to self")
 
 	p.Allow(exceptID)
-	if !p.Allowed(exceptID) {
-		t.Error("peer ID should be allowed by policy")
-	}
+	require.True(t, p.Allowed(exceptID), "peer ID should be allowed by policy")
 
 	p.Block(otherID)
-	if p.Allowed(otherID) {
-		t.Error("peer ID should not be allowed")
-	}
+	require.False(t, p.Allowed(otherID), "peer ID should not be allowed")
 
 	cfg := p.ToConfig()
-	if cfg.Allow != true {
-		t.Error("wrong config.Allow")
-	}
-	if cfg.Publish != true {
-		t.Error("wrong config.Publish")
-	}
-	if len(cfg.Except) != 1 {
-		t.Fatal("expected 1 item in cfg.Except")
-	}
-	if cfg.Except[0] != otherIDStr {
-		t.Error("wrong ID in cfg.Except")
-	}
-	if len(cfg.PublishExcept) != 1 {
-		t.Fatal("expected 1 item in cfg.PublishExcept")
-	}
+	require.True(t, cfg.Allow)
+	require.True(t, cfg.Publish)
+	require.Equal(t, 1, len(cfg.Except))
+	require.Equal(t, otherIDStr, cfg.Except[0])
+	require.Equal(t, 1, len(cfg.PublishExcept))
 
 	p, err = New(config.Policy{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !p.NoneAllowed() {
-		t.Error("expected inaccessible policy")
-	}
+	require.NoError(t, err)
+	require.True(t, p.NoneAllowed(), "expected inaccessible policy")
 }

--- a/server/admin/http/server_test.go
+++ b/server/admin/http/server_test.go
@@ -291,9 +291,7 @@ func initRegistry(t *testing.T, trustedID string) *registry.Registry {
 		UseAssigner:  true,
 	}
 	reg, err := registry.New(context.Background(), discoveryCfg, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return reg
 }
 
@@ -305,14 +303,10 @@ func initIngest(t *testing.T, indx indexer.Interface, reg *registry.Registry) *i
 	cfg := config.NewIngest()
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
 	host, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	ing, err := ingest.NewIngester(cfg, host, indx, reg, ds)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	t.Cleanup(func() {
 		ing.Close()
 	})

--- a/server/finder/http/protocol_test.go
+++ b/server/finder/http/protocol_test.go
@@ -15,21 +15,18 @@ import (
 	"github.com/ipni/storetheindex/internal/registry"
 	httpserver "github.com/ipni/storetheindex/server/finder/http"
 	"github.com/ipni/storetheindex/server/finder/test"
+	"github.com/stretchr/testify/require"
 )
 
 func setupServer(ind indexer.Interface, reg *registry.Registry, idxCts *counter.IndexCounts, t *testing.T) *httpserver.Server {
 	s, err := httpserver.New("127.0.0.1:0", ind, reg, httpserver.WithIndexCounts(idxCts))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return s
 }
 
 func setupClient(host string, t *testing.T) *httpclient.Client {
 	c, err := httpclient.New(host)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return c
 }
 
@@ -61,14 +58,10 @@ func TestFindIndexData(t *testing.T) {
 		t.Error("shutdown error:", err)
 	}
 	err = <-errChan
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	reg.Close()
-	if err = ind.Close(); err != nil {
-		t.Errorf("Error closing indexer core: %s", err)
-	}
+	require.NoError(t, ind.Close(), "Error closing indexer core")
 }
 
 func TestFindIndexWithExtendedProviders(t *testing.T) {
@@ -101,19 +94,12 @@ func TestFindIndexWithExtendedProviders(t *testing.T) {
 	test.MainProviderChainRecordIsIncludedIfItsMetadataIsDifferentTest(ctx, t, c, ind, reg)
 	test.MainProviderContextRecordIsIncludedIfItsMetadataIsDifferentTest(ctx, t, c, ind, reg)
 
-	err := s.Close()
-	if err != nil {
-		t.Error("shutdown error:", err)
-	}
-	err = <-errChan
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, s.Close(), "shutdown error")
+	err := <-errChan
+	require.NoError(t, err)
 
 	reg.Close()
-	if err = ind.Close(); err != nil {
-		t.Errorf("Error closing indexer core: %s", err)
-	}
+	require.NoError(t, ind.Close(), "Error closing indexer core")
 }
 
 func TestReframeFindIndexData(t *testing.T) {
@@ -125,13 +111,9 @@ func TestReframeFindIndexData(t *testing.T) {
 
 	// create delegated routing client
 	q, err := proto.New_DelegatedRouting_Client(s.URL() + "/reframe")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	reframeClient, err := client.NewClient(q, nil, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Start server
 	errChan := make(chan error, 1)
@@ -149,19 +131,12 @@ func TestReframeFindIndexData(t *testing.T) {
 
 	test.ReframeFindIndexTest(ctx, t, c, reframeClient, ind, reg)
 
-	err = s.Close()
-	if err != nil {
-		t.Error("shutdown error:", err)
-	}
+	require.NoError(t, s.Close(), "shutdown error")
 	err = <-errChan
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	reg.Close()
-	if err = ind.Close(); err != nil {
-		t.Errorf("Error closing indexer core: %s", err)
-	}
+	require.NoError(t, ind.Close(), "Error closing indexer core")
 }
 
 func TestProviderInfo(t *testing.T) {
@@ -194,19 +169,12 @@ func TestProviderInfo(t *testing.T) {
 
 	test.ListProvidersTest(t, httpClient, peerID)
 
-	err := s.Close()
-	if err != nil {
-		t.Error("shutdown error:", err)
-	}
-	err = <-errChan
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, s.Close(), "shutdown error")
+	err := <-errChan
+	require.NoError(t, err)
 
 	reg.Close()
-	if err = ind.Close(); err != nil {
-		t.Errorf("Error closing indexer core: %s", err)
-	}
+	require.NoError(t, ind.Close(), "Error closing indexer core")
 }
 
 func TestGetStats(t *testing.T) {
@@ -233,14 +201,9 @@ func TestGetStats(t *testing.T) {
 
 	test.GetStatsTest(ctx, t, ind, s.RefreshStats, httpClient)
 
-	err := s.Close()
-	if err != nil {
-		t.Error("shutdown error:", err)
-	}
-	err = <-errChan
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, s.Close(), "shutdown error")
+	err := <-errChan
+	require.NoError(t, err)
 }
 
 func TestRemoveProvider(t *testing.T) {
@@ -266,17 +229,10 @@ func TestRemoveProvider(t *testing.T) {
 
 	test.RemoveProviderTest(ctx, t, c, ind, reg)
 
-	err := s.Close()
-	if err != nil {
-		t.Error("shutdown error:", err)
-	}
-	err = <-errChan
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, s.Close(), "shutdown error")
+	err := <-errChan
+	require.NoError(t, err)
 
 	reg.Close()
-	if err = ind.Close(); err != nil {
-		t.Errorf("Error closing indexer core: %s", err)
-	}
+	require.NoError(t, ind.Close(), "Error closing indexer core")
 }

--- a/server/finder/libp2p/protocol_test.go
+++ b/server/finder/libp2p/protocol_test.go
@@ -14,22 +14,19 @@ import (
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
 )
 
 func setupServer(ctx context.Context, ind indexer.Interface, reg *registry.Registry, idxCts *counter.IndexCounts, t *testing.T) (*p2pserver.FinderServer, host.Host) {
 	h, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/0"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	s := p2pserver.New(ctx, h, ind, reg, idxCts)
 	return s, h
 }
 
 func setupClient(peerID peer.ID, t *testing.T) *p2pclient.Client {
 	c, err := p2pclient.New(nil, peerID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return c
 }
 
@@ -43,15 +40,11 @@ func TestFindIndexData(t *testing.T) {
 	s, sh := setupServer(ctx, ind, reg, nil, t)
 	c := setupClient(s.ID(), t)
 	err := c.ConnectAddrs(ctx, sh.Addrs()...)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	test.FindIndexTest(ctx, t, c, ind, reg)
 
 	reg.Close()
-	if err = ind.Close(); err != nil {
-		t.Errorf("Error closing indexer core: %s", err)
-	}
+	require.NoError(t, ind.Close(), "Error closing indexer core")
 }
 
 func TestFindIndexWithExtendedProviders(t *testing.T) {
@@ -64,9 +57,7 @@ func TestFindIndexWithExtendedProviders(t *testing.T) {
 	s, sh := setupServer(ctx, ind, reg, nil, t)
 	c := setupClient(s.ID(), t)
 	err := c.ConnectAddrs(ctx, sh.Addrs()...)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	test.ProvidersShouldBeUnaffectedByExtendedProvidersOfEachOtherTest(ctx, t, c, ind, reg)
 	test.ExtendedProviderShouldHaveOwnMetadataTest(ctx, t, c, ind, reg)
 	test.ExtendedProviderShouldInheritMetadataOfMainProviderTest(ctx, t, c, ind, reg)
@@ -76,9 +67,7 @@ func TestFindIndexWithExtendedProviders(t *testing.T) {
 	test.MainProviderContextRecordIsIncludedIfItsMetadataIsDifferentTest(ctx, t, c, ind, reg)
 
 	reg.Close()
-	if err = ind.Close(); err != nil {
-		t.Errorf("Error closing indexer core: %s", err)
-	}
+	require.NoError(t, ind.Close(), "Error closing indexer core")
 }
 
 func TestProviderInfo(t *testing.T) {
@@ -93,9 +82,7 @@ func TestProviderInfo(t *testing.T) {
 	s, sh := setupServer(ctx, ind, reg, idxCts, t)
 	p2pClient := setupClient(s.ID(), t)
 	err := p2pClient.ConnectAddrs(ctx, sh.Addrs()...)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	peerID := test.Register(ctx, t, reg)
 
@@ -106,9 +93,7 @@ func TestProviderInfo(t *testing.T) {
 	test.ListProvidersTest(t, p2pClient, peerID)
 
 	reg.Close()
-	if err = ind.Close(); err != nil {
-		t.Errorf("Error closing indexer core: %s", err)
-	}
+	require.NoError(t, ind.Close(), "Error closing indexer core")
 }
 
 func TestGetStats(t *testing.T) {
@@ -123,9 +108,7 @@ func TestGetStats(t *testing.T) {
 	s, sh := setupServer(ctx, ind, reg, nil, t)
 	c := setupClient(s.ID(), t)
 	err := c.ConnectAddrs(ctx, sh.Addrs()...)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	test.GetStatsTest(ctx, t, ind, s.RefreshStats, c)
 }
 
@@ -139,14 +122,10 @@ func TestRemoveProvider(t *testing.T) {
 	s, sh := setupServer(ctx, ind, reg, nil, t)
 	c := setupClient(s.ID(), t)
 	err := c.ConnectAddrs(ctx, sh.Addrs()...)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	test.RemoveProviderTest(ctx, t, c, ind, reg)
 
 	reg.Close()
-	if err = ind.Close(); err != nil {
-		t.Errorf("Error closing indexer core: %s", err)
-	}
+	require.NoError(t, ind.Close(), "Error closing indexer core")
 }

--- a/server/ingest/http/handler_test.go
+++ b/server/ingest/http/handler_test.go
@@ -90,9 +90,7 @@ func TestHandleRegisterProvider(t *testing.T) {
 
 	addrs := []string{"/ip4/127.0.0.1/tcp/9999"}
 	data, err := model.MakeRegisterRequest(peerID, privKey, addrs)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	reqBody := bytes.NewBuffer(data)
 
 	req := httptest.NewRequest(http.MethodPost, "http://example.com/providers", reqBody)
@@ -101,15 +99,9 @@ func TestHandleRegisterProvider(t *testing.T) {
 
 	resp := w.Result()
 
-	if resp.StatusCode != http.StatusOK {
-		t.Fatal("expected response to be", http.StatusOK)
-	}
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 
 	pinfo, allowed := reg.ProviderInfo(peerID)
-	if pinfo == nil {
-		t.Fatal("provider was not registered")
-	}
-	if !allowed {
-		t.Fatal("provider not allowed")
-	}
+	require.NotNil(t, pinfo, "provider was not registered")
+	require.True(t, allowed, "provider not allowed")
 }


### PR DESCRIPTION
Use the `require` consistently in test code. In some test code it is used in some places and not others.
Use the `require` test utility library in more test code in general to reduce code and have more consistent error messages.