### PR TITLE
Ingest advertisement data from car mirror

### DIFF
--- a/carstore/carwriter_test.go
+++ b/carstore/carwriter_test.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"io"
+	"io/fs"
 	"math/rand"
 	"testing"
 
@@ -170,6 +171,10 @@ func TestWriteToExistingAdCar(t *testing.T) {
 	require.NoError(t, err)
 
 	fileName := adCid.String() + carstore.CarFileSuffix
+	if testCompress == carstore.Gzip {
+		fileName += carstore.GzipFileSuffix
+	}
+
 	_, err = fileStore.Put(ctx, fileName, nil)
 	require.NoError(t, err)
 
@@ -177,7 +182,8 @@ func TestWriteToExistingAdCar(t *testing.T) {
 	require.NoError(t, err)
 
 	carInfo, err := carw.Write(ctx, adCid, false)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, fs.ErrExist)
+	require.Zero(t, carInfo.Size)
 
 	// Check that ad car file was not written to.
 	fileInfo, err := fileStore.Head(ctx, carInfo.Path)

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -226,10 +226,14 @@ func TestEndToEndWithReferenceProvider(t *testing.T) {
 	cfg, err = config.Load(stiCfgPath)
 	require.NoError(t, err)
 	indexerID := cfg.Identity.PeerID
-	cfg.Ingest.CarMirrorDestination = config.FileStore{
-		Type: "local",
-		Local: config.LocalFileStore{
-			BasePath: e.dir,
+	cfg.Ingest.AdvertisementMirror = config.Mirror{
+		Compress: "gzip",
+		Write:    true,
+		Storage: config.FileStore{
+			Type: "local",
+			Local: config.LocalFileStore{
+				BasePath: e.dir,
+			},
 		},
 	}
 	cfg.Save(stiCfgPath)

--- a/filestore/error.go
+++ b/filestore/error.go
@@ -1,7 +1,0 @@
-package filestore
-
-import "errors"
-
-var (
-	ErrNotFound = errors.New("not found")
-)

--- a/filestore/filestore.go
+++ b/filestore/filestore.go
@@ -26,9 +26,11 @@ type File struct {
 type Interface interface {
 	// Delete removes the specified file from storage.
 	Delete(ctx context.Context, path string) error
-	// Get retrieves the specified file from storage.
+	// Get retrieves the specified file from storage. Returns fs.ErrNotExist if
+	// file is not count.
 	Get(ctx context.Context, path string) (*File, io.ReadCloser, error)
-	// Head gets information about the specified file in storage.
+	// Head gets information about the specified file in storage. Returns
+	// fs.ErrNotExist if file is not count.
 	Head(ctx context.Context, path string) (*File, error)
 	// List returns a series of *File on the first channel returned. If an
 	// error occurs, the first channel is closed and the error is returned on

--- a/filestore/local.go
+++ b/filestore/local.go
@@ -43,7 +43,7 @@ func (l *Local) Get(ctx context.Context, relPath string) (*File, io.ReadCloser, 
 	f, err := os.Open(absPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil, ErrNotFound
+			return nil, nil, fs.ErrNotExist
 		}
 		return nil, nil, err
 	}
@@ -56,7 +56,7 @@ func (l *Local) Get(ctx context.Context, relPath string) (*File, io.ReadCloser, 
 
 	if fi.IsDir() {
 		f.Close()
-		return nil, nil, ErrNotFound
+		return nil, nil, fs.ErrNotExist
 	}
 
 	return &File{
@@ -71,13 +71,13 @@ func (l *Local) Head(ctx context.Context, relPath string) (*File, error) {
 	fi, err := os.Stat(absPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, ErrNotFound
+			return nil, fs.ErrNotExist
 		}
 		return nil, err
 	}
 
 	if fi.IsDir() {
-		return nil, ErrNotFound
+		return nil, fs.ErrNotExist
 	}
 
 	return &File{

--- a/filestore/s3.go
+++ b/filestore/s3.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"io/fs"
 	"path"
 	"strings"
 
@@ -95,12 +96,12 @@ func (s *S3) Get(ctx context.Context, relPath string) (*File, io.ReadCloser, err
 	if err != nil {
 		var nsk *types.NoSuchKey
 		if errors.As(err, &nsk) {
-			return nil, nil, ErrNotFound
+			return nil, nil, fs.ErrNotExist
 		}
 		var apiErr smithy.APIError
 		if errors.As(err, &apiErr) {
 			if apiErr.ErrorCode() == "NotFound" {
-				return nil, nil, ErrNotFound
+				return nil, nil, fs.ErrNotExist
 			}
 		}
 		return nil, nil, err
@@ -127,16 +128,16 @@ func (s *S3) Head(ctx context.Context, relPath string) (*File, error) {
 		var apiErr smithy.APIError
 		if errors.As(err, &apiErr) {
 			if apiErr.ErrorCode() == "NotFound" {
-				return nil, ErrNotFound
+				return nil, fs.ErrNotExist
 			}
 		}
 		var nsk *types.NoSuchKey
 		if errors.As(err, &nsk) {
-			return nil, ErrNotFound
+			return nil, fs.ErrNotExist
 		}
 		var nf *types.NotFound
 		if errors.As(err, &nf) {
-			return nil, ErrNotFound
+			return nil, fs.ErrNotExist
 		}
 		return nil, err
 	}

--- a/internal/ingest/mirror.go
+++ b/internal/ingest/mirror.go
@@ -1,0 +1,93 @@
+package ingest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	"github.com/ipni/storetheindex/carstore"
+	"github.com/ipni/storetheindex/config"
+	"github.com/ipni/storetheindex/filestore"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+type adMirror struct {
+	carReader *carstore.CarReader
+	carWriter *carstore.CarWriter
+}
+
+func (m adMirror) canRead() bool {
+	return m.carReader != nil
+}
+func (m adMirror) canWrite() bool {
+	return m.carWriter != nil
+}
+
+func (m adMirror) read(ctx context.Context, adCid cid.Cid, skipEntries bool) (*carstore.AdBlock, error) {
+	return m.carReader.Read(ctx, adCid, skipEntries)
+}
+
+func (m adMirror) readHead(ctx context.Context, publisher peer.ID) (cid.Cid, error) {
+	return m.carReader.ReadHead(ctx, publisher)
+}
+
+func (m adMirror) write(ctx context.Context, adCid cid.Cid, skipEntries bool) (*filestore.File, error) {
+	return m.carWriter.Write(ctx, adCid, skipEntries)
+}
+
+func (m adMirror) writeHead(ctx context.Context, adCid cid.Cid, publisher peer.ID) (*filestore.File, error) {
+	return m.carWriter.WriteHead(ctx, adCid, publisher)
+}
+
+func newMirror(cfgMirror config.Mirror, dstore datastore.Datastore) (adMirror, error) {
+	var m adMirror
+
+	if !(cfgMirror.Read || cfgMirror.Write) {
+		return m, nil
+	}
+
+	fileStore, err := makeFilestore(cfgMirror.Storage)
+	if err != nil {
+		return m, fmt.Errorf("cannot create car file storage for mirror: %w", err)
+	}
+	if fileStore == nil {
+		return m, nil
+	}
+
+	if cfgMirror.Write {
+		m.carWriter, err = carstore.NewWriter(dstore, fileStore, carstore.WithCompress(cfgMirror.Compress))
+		if err != nil {
+			return m, fmt.Errorf("cannot create car file writer: %w", err)
+		}
+	}
+
+	if cfgMirror.Read {
+		m.carReader, err = carstore.NewReader(fileStore, carstore.WithCompress(cfgMirror.Compress))
+		if err != nil {
+			return m, fmt.Errorf("cannot create car file reader: %w", err)
+		}
+	}
+
+	return m, nil
+}
+
+// Create a new storage system of the configured type.
+func makeFilestore(cfg config.FileStore) (filestore.Interface, error) {
+	switch cfg.Type {
+	case "local":
+		return filestore.NewLocal(cfg.Local.BasePath)
+	case "s3":
+		return filestore.NewS3(cfg.S3.BucketName,
+			filestore.WithEndpoint(cfg.S3.Endpoint),
+			filestore.WithRegion(cfg.S3.Region),
+			filestore.WithKeys(cfg.S3.AccessKey, cfg.S3.SecretKey),
+		)
+	case "":
+		return nil, errors.New("storage type not defined")
+	case "none":
+		return nil, nil
+	}
+	return nil, fmt.Errorf("unsupported file storage type: %s", cfg.Type)
+}


### PR DESCRIPTION
## Context
This PR provides a portion of the functionality to ingest from a content advertisement mirror: When ingesting advertisements, get their multihash entry data from car files in the mirror, if available, instead of syncing the entries chain with the publisher.

The portion of the functionality responsible for syncing advertisement chains from a mirror will follow in subsequent PR(s).

Since the vast majority of advertisement data consists of the multihash entries associated with each advertisement, reading this data from a mirror results in a significant reduction in data transfer between the publisher and indexer.

Note thatdeploying this PR requires a change in configuration for any nodes that are currently saving advertisement data to a car store.  The new configuration should look like this:
```json
  "Ingest": {
    "AdvertisementMirror": {
      "Read": true,
      "Write": true,
      "Compress": "gzip",
      "Storage": {
        "Type": "s3",
        "S3": {
          "BucketName": "dev-sti-adstore"
        }
      }
    }
```
If the indexer is the only one writing the advertisements, then set `"Read": false` as there will never be more advertisements to read from the mirror than are already processed by the indexer.

## Proposed Changes
- Changed configuration to configure AdvertisementMirror
- An advertisement mirror can be configured to be readable, writable, or both.
- Changed how CarReader reads entries to fix possible goroutine leak
- Fixed check for existing files in CarWriter.
- Do not write head file if CAR file already exists.

## Tests
- Unit test to check that ingesting multihashes from mirror works

## Revert Strategy
Reverting requires restoring the old configuration. To make it easier to revert, the old configuration can be left in place as the new code will ignore it.  Then at a later time, the old configuration can be removed.

Other than config, this change is safe to revert.
