### PR TITLE
Fix missing addr handling

### DIFF
--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -238,8 +238,8 @@ func (ing *Ingester) ingestAd(ctx context.Context, publisherID peer.ID, adCid ci
 		}
 	}
 
-	// If head ad does not have provider addresses, then with addrs from the
-	// current advertisemet.
+	// If head ad does not have provider addresses, then update using addresses
+	// from the current advertisement.
 	if len(headProvider.Addrs) == 0 {
 		headProvider.Addrs = stringsToMultiaddrs(ad.Addresses)
 	}
@@ -356,7 +356,7 @@ func (ing *Ingester) ingestAd(ctx context.Context, publisherID peer.ID, adCid ci
 	if isHAMT(node) {
 		log = log.With("entriesKind", "hamt")
 		// Keep track of all CIDs in the HAMT to remove them later when the
-		// processing is done. This is equivalent behaviour to ingestEntryChunk
+		// processing is done. This is equivalent behavior to ingestEntryChunk
 		// which removes an entry chunk right afrer it is processed.
 		hamtCids := []cid.Cid{syncedFirstEntryCid}
 		gatherCids := func(_ peer.ID, c cid.Cid, _ dagsync.SegmentSyncActions) {

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -260,10 +260,11 @@ func (ing *Ingester) ingestAd(ctx context.Context, publisherID peer.ID, adCid ci
 	// allowed by policy to be registered.
 	err = ing.reg.Update(ctx, provider, publisher, adCid, extendedProviders, lag)
 	if err != nil {
-		if errors.Is(err, registry.ErrMissingProviderAddr) {
-			// Initial adverstisement missing valid provider address.
-			return adIngestError{adIngestMalformedErr, fmt.Errorf("could not register provider info: %w", err)}
-		}
+		// A registry.ErrMissingProviderAddr error is not considered a
+		// permanent adIngestMalformedErr error, because an advertisement added
+		// to the chain in the future may have a valid address than can be
+		// used, allowing all the previous ads without valid addresses to be
+		// processed.
 		return adIngestError{adIngestRegisterProviderErr, fmt.Errorf("could not register/update provider info: %w", err)}
 	}
 

--- a/internal/metrics/server.go
+++ b/internal/metrics/server.go
@@ -34,7 +34,6 @@ var (
 	AdLoadError          = stats.Int64("ingest/adLoadError", "Number of times an ad failed to load", stats.UnitDimensionless)
 	ProviderCount        = stats.Int64("provider/count", "Number of known (registered) providers", stats.UnitDimensionless)
 	EntriesSyncLatency   = stats.Float64("ingest/entriessynclatency", "How long it took to sync an Ad's entries", stats.UnitMilliseconds)
-	MhStoreNanoseconds   = stats.Int64("ingest/mhstorenanoseconds", "Average nanoseconds to store one multihash", stats.UnitDimensionless)
 	IndexCount           = stats.Int64("provider/indexCount", "Number of indexes stored for all providers", stats.UnitDimensionless)
 	PercentUsage         = stats.Float64("ingest/percentusage", "Percent usage of storage available in value store", stats.UnitDimensionless)
 )
@@ -92,10 +91,6 @@ var (
 		Measure:     AdLoadError,
 		Aggregation: view.Count(),
 	}
-	mhStoreNanosecondsView = &view.View{
-		Measure:     MhStoreNanoseconds,
-		Aggregation: view.LastValue(),
-	}
 	indexCountView = &view.View{
 		Measure:     IndexCount,
 		Aggregation: view.LastValue(),
@@ -124,7 +119,6 @@ func Start(views []*view.View) http.Handler {
 		adIngestSkipped,
 		adIngestSuccess,
 		adLoadError,
-		mhStoreNanosecondsView,
 		indexCountView,
 		percentUsageView,
 	)

--- a/internal/registry/errors.go
+++ b/internal/registry/errors.go
@@ -7,6 +7,7 @@ var (
 	ErrInProgress          = errors.New("discovery already in progress")
 	ErrCannotPublish       = errors.New("publisher not allowed to publish to other provider")
 	ErrFrozen              = errors.New("indexer frozen")
+	ErrMissingProviderAddr = errors.New("advertisement missing provider address")
 	ErrNotAllowed          = errors.New("peer not allowed by policy")
 	ErrNoDiscovery         = errors.New("discovery not available")
 	ErrNoFreeze            = errors.New("freeze not configured")

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -656,7 +656,7 @@ func (r *Registry) Update(ctx context.Context, provider, publisher peer.AddrInfo
 			return err
 		}
 		if len(provider.Addrs) == 0 {
-			return errors.New("missing provider address")
+			return ErrMissingProviderAddr
 		}
 		info = &ProviderInfo{
 			AddrInfo: provider,

--- a/test/typehelpers/typehelpers.go
+++ b/test/typehelpers/typehelpers.go
@@ -67,6 +67,10 @@ func (b RandomAdBuilder) build(t *testing.T, lsys ipld.LinkSystem, signingKey cr
 			ContextID: ctxID,
 			Metadata:  metadata,
 		}
+		ecbAddrs := ecb.GetAddrs()
+		if ecbAddrs != nil {
+			ad.Addresses = ecbAddrs
+		}
 
 		ad.PreviousID = headLink
 
@@ -112,6 +116,7 @@ func (b RandomAdBuilder) build(t *testing.T, lsys ipld.LinkSystem, signingKey cr
 
 type EntryBuilder interface {
 	Build(t *testing.T, lsys ipld.LinkSystem) datamodel.Link
+	GetAddrs() []string
 }
 
 var _ EntryBuilder = (*RandomEntryChunkBuilder)(nil)
@@ -121,6 +126,11 @@ type RandomEntryChunkBuilder struct {
 	EntriesPerChunk        uint8
 	Seed                   int64
 	WithInvalidMultihashes bool
+	Addrs                  []string
+}
+
+func (b RandomEntryChunkBuilder) GetAddrs() []string {
+	return b.Addrs
 }
 
 func (b RandomEntryChunkBuilder) Build(t *testing.T, lsys ipld.LinkSystem) datamodel.Link {
@@ -162,6 +172,11 @@ type RandomHamtEntryBuilder struct {
 	MultihashCount         uint32
 	Seed                   int64
 	WithInvalidMultihashes bool
+	Addrs                  []string
+}
+
+func (b RandomHamtEntryBuilder) GetAddrs() []string {
+	return b.Addrs
 }
 
 func (b RandomHamtEntryBuilder) Build(t *testing.T, lsys ipld.LinkSystem) datamodel.Link {


### PR DESCRIPTION
## Context
Fixes #1402
Fixes #1404
Fixes #1405 

See the above issues for context.

Cannot process advertisement chain if the first advertisement is missing provider addresses. This is preventing us from ingesting some chains where the first advertisement(s) do not have routable addresses, even if later advertisements do provide routable addresses.

Some non-permanent errors are being incorrectly handled as permanent errors and causing advertisements to be discarded.

## Proposed Changes
This PR fixes #1402 by trying to update using the provider addresses from the head advertisement when ingesting ads deeper in the ad chain.

This PR fixes #1404 by correctly designating errors during ingestion of entry chunks.
 
## Tests
Included a test of an ad chain with the first ad missing the provider addresses. Fails without this PR.

## Revert Strategy
Change is safe to revert.
