### PR TITLE
Add double hashed indexer - inga

### DIFF
--- a/deploy/infrastructure/prod/us-east-2/eks.tf
+++ b/deploy/infrastructure/prod/us-east-2/eks.tf
@@ -26,7 +26,7 @@ module "eks" {
   }
 
   eks_managed_node_groups = {
-    # Node group for running dhstore and double hashed indexer nodes
+    # Node group for running dhstore nodes
     prod-ue2c-r5n-2xl = {
       min_size       = 1
       max_size       = 3
@@ -40,6 +40,14 @@ module "eks" {
           effect = "NO_SCHEDULE"
         }
       }
+    }
+    # Node group for running double hashed indexer nodes
+    prod-ue2c-r6a-xl = {
+      min_size       = 0
+      max_size       = 3
+      desired_size   = 1
+      instance_types = ["r6a.xlarge"]
+      subnet_ids     = [data.aws_subnet.ue2c2.id]
     }
 
     # General purpose node-group.

--- a/deploy/manifests/prod/us-east-2/cluster/kube-system/aws-auth.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/kube-system/aws-auth.yaml
@@ -40,6 +40,11 @@ data:
       - system:nodes
       rolearn: arn:aws:iam::407967248065:role/prod-ue2c-r5n-2xl-eks-node-group
       username: system:node:{{EC2PrivateDNSName}}
