### PR TITLE
Explicitly set subnet for dhstore load balancer

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/internal-service.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/internal-service.yaml
@@ -11,6 +11,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-scheme: internal
     service.beta.kubernetes.io/aws-load-balancer-type: nlb
     service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+    service.beta.kubernetes.io/aws-load-balancer-subnets: subnet-090ac87218b91a5c2
     external-dns.alpha.kubernetes.io/access: private
     external-dns.alpha.kubernetes.io/hostname: dhstore.internal.prod.cid.contact
   labels:


### PR DESCRIPTION
So that it is created only in the subnet needed, with enough IPs available.

