### PR TITLE
Deploy dhstore to prod

### DIFF
--- a/deploy/infrastructure/prod/us-east-2/eks.tf
+++ b/deploy/infrastructure/prod/us-east-2/eks.tf
@@ -26,6 +26,22 @@ module "eks" {
   }
 
   eks_managed_node_groups = {
+    # Node group for running dhstore and double hashed indexer nodes
+    prod-ue2c-r5n-2xl = {
+      min_size       = 1
+      max_size       = 3
+      desired_size   = 1
+      instance_types = ["r5n.2xlarge"]
+      subnet_ids     = [data.aws_subnet.ue2c2.id]
+      taints         = {
+        dedicated = {
+          key    = "dedicated"
+          value  = "r5n-2xl"
+          effect = "NO_SCHEDULE"
+        }
+      }
+    }
+
     # General purpose node-group.
     prod-ue2-m4-xl-2 = {
       min_size       = 3

--- a/deploy/manifests/prod/us-east-2/cluster/kube-system/aws-auth.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/kube-system/aws-auth.yaml
@@ -35,6 +35,11 @@ data:
       - system:nodes
       rolearn: arn:aws:iam::407967248065:role/prod-ue2c-c6a-8xl-eks-node-group
       username: system:node:{{EC2PrivateDNSName}}
+    - groups:
+      - system:bootstrappers
+      - system:nodes
+      rolearn: arn:aws:iam::407967248065:role/prod-ue2c-r5n-2xl-eks-node-group
+      username: system:node:{{EC2PrivateDNSName}}
   mapUsers: |
     - userarn: arn:aws:iam::407967248065:user/masih
       username: masih

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dhstore
+spec:
+  template:
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+      containers:
+        - name: dhstore
+          args:
+            - '--storePath=/data'
+            - '--disableWAL'
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            limits:
+              cpu: "6"
+              memory: 60Gi
+            requests:
+              cpu: "6"
+              memory: 60Gi
+          ports:
+            - containerPort: 40081
+              name: metrics
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.kubernetes.io/instance-type
+                    operator: In
+                    values:
+                      - r5n.2xlarge
+                  - key: topology.kubernetes.io/zone
+                    operator: In
+                    values:
+                      - us-east-2c    
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: dhstore-data
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: r5n-2xl
+          effect: NoSchedule
+

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/internal-service.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/internal-service.yaml
@@ -1,0 +1,26 @@
+# DHStore internal service, accessible only within K8S cluster VPC via:
+#  - http://dhstore.internal.dev.cid.contact
+#
+# See: https://github.com/ipni/dhstore
+kind: Service
+apiVersion: v1
+metadata:
+  name: dhstore-internal
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internal
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+    external-dns.alpha.kubernetes.io/access: private
+    external-dns.alpha.kubernetes.io/hostname: dhstore.internal.prod.cid.contact
+  labels:
+    app: dhstore
+spec:
+  externalTrafficPolicy: Cluster
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+  selector:
+    app: dhstore
+  type: LoadBalancer

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - github.com/ipni/dhstore/deploy/kubernetes?ref=58dfcad7aae9c172c68237dad25494625d8ac160
+  - pvc.yaml
+  - internal-service.yaml
+  - pod-monitor.yaml
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: dhstore
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
+    newTag: 20230222161136-c071f8c8bcc53380aa53cd5b2432ba6e1ce0500b

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/pod-monitor.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/pod-monitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: dhstore
+  labels:
+    app: dhstore
+spec:
+  selector:
+    matchLabels:
+      app: dhstore
+  namespaceSelector:
+    matchNames:
+      - storetheindex
+  podMetricsEndpoints:
+    - path: /metrics
+      port: metrics

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/pvc.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dhstore-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Ti
+  storageClassName: io2

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - snapshots
 - caskadht
 - lookout
+- dhstore
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}


### PR DESCRIPTION
* Create a new node group. `ue2c2` seems to have the most ip addresses available. `r5n.2xlarge` is the same instance type as dhstore is running in dev;
* Deploy the service without hooking it up to anything