+    - groups:
+      - system:bootstrappers
+      - system:nodes
+      rolearn: arn:aws:iam::407967248065:role/prod-ue2c-r6a-xl-eks-node-group
+      username: system:node:{{EC2PrivateDNSName}}
   mapUsers: |
     - userarn: arn:aws:iam::407967248065:user/masih
       username: masih

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/README.md
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/README.md
@@ -7,3 +7,4 @@ List of individually configurable instances:
 | `oden`   | io2           | 5            | Pebble        | [v0.5.4](https://github.com/filecoin-project/storetheindex/releases/tag/v0.5.4) |
 | `dido`   | io2           | 5            | Pebble        | [v0.5.4](https://github.com/filecoin-project/storetheindex/releases/tag/v0.5.4) |
 | `kepa`   | io2           | 3            | Pebble        | [v0.5.4](https://github.com/filecoin-project/storetheindex/releases/tag/v0.5.4) |
+| `inga`   | io2           | -            | DHStore       | [v0.5.4](https://github.com/filecoin-project/storetheindex/releases/tag/v0.5.4) |

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/README.md
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/README.md
@@ -7,4 +7,4 @@ List of individually configurable instances:
 | `oden`   | io2           | 5            | Pebble        | [v0.5.4](https://github.com/filecoin-project/storetheindex/releases/tag/v0.5.4) |
 | `dido`   | io2           | 5            | Pebble        | [v0.5.4](https://github.com/filecoin-project/storetheindex/releases/tag/v0.5.4) |
 | `kepa`   | io2           | 3            | Pebble        | [v0.5.4](https://github.com/filecoin-project/storetheindex/releases/tag/v0.5.4) |
-| `inga`   | io2           | -            | DHStore       | [v0.5.4](https://github.com/filecoin-project/storetheindex/releases/tag/v0.5.4) |
+| `inga`   | gp3           | -            | DHStore       | [v0.5.4](https://github.com/filecoin-project/storetheindex/releases/tag/v0.5.4) |

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
@@ -1,0 +1,106 @@
+{
+  "Version": 2,
+  "Identity": {
+    "PeerID": "",
+    "PrivKey": ""
+  },
+  "Addresses": {
+    "Admin": "/ip4/0.0.0.0/tcp/3002",
+    "Finder": "/ip4/0.0.0.0/tcp/3000",
+    "FinderWebpage": "https://web-ipni.cid.contact/dev",
+    "Ingest": "/ip4/0.0.0.0/tcp/3001",
+    "P2PAddr": "/ip4/0.0.0.0/tcp/3003",
+    "NoResourceManager": true
+  },
+  "Bootstrap": {
+    "Peers": [
+      "/dns4/bootstrap-0.ipfsmain.cn/tcp/34721/p2p/12D3KooWQnwEGNqcM2nAcPtRR9rAX8Hrg4k9kJLCHoTR5chJfz6d",
+      "/dns4/bootstrap-3.mainnet.filops.net/tcp/1347/p2p/12D3KooWKhgq8c7NQ9iGjbyK7v7phXvG6492HQfiDaGHLHLQjk7R",
+      "/dns4/bootstrap-4.mainnet.filops.net/tcp/1347/p2p/12D3KooWL6PsFNPhYftrJzGgF5U18hFoaVhfGk7xwzD8yVrHJ3Uc",
+      "/dns4/bootstrap-6.mainnet.filops.net/tcp/1347/p2p/12D3KooWP5MwCiqdMETF9ub1P3MbCvQCcfconnYHbWg6sUJcDRQQ",
+      "/dns4/bootstrap-7.mainnet.filops.net/tcp/1347/p2p/12D3KooWRs3aY1p3juFjPy8gPN95PEQChm2QKGUCAdcDCC4EBMKf",
+      "/dns4/bootstrap-8.mainnet.filops.net/tcp/1347/p2p/12D3KooWScFR7385LTyR4zU1bYdzSiiAb5rnNABfVahPvVSzyTkR",
+      "/dns4/node.glif.io/tcp/1235/p2p/12D3KooWBF8cpp65hp2u9LK5mh19x67ftAam84z9LsfaquTDSBpt",
+      "/dns4/bootstrap-2.mainnet.filops.net/tcp/1347/p2p/12D3KooWEWVwHGn2yR36gKLozmb4YjDJGerotAPGxmdWZx2nxMC4",
+      "/dns4/bootstrap-5.mainnet.filops.net/tcp/1347/p2p/12D3KooWLFynvDQiUpXoHroV1YxKHhPJgysQGH2k3ZGwtWzR4dFH",
+      "/dns4/bootstrap-1.starpool.in/tcp/12757/p2p/12D3KooWQZrGH1PxSNZPum99M1zNvjNFM33d1AAu5DcvdHptuU7u",
+      "/dns4/bootstrap-0.mainnet.filops.net/tcp/1347/p2p/12D3KooWCVe8MmsEMes2FzgTpt9fXtmCY7wrq91GRiaC8PHSCCBj",
+      "/dns4/bootstrap-1.mainnet.filops.net/tcp/1347/p2p/12D3KooWCwevHg1yLCvktf2nvLu7L9894mcrJR4MsBCcm4syShVc",
+      "/dns4/bootstrap-0.starpool.in/tcp/12757/p2p/12D3KooWGHpBMeZbestVEWkfdnC9u7p6uFHXL1n7m1ZBqsEmiUzz",
+      "/dns4/lotus-bootstrap.ipfsforce.com/tcp/41778/p2p/12D3KooWGhufNmZHF3sv48aQeS13ng5XVJZ9E6qy2Ms4VzqeUsHk",
+      "/dns4/bootstrap-1.ipfsmain.cn/tcp/34723/p2p/12D3KooWMKxMkD5DMpSWsW7dBddKxKT7L2GgbNuckz9otxvkvByP"
+    ],
+    "MinimumPeers": 4
+  },
+  "Datastore": {
+    "Type": "levelds",
+    "Dir": "/data/datastore",
+    "DirAdvertisements": "/addata"
+  },
+  "Discovery": {
+    "FilterIPs": true,
+    "LotusGateway": "wss://api.chain.love",
+    "Policy": {
+      "Allow": true,
+      "Except": [
+      ],
+      "Publish": true,
+      "PublishExcept": null
+    },
+    "PollInterval": "24h0m0s",
+    "PollRetryAfter": "5m0s",
+    "PollStopAfter": "168h0m0s",
+    "PollOverrides": null,
+    "RediscoverWait": "5m0s",
+    "Timeout": "2m0s",
+    "UseAssigner": false
+  },
+  "Indexer": {
+    "CacheSize": -1,
+    "ConfigCheckInterval": "30s",
+    "ShutdownTimeout": "15m",
+    "ValueStoreDir": "/data/valuestore",
+    "ValueStoreType": "pebble",
+    "DisableWAL": true,
+    "VSNoNewMH": true,
+    "DHBatchSize": 5000,
+    "DHStoreURL": "http://dhstore.internal.prod.cid.contact",
+    "DHStoreHttpClientTimeout": "30s"
+  },
+  "Ingest": {
+    "AdvertisementDepthLimit": 33554432,
+    "EntriesDepthLimit": 65536,
+    "HttpSyncRetryMax": 4,
+    "HttpSyncRetryWaitMax": "30s",
+    "HttpSyncRetryWaitMin": "1s",
+    "HttpSyncTimeout": "10s",
+    "IngestWorkerCount": 10,
+    "KeepAdvertisements":true,
+    "PubSubTopic": "/indexer/ingest/mainnet",
+    "RateLimit": {
+      "Apply": false,
+      "Except": null,
+      "BlocksPerSecond": 0,
+      "BurstSize": 500
+    },
+    "ResendDirectAnnounce": false,
+    "StoreBatchSize": 8192,
+    "SyncSegmentDepthLimit": 2000,
+    "SyncTimeout": "2h0m0s"
+  },
+  "Logging": {
+    "Level": "info",
+    "Loggers": {
+      "basichost": "warn",
+      "bootstrap": "warn",
+      "dt-impl": "warn",
+      "dt_graphsync": "warn",
+      "graphsync": "warn"
+    }
+  },
+  "Peering": {
+    "Peers": [
+      "/dns4/assigner/tcp/3003/p2p/12D3KooWDBjcDRQ7CKJeF9Yy3UKbriHfyETDrXKzTDB6biH3ibBd"
+    ]
+  }
+}

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
@@ -97,5 +97,10 @@
       "dt_graphsync": "warn",
       "graphsync": "warn"
     }
+  },
+  "Peering": {
+    "Peers": [
+      "/dns4/assigner/tcp/3003/p2p/12D3KooWQAymjDKMivbkUNiJP7ChRsvsDuazerHW4wERRvQMWNor"
+    ]
   }
 }

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
@@ -97,10 +97,5 @@
       "dt_graphsync": "warn",
       "graphsync": "warn"
     }
-  },
-  "Peering": {
-    "Peers": [
-      "/dns4/assigner/tcp/3003/p2p/12D3KooWDBjcDRQ7CKJeF9Yy3UKbriHfyETDrXKzTDB6biH3ibBd"
-    ]
   }
 }

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: indexer
+spec:
+  template:
+    spec:
+      serviceAccountName: storetheindex
+      terminationGracePeriodSeconds: 600
+      containers:
+        - name: indexer
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: addata
+              mountPath: /addata
+          resources:
+            limits:
+              cpu: "3"
+              memory: 28Gi
+            requests:
+              cpu: "3"
+              memory: 28Gi
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.kubernetes.io/instance-type
+                    operator: In
+                    values:
+                      - r6a.xlarge
+                  - key: topology.kubernetes.io/zone
+                    operator: In
+                    values:
+                      - us-east-2c
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: inga-data
+        - name: addata
+          persistentVolumeClaim:
+            claimName: inga-addata
+

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/identity.key.encrypted
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/identity.key.encrypted
@@ -1,11 +1,11 @@
 {
-	"data": "ENC[AES256_GCM,data:67/0zlP6cJ9jtssu+vFzVUkuFkgEYIpFJZjpztbDcp53+3323qmTj8uoiTg3YAgmFRkeD0bj9fUXkj1E/NOEhFaf9R4=,iv:i9cKH73tZ+2owh/C0Zi1bYZZE3EEDuoD/XmNmGPxCRw=,tag:WCvzTiAr1+GeeXtJqNa/1g==,type:str]",
+	"data": "ENC[AES256_GCM,data:5XXqHzpF8Bg16Plc4ByibhG+QFxXzvFg77gIJSkjhUzrYAvKT9atmZR0m5TNmQKeZfbIC1pe4efIorqj4nujyojDi7s=,iv:eyf2dE8G4ufIN+0xbQ3Wtq50xreFEtKon9FhhcDAaNY=,tag:W/qjrh2TS0z5hpvDx1pSRg==,type:str]",
 	"sops": {
 		"kms": [
 			{
-				"arn": "arn:aws:kms:us-east-2:407967248065:alias/sti_flux",
-				"created_at": "2023-01-20T11:47:21Z",
-				"enc": "AQICAHi99m+hXhXmjeAqO3v9MBDcMaC2zWJIlamGyiBfOVdULAHEXWzouv3pcR05YnPcN0WFAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM9RNbWpFKceGR9uwVAgEQgDtWvejyQX4NPwf6M/+t+Up/t4FJ3pN0g+S1MHeGqX5bW48S4FxtsTGkIymygsVYROwPMavmmZmTGlyt4w==",
+				"arn": "arn:aws:kms:us-east-2:407967248065:alias/prod/us-east-2/sti",
+				"created_at": "2023-03-15T15:31:38Z",
+				"enc": "AQICAHjmLCaDZ4fRYyty7669VvFjJmy9C7/Y4dwd6seUJHRobwFDUv6gGIxsWWYFPBskUcBzAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMvmpDC7xg/hrjMoX0AgEQgDt/GSkHaU+RuinSGmXVCHBPgQDCjcIb5pFb8hPnqbpLmpLcDy0UscmiCXgwhGMbcD7l/EP2BlPItXa+GA==",
 				"aws_profile": ""
 			}
 		],
@@ -13,8 +13,8 @@
 		"azure_kv": null,
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2023-01-20T11:47:21Z",
-		"mac": "ENC[AES256_GCM,data:1MUTqHyhoQYgLUEbwI8OvqxLGqXk45f88CBu62ArTusgxI5b9R35cBrNhPevBiXbQjKKDGlJxkR37syKBfjRdm0cBQ0W+7V8Gpn+6j3Czh5/Kgf+MIlpWwDkmvadxnRENiCWfEWIlmRa/3WN7xcYb60Nc3OhH18VyTH7rZThazw=,iv:AV4GWYvSVOk8E2GcrgrvLuFG8QN/j8e3Pp1ktMABqxQ=,tag:LY3Si3+w0DGlmbaYvmBjig==,type:str]",
+		"lastmodified": "2023-03-15T15:31:38Z",
+		"mac": "ENC[AES256_GCM,data:IbwQFCXI2XHoew1yuhH8MAlO/CvbR05v0/lunuZkDToK1Rd0j+QBYVGxOIJTiZEe8P+epy0IePJV2FGNabl8+qGdu0i2ngv3TCnnMeY+SuKYoe3eNhMkmtUIxEDbWkFbY1jn/yCdvTT59WXUqgGg4jQhUFvx5yto/rPWyKmTVhI=,iv:QU8tbVtumsHAy/Lp5DTGyXAd7fmNAL7AbgN47/wHQJs=,tag:qTtxlKMQVY8JfOWYQXhTFg==,type:str]",
 		"pgp": null,
 		"encrypted_regex": "^(data|stringData)$",
 		"version": "3.7.3"

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/identity.key.encrypted
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/identity.key.encrypted
@@ -1,0 +1,22 @@
+{
+	"data": "ENC[AES256_GCM,data:67/0zlP6cJ9jtssu+vFzVUkuFkgEYIpFJZjpztbDcp53+3323qmTj8uoiTg3YAgmFRkeD0bj9fUXkj1E/NOEhFaf9R4=,iv:i9cKH73tZ+2owh/C0Zi1bYZZE3EEDuoD/XmNmGPxCRw=,tag:WCvzTiAr1+GeeXtJqNa/1g==,type:str]",
+	"sops": {
+		"kms": [
+			{
+				"arn": "arn:aws:kms:us-east-2:407967248065:alias/sti_flux",
+				"created_at": "2023-01-20T11:47:21Z",
+				"enc": "AQICAHi99m+hXhXmjeAqO3v9MBDcMaC2zWJIlamGyiBfOVdULAHEXWzouv3pcR05YnPcN0WFAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM9RNbWpFKceGR9uwVAgEQgDtWvejyQX4NPwf6M/+t+Up/t4FJ3pN0g+S1MHeGqX5bW48S4FxtsTGkIymygsVYROwPMavmmZmTGlyt4w==",
+				"aws_profile": ""
+			}
+		],
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2023-01-20T11:47:21Z",
+		"mac": "ENC[AES256_GCM,data:1MUTqHyhoQYgLUEbwI8OvqxLGqXk45f88CBu62ArTusgxI5b9R35cBrNhPevBiXbQjKKDGlJxkR37syKBfjRdm0cBQ0W+7V8Gpn+6j3Czh5/Kgf+MIlpWwDkmvadxnRENiCWfEWIlmRa/3WN7xcYb60Nc3OhH18VyTH7rZThazw=,iv:AV4GWYvSVOk8E2GcrgrvLuFG8QN/j8e3Pp1ktMABqxQ=,tag:LY3Si3+w0DGlmbaYvmBjig==,type:str]",
+		"pgp": null,
+		"encrypted_regex": "^(data|stringData)$",
+		"version": "3.7.3"
+	}
+}

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/ingress.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: indexer
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt"
+spec:
+  tls:
+    - hosts:
+        - inga.prod.cid.contact
+      secretName: inga-indexer-ingress-tls
+  rules:
+    - host: inga.prod.cid.contact
+      http:
+        paths:
+          - path: /ingest
+            pathType: Prefix
+            backend:
+              service:
+                name: indexer
+                port:
+                  number: 3001
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: indexer
+                port:
+                  number: 3000

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
 namePrefix: inga-
 
 commonLabels:
-  name: ago
+  name: inga
 
 secretGenerator:
   - name: identity

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/kustomization.yaml
@@ -1,0 +1,30 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - ../../../../../../base/storetheindex-single
+  - ingress.yaml
+  - pvc_addata.yaml
+  - pvc_data.yaml
+
+namePrefix: inga-
+
+commonLabels:
+  name: ago
+
+secretGenerator:
+  - name: identity
+    behavior: replace
+    files:
+      - identity.key=identity.key.encrypted # 12D3KooWGRNQLAeMZ658jcuCkVBcVnCkxVYT4GqknQV2tRwDXfRT
+
+configMapGenerator:
+  - name: config
+    behavior: replace
+    files:
+      - config=config.json
+
+patchesStrategicMerge:
+  - deployment.yaml

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/pvc_addata.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/pvc_addata.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: addata
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 3Ti
+  storageClassName: io2

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/pvc_addata.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/pvc_addata.yaml
@@ -8,4 +8,4 @@ spec:
   resources:
     requests:
       storage: 3Ti
-  storageClassName: io2
+  storageClassName: gp3

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/pvc_data.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/pvc_data.yaml
@@ -12,4 +12,4 @@ spec:
   resources:
     requests:
       storage: 1Ti
-  storageClassName: io2
+  storageClassName: gp3

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/pvc_data.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/pvc_data.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: indexer-single
+    app.kubernetes.io/managed-by: kustomization
+    app.kubernetes.io/part-of: storetheindex
+  name: data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Ti
+  storageClassName: io2

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/pvc_data.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/pvc_data.yaml
@@ -11,5 +11,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1Ti
+      storage: 10Gi
   storageClassName: gp3

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - oden # pebble, 5 IOPS per GiB, nft.storage only
   - dido # pebble, 5 IOPS per GiB, on us-east2a
   - kepa # pebble, 3 IOPS per GiB, mirror of dido but on us-east2b, replacement of indexer-1
+  - inga # double hashed instance, writes to prod dhstore


### PR DESCRIPTION
`inga` is a new production double hashed indexer that writes into production `dhstore`. In this PR:
* create a new node group with the same instance type that is used by `ago` in dev;
* create a new identity for `inga`;
* create a new deployment configuration for `inga`. Note - `inga` won't be mirroring car files into s3 a this is being already done by `ago`. 
