### PR TITLE
Remove explicitly defined sservice account

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   template:
     spec:
-      serviceAccountName: storetheindex
       terminationGracePeriodSeconds: 600
       containers:
         - name: indexer


### PR DESCRIPTION
Fixes k8s error: 

```
0s          Warning   FailedCreate                 replicaset/inga-indexer-59bccc7945                              Error creating: pods "inga-indexer-59bccc7945-" is forbidden: error looking up service account storetheindex/storetheindex: serviceaccount "storetheindex" not found
```

Explicit service account isn't needed as `inga` doesn't need to write to s3.