### PR TITLE
Revert "Hook up dhstore to indexstar in prod"

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -20,7 +20,6 @@ spec:
             - '--backends=http://oden-indexer:3000/'
             - '--backends=http://kepa-indexer:3000/'
             - '--backends=http://dhstore.internal.prod.cid.contact/'
-            - '--backends=http://dhfind.internal.prod.cid.contact/'
             - '--cascadeBackends=http://caskadht.internal.prod.cid.contact/'
           env:
             # Increase maximum accepted request body to 1 MiB in order to allow batch finds requests

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -19,7 +19,6 @@ spec:
             - '--backends=http://dido-indexer:3000/'
             - '--backends=http://oden-indexer:3000/'
             - '--backends=http://kepa-indexer:3000/'
-            - '--backends=http://dhstore.internal.prod.cid.contact/'
             - '--cascadeBackends=http://caskadht.internal.prod.cid.contact/'
           env:
             # Increase maximum accepted request body to 1 MiB in order to allow batch finds requests


### PR DESCRIPTION
Reverts ipni/storetheindex#1412

After this change got deployed we've received an upstream latency alert. The latency spike is caused by timeouts in `indexstar`. During scatter-gather half of the times `indexstar` can not resolve `dhfind` host. This is in turn due a lack of free IPs in subnets, which needs to be fixed first.