### PR TITLE
Publish ECR tag on `version.json` change

### DIFF
--- a/.github/workflows/ecr-publisher-release.yml
+++ b/.github/workflows/ecr-publisher-release.yml
@@ -1,0 +1,44 @@
+# Publishes storetheindex container images to the private AWS ECR.
+# The published images use whatever version is in the `version.json` as tag.
+# This is to work around unified CI creating releases too which will not trigger
+# other workflows as the release creator is a bot.
+name: ECR
+
+on:
+  workflow_dispatch: { }
+  push:
+    paths: [ 'version.json' ]
+
+jobs:
+  publisher:
+    if: ${{ github.event.pusher.name != 'sti-bot' }}
+    name: Publish Release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      ECR_REGISTRY: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - id: version
+        name: Determine Container Tag
+        run: |
+          IMAGE_TAG="${$(jq -r .version version.json)#v}"
+          echo "Using image tag: ${IMAGE_TAG}"
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+      - name: AWS Login
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-2
+          role-to-assume: "arn:aws:iam::407967248065:role/common/github_actions"
+          role-duration-seconds: 1200
+      - name: Login to Amazon ECR
+        run: aws ecr get-login-password | docker login --username AWS --password-stdin ${ECR_REGISTRY}
+      - name: Publish Container Image
+        run: |
+          IMAGE_NAME="${ECR_REGISTRY}/storetheindex:${IMAGE_TAG}"
+          docker build -t "${IMAGE_NAME}" .
+          docker push "${IMAGE_NAME}"
+          echo "Published image ${IMAGE_NAME}"


### PR DESCRIPTION
This is to work around the recent changes in the unified CI, where it also creates the github release when the version file is updated.

As a result, because release is published by a bot the ECR image build with the release tag is not triggered.

The changes here would trigger image publish as soon as the version file is changed, not relying on specific github release events.

