### PR TITLE
Add get pending syncs command

### DIFF
--- a/command/admin.go
+++ b/command/admin.go
@@ -46,9 +46,10 @@ var listPendinSyncsCmd = &cli.Command{
 var adminSyncFlags = []cli.Flag{
 	indexerHostFlag,
 	&cli.StringFlag{
-		Name:    "pubid",
-		Usage:   "Publisher peer ID",
-		Aliases: []string{"p"},
+		Name:     "pubid",
+		Usage:    "Publisher peer ID",
+		Aliases:  []string{"p"},
+		Required: true,
 	},
 	&cli.StringFlag{
 		Name:  "addr",

--- a/command/admin.go
+++ b/command/admin.go
@@ -29,9 +29,18 @@ var AdminCmd = &cli.Command{
 
 var syncCmd = &cli.Command{
 	Name:   "sync",
-	Usage:  "Sync indexer with provider. If no flags are provided returns a list of currently pending syncs.",
+	Usage:  "Sync indexer with provider.",
 	Flags:  adminSyncFlags,
 	Action: syncAction,
+	Subcommands: []*cli.Command{
+		listPendinSyncsCmd,
+	},
+}
+
+var listPendinSyncsCmd = &cli.Command{
+	Name:   "list-pending",
+	Usage:  "Returns a list of currently pending syncs.",
+	Action: listPendingSyncsAction,
 }
 
 var adminSyncFlags = []cli.Flag{
@@ -169,14 +178,7 @@ var unassignFlags = []cli.Flag{
 	indexerHostFlag,
 }
 
-func syncAction(cctx *cli.Context) error {
-	if cctx.String("pubid") == "" {
-		return getPendingSyncs(cctx)
-	}
-	return postSync(cctx)
-}
-
-func getPendingSyncs(cctx *cli.Context) error {
+func listPendingSyncsAction(cctx *cli.Context) error {
 	cl, err := httpclient.New(cliIndexer(cctx, "admin"))
 	if err != nil {
 		return err
@@ -194,7 +196,7 @@ func getPendingSyncs(cctx *cli.Context) error {
 	return nil
 }
 
-func postSync(cctx *cli.Context) error {
+func syncAction(cctx *cli.Context) error {
 	cl, err := httpclient.New(cliIndexer(cctx, "admin"))
 	if err != nil {
 		return err

--- a/server/admin/http/handler.go
+++ b/server/admin/http/handler.go
@@ -323,8 +323,6 @@ func (h *adminHandler) handlePostSyncs(w http.ResponseWriter, r *http.Request) {
 	log.Info("Syncing with peer")
 
 	// Start the sync, but do not wait for it to complete.
-	//
-	// TODO: Provide some way for the client to see if the indexer has synced.
 	h.pendingSyncs.Add(1)
 	h.pendingSyncsLock.Lock()
 	defer h.pendingSyncsLock.Unlock()

--- a/server/admin/http/handler.go
+++ b/server/admin/http/handler.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"sort"
 	"strconv"
 	"sync"
 
@@ -25,23 +26,26 @@ import (
 )
 
 type adminHandler struct {
-	ctx           context.Context
-	id            peer.ID
-	indexer       indexer.Interface
-	ingester      *ingest.Ingester
-	reg           *registry.Registry
-	reloadErrChan chan<- chan error
-	pendingSyncs  sync.WaitGroup
+	ctx                context.Context
+	id                 peer.ID
+	indexer            indexer.Interface
+	ingester           *ingest.Ingester
+	reg                *registry.Registry
+	reloadErrChan      chan<- chan error
+	pendingSyncs       sync.WaitGroup
+	pendingsSyncsPeers map[string]struct{}
+	pendingSyncsLock   sync.Mutex
 }
 
 func newHandler(ctx context.Context, id peer.ID, indexer indexer.Interface, ingester *ingest.Ingester, reg *registry.Registry, reloadErrChan chan<- chan error) *adminHandler {
 	return &adminHandler{
-		ctx:           ctx,
-		id:            id,
-		indexer:       indexer,
-		ingester:      ingester,
-		reg:           reg,
-		reloadErrChan: reloadErrChan,
+		ctx:                ctx,
+		id:                 id,
+		indexer:            indexer,
+		ingester:           ingester,
+		reg:                reg,
+		reloadErrChan:      reloadErrChan,
+		pendingsSyncsPeers: make(map[string]struct{}),
 	}
 }
 
@@ -250,7 +254,7 @@ func (h *adminHandler) blockPeer(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-func (h *adminHandler) sync(w http.ResponseWriter, r *http.Request) {
+func (h *adminHandler) handlePostSyncs(w http.ResponseWriter, r *http.Request) {
 	if !httpserver.MethodOK(w, r, http.MethodPost) {
 		return
 	}
@@ -322,6 +326,14 @@ func (h *adminHandler) sync(w http.ResponseWriter, r *http.Request) {
 	//
 	// TODO: Provide some way for the client to see if the indexer has synced.
 	h.pendingSyncs.Add(1)
+	h.pendingSyncsLock.Lock()
+	defer h.pendingSyncsLock.Unlock()
+	if _, ok := h.pendingsSyncsPeers[peerID.String()]; ok {
+		msg := fmt.Sprintf("Peer %s has already a sync in progress", peerID.String())
+		http.Error(w, msg, http.StatusBadRequest)
+		return
+	}
+	h.pendingsSyncsPeers[peerID.String()] = struct{}{}
 	go func() {
 		_, err := h.ingester.Sync(h.ctx, peerID, syncAddr, int(depth), resync)
 		if err != nil {
@@ -329,10 +341,40 @@ func (h *adminHandler) sync(w http.ResponseWriter, r *http.Request) {
 			log.Errorw(msg, "err", err)
 		}
 		h.pendingSyncs.Done()
+		h.pendingSyncsLock.Lock()
+		defer h.pendingSyncsLock.Unlock()
+		delete(h.pendingsSyncsPeers, peerID.String())
 	}()
 
 	// Return (202) Accepted
 	w.WriteHeader(http.StatusAccepted)
+}
+
+func (h *adminHandler) handleGetSyncs(w http.ResponseWriter, r *http.Request) {
+	h.pendingSyncsLock.Lock()
+	defer h.pendingSyncsLock.Unlock()
+	peers := make([]string, 0, len(h.pendingsSyncsPeers))
+	for k := range h.pendingsSyncsPeers {
+		peers = append(peers, k)
+	}
+	sort.Strings(peers)
+	marshalled, err := json.Marshal(peers)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	httpserver.WriteJsonResponse(w, http.StatusOK, marshalled)
+}
+
+func (h *adminHandler) sync(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		h.handlePostSyncs(w, r)
+	case http.MethodGet:
+		h.handleGetSyncs(w, r)
+	default:
+		http.Error(w, "", http.StatusMethodNotAllowed)
+	}
 }
 
 func (h *adminHandler) importProviders(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Currently there is no functionality for checking whether there are any syncs in progress. That complicates troubleshooting, specifically when the indexer seems to be busy with doing something without writing anything into the datastore. This PR adds:
* a new admin endpoint and respective CLI functionality for fetching a sorted list of currently pending syncs
* it also prevents a sync for the same peer from being submitted while there is one already in-progress.
