### PR TITLE
HTTP publisher returns 204 when it has nothing to publish

### DIFF
--- a/dagsync/announce_test.go
+++ b/dagsync/announce_test.go
@@ -39,12 +39,12 @@ func TestAnnounceReplace(t *testing.T) {
 	require.NoError(t, err)
 	defer pub.Close()
 
+	err = test.WaitForP2PPublisher(pub, dstHost, testTopic)
+	require.NoError(t, err)
+
 	sub, err := NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, nil)
 	require.NoError(t, err)
 	defer sub.Close()
-
-	err = test.WaitForPublisher(dstHost, testTopic, srcHost.ID())
-	require.NoError(t, err)
 
 	watcher, cncl := sub.OnSyncFinished()
 	defer cncl()
@@ -222,6 +222,9 @@ func TestAnnounceRepublish(t *testing.T) {
 	require.NoError(t, err)
 	defer pub.Close()
 
+	err = test.WaitForP2PPublisher(pub, dstHost, testTopic)
+	require.NoError(t, err)
+
 	sub1, err := NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, nil, Topic(topics[0]), ResendAnnounce(true))
 	require.NoError(t, err)
 	defer sub1.Close()
@@ -229,9 +232,6 @@ func TestAnnounceRepublish(t *testing.T) {
 	sub2, err := NewSubscriber(dstHost2, dstStore2, dstLnkS2, testTopic, nil, Topic(topics[1]))
 	require.NoError(t, err)
 	defer sub2.Close()
-
-	err = test.WaitForPublisher(dstHost, testTopic, srcHost.ID())
-	require.NoError(t, err)
 
 	watcher2, cncl := sub2.OnSyncFinished()
 	defer cncl()

--- a/dagsync/announce_test.go
+++ b/dagsync/announce_test.go
@@ -38,9 +38,7 @@ func TestAnnounceReplace(t *testing.T) {
 	pub, err := dtsync.NewPublisher(srcHost, srcStore, srcLnkS, testTopic)
 	require.NoError(t, err)
 	defer pub.Close()
-
-	err = test.WaitForP2PPublisher(pub, dstHost, testTopic)
-	require.NoError(t, err)
+	require.NoError(t, test.WaitForP2PPublisher(pub, dstHost, testTopic))
 
 	sub, err := NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, nil)
 	require.NoError(t, err)
@@ -221,9 +219,7 @@ func TestAnnounceRepublish(t *testing.T) {
 	pub, err := dtsync.NewPublisher(srcHost, srcStore, srcLnkS, testTopic)
 	require.NoError(t, err)
 	defer pub.Close()
-
-	err = test.WaitForP2PPublisher(pub, dstHost, testTopic)
-	require.NoError(t, err)
+	require.NoError(t, test.WaitForP2PPublisher(pub, dstHost, testTopic))
 
 	sub1, err := NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, nil, Topic(topics[0]), ResendAnnounce(true))
 	require.NoError(t, err)

--- a/dagsync/dtsync/publisher.go
+++ b/dagsync/dtsync/publisher.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ipni/storetheindex/announce/message"
 	"github.com/ipni/storetheindex/dagsync/p2p/protocol/head"
 	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
 )
 
@@ -91,6 +92,14 @@ func NewPublisherFromExisting(dtManager dt.Manager, host host.Host, topicName st
 
 func (p *publisher) Addrs() []multiaddr.Multiaddr {
 	return p.host.Addrs()
+}
+
+func (p *publisher) ID() peer.ID {
+	return p.host.ID()
+}
+
+func (p *publisher) Protocol() int {
+	return multiaddr.P_P2P
 }
 
 func (p *publisher) AnnounceHead(ctx context.Context) error {

--- a/dagsync/interface.go
+++ b/dagsync/interface.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
 )
 
@@ -12,6 +13,10 @@ import (
 type Publisher interface {
 	// Addrs returns the addresses that the publisher is listening on.
 	Addrs() []multiaddr.Multiaddr
+	// ID returns the peer ID associated with the publisher.
+	ID() peer.ID
+	// Protocol returns multiaddr protocol code (P_P2P or P_HTTP).
+	Protocol() int
 	// AnnounceHead sends an announce messag, via all senders, to announce the
 	// current head advertisement CID. If there is no head, then does nothing.
 	AnnounceHead(context.Context) error

--- a/dagsync/legs_test.go
+++ b/dagsync/legs_test.go
@@ -35,7 +35,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func initPubSub(t *testing.T, srcStore, dstStore datastore.Batching) (host.Host, host.Host, dagsync.Publisher, *dagsync.Subscriber, error) {
+func initPubSub(t *testing.T, srcStore, dstStore datastore.Batching) (host.Host, host.Host, dagsync.Publisher, *dagsync.Subscriber) {
 	srcHost := test.MkTestHost()
 	dstHost := test.MkTestHost()
 
@@ -47,29 +47,21 @@ func initPubSub(t *testing.T, srcStore, dstStore datastore.Batching) (host.Host,
 	require.NoError(t, err)
 
 	pub, err := dtsync.NewPublisher(srcHost, srcStore, srcLnkS, testTopic, dtsync.WithExtraData([]byte("t01000")), dtsync.WithAnnounceSenders(p2pSender))
-	if err != nil {
-		return nil, nil, nil, nil, err
-	}
+	require.NoError(t, err)
+
+	require.NoError(t, test.WaitForP2PPublisher(pub, dstHost, testTopic))
 
 	srcHost.Peerstore().AddAddrs(dstHost.ID(), dstHost.Addrs(), time.Hour)
 	dstHost.Peerstore().AddAddrs(srcHost.ID(), srcHost.Addrs(), time.Hour)
 	dstLnkS := test.MkLinkSystem(dstStore)
 
 	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, nil, dagsync.Topic(topics[1]))
-	if err != nil {
-		return nil, nil, nil, nil, err
-	}
+	require.NoError(t, err)
 
-	if err := srcHost.Connect(context.Background(), dstHost.Peerstore().PeerInfo(dstHost.ID())); err != nil {
-		return nil, nil, nil, nil, err
-	}
+	err = srcHost.Connect(context.Background(), dstHost.Peerstore().PeerInfo(dstHost.ID()))
+	require.NoError(t, err)
 
-	err = test.WaitForPublisher(dstHost, testTopic, srcHost.ID())
-	if err != nil {
-		return nil, nil, nil, nil, err
-	}
-
-	return srcHost, dstHost, pub, sub, nil
+	return srcHost, dstHost, pub, sub
 }
 
 func TestAllowPeerReject(t *testing.T) {
@@ -77,8 +69,7 @@ func TestAllowPeerReject(t *testing.T) {
 	// Init dagsync publisher and subscriber
 	srcStore := dssync.MutexWrap(datastore.NewMapDatastore())
 	dstStore := dssync.MutexWrap(datastore.NewMapDatastore())
-	srcHost, dstHost, pub, sub, err := initPubSub(t, srcStore, dstStore)
-	require.NoError(t, err)
+	srcHost, dstHost, pub, sub := initPubSub(t, srcStore, dstStore)
 	defer srcHost.Close()
 	defer dstHost.Close()
 	defer pub.Close()
@@ -96,7 +87,7 @@ func TestAllowPeerReject(t *testing.T) {
 	c := mkLnk(t, srcStore)
 
 	// Update root with item
-	err = pub.UpdateRoot(context.Background(), c)
+	err := pub.UpdateRoot(context.Background(), c)
 	require.NoError(t, err)
 
 	select {
@@ -111,8 +102,7 @@ func TestAllowPeerAllows(t *testing.T) {
 	// Init dagsync publisher and subscriber
 	srcStore := dssync.MutexWrap(datastore.NewMapDatastore())
 	dstStore := dssync.MutexWrap(datastore.NewMapDatastore())
-	srcHost, dstHost, pub, sub, err := initPubSub(t, srcStore, dstStore)
-	require.NoError(t, err)
+	srcHost, dstHost, pub, sub := initPubSub(t, srcStore, dstStore)
 	defer srcHost.Close()
 	defer dstHost.Close()
 	defer pub.Close()
@@ -129,7 +119,7 @@ func TestAllowPeerAllows(t *testing.T) {
 	c := mkLnk(t, srcStore)
 
 	// Update root with item
-	err = pub.UpdateRoot(context.Background(), c)
+	err := pub.UpdateRoot(context.Background(), c)
 	require.NoError(t, err)
 
 	select {
@@ -170,6 +160,8 @@ func TestPublisherRejectsPeer(t *testing.T) {
 	require.NoError(t, err)
 	defer pub.Close()
 
+	require.NoError(t, test.WaitForP2PPublisher(pub, dstHost, testTopic))
+
 	srcHost.Peerstore().AddAddrs(dstHost.ID(), dstHost.Addrs(), time.Hour)
 	dstHost.Peerstore().AddAddrs(srcHost.ID(), srcHost.Addrs(), time.Hour)
 	dstLnkS := test.MkLinkSystem(dstStore)
@@ -179,9 +171,6 @@ func TestPublisherRejectsPeer(t *testing.T) {
 	defer sub.Close()
 
 	err = srcHost.Connect(context.Background(), dstHost.Peerstore().PeerInfo(dstHost.ID()))
-	require.NoError(t, err)
-
-	err = test.WaitForPublisher(dstHost, testTopic, srcHost.ID())
 	require.NoError(t, err)
 
 	watcher, cncl := sub.OnSyncFinished()

--- a/dagsync/sync_test.go
+++ b/dagsync/sync_test.go
@@ -42,13 +42,11 @@ func TestLatestSyncSuccess(t *testing.T) {
 	pub, err := dtsync.NewPublisher(srcHost, srcStore, srcLnkS, testTopic, dtsync.WithAnnounceSenders(p2pSender))
 	require.NoError(t, err)
 	defer pub.Close()
+	require.NoError(t, test.WaitForP2PPublisher(pub, dstHost, testTopic))
 
 	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, nil, dagsync.Topic(topics[1]))
 	require.NoError(t, err)
 	defer sub.Close()
-
-	err = test.WaitForPublisher(dstHost, topics[0].String(), srcHost.ID())
-	require.NoError(t, err)
 
 	watcher, cncl := sub.OnSyncFinished()
 	defer cncl()
@@ -86,6 +84,7 @@ func TestSyncFn(t *testing.T) {
 	pub, err := dtsync.NewPublisher(srcHost, srcStore, srcLnkS, testTopic, dtsync.WithAnnounceSenders(p2pSender))
 	require.NoError(t, err)
 	defer pub.Close()
+	require.NoError(t, test.WaitForP2PPublisher(pub, dstHost, testTopic))
 
 	var blockHookCalls int
 	blocksSeenByHook := make(map[cid.Cid]struct{})
@@ -103,9 +102,6 @@ func TestSyncFn(t *testing.T) {
 
 	// Store the whole chain in source node
 	chainLnks := test.MkChain(srcLnkS, true)
-
-	err = test.WaitForPublisher(dstHost, topics[0].String(), srcHost.ID())
-	require.NoError(t, err)
 
 	watcher, cancelWatcher := sub.OnSyncFinished()
 	defer cancelWatcher()
@@ -203,6 +199,7 @@ func TestPartialSync(t *testing.T) {
 	pub, err := dtsync.NewPublisher(srcHost, srcStore, srcLnkS, testTopic, dtsync.WithAnnounceSenders(p2pSender))
 	require.NoError(t, err)
 	defer pub.Close()
+	require.NoError(t, test.WaitForP2PPublisher(pub, dstHost, testTopic))
 	test.MkChain(srcLnkS, true)
 
 	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, nil, dagsync.Topic(topics[1]))
@@ -213,9 +210,6 @@ func TestPartialSync(t *testing.T) {
 	require.NoError(t, err)
 
 	err = srcHost.Connect(context.Background(), dstHost.Peerstore().PeerInfo(dstHost.ID()))
-	require.NoError(t, err)
-
-	err = test.WaitForPublisher(dstHost, topics[0].String(), srcHost.ID())
 	require.NoError(t, err)
 
 	watcher, cncl := sub.OnSyncFinished()
@@ -264,13 +258,11 @@ func TestStepByStepSync(t *testing.T) {
 	pub, err := dtsync.NewPublisher(srcHost, srcStore, srcLnkS, testTopic, dtsync.WithAnnounceSenders(p2pSender))
 	require.NoError(t, err)
 	defer pub.Close()
+	require.NoError(t, test.WaitForP2PPublisher(pub, dstHost, testTopic))
 
 	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, nil, dagsync.Topic(topics[1]))
 	require.NoError(t, err)
 	defer sub.Close()
-
-	err = test.WaitForPublisher(dstHost, topics[0].String(), srcHost.ID())
-	require.NoError(t, err)
 
 	watcher, cncl := sub.OnSyncFinished()
 	defer cncl()
@@ -307,6 +299,7 @@ func TestLatestSyncFailure(t *testing.T) {
 	srcHost.Peerstore().AddAddrs(dstHost.ID(), dstHost.Addrs(), time.Hour)
 	dstHost.Peerstore().AddAddrs(srcHost.ID(), srcHost.Addrs(), time.Hour)
 	dstLnkS := test.MkLinkSystem(dstStore)
+	require.NoError(t, test.WaitForP2PPublisher(pub, dstHost, testTopic))
 
 	t.Log("source host:", srcHost.ID())
 	t.Log("targer host:", dstHost.ID())
@@ -319,9 +312,6 @@ func TestLatestSyncFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	err = sub.SetLatestSync(srcHost.ID(), chainLnks[3].(cidlink.Link).Cid)
-	require.NoError(t, err)
-
-	err = test.WaitForPublisher(dstHost, testTopic, srcHost.ID())
 	require.NoError(t, err)
 
 	watcher, cncl := sub.OnSyncFinished()
@@ -363,13 +353,11 @@ func TestAnnounce(t *testing.T) {
 	pub, err := dtsync.NewPublisher(srcHost, srcStore, srcLnkS, testTopic)
 	require.NoError(t, err)
 	defer pub.Close()
+	require.NoError(t, test.WaitForP2PPublisher(pub, dstHost, testTopic))
 
 	sub, err := dagsync.NewSubscriber(dstHost, dstStore, dstLnkS, testTopic, nil)
 	require.NoError(t, err)
 	defer sub.Close()
-
-	err = test.WaitForPublisher(dstHost, testTopic, srcHost.ID())
-	require.NoError(t, err)
 
 	watcher, cncl := sub.OnSyncFinished()
 	defer cncl()

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/cockroachdb/pebble v0.0.0-20220726144858-a78491c0086f
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.3.0
-	github.com/filecoin-project/go-data-transfer/v2 v2.0.0-rc4
+	github.com/filecoin-project/go-data-transfer/v2 v2.0.0-rc5
 	github.com/gammazero/deque v0.2.1
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.7.1
@@ -40,7 +40,6 @@ require (
 	github.com/multiformats/go-multiaddr v0.8.0
 	github.com/multiformats/go-multicodec v0.8.0
 	github.com/multiformats/go-multihash v0.2.1
-	github.com/multiformats/go-multistream v0.4.1
 	github.com/multiformats/go-varint v0.0.7
 	github.com/orlangure/gnomock v0.24.0
 	github.com/prometheus/client_golang v1.14.0
@@ -183,6 +182,7 @@ require (
 	github.com/multiformats/go-multiaddr-dns v0.3.1 // indirect
 	github.com/multiformats/go-multiaddr-fmt v0.1.0 // indirect
 	github.com/multiformats/go-multibase v0.1.1 // indirect
+	github.com/multiformats/go-multistream v0.4.1 // indirect
 	github.com/onsi/ginkgo/v2 v2.5.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -238,8 +238,8 @@ github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03 h1:2pMX
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03/go.mod h1:+viYnvGtUTgJRdy6oaeF4MTFKAfatX071MPDPBL11EQ=
 github.com/filecoin-project/go-dagaggregator-unixfs v0.3.0 h1:UXLtBUnPa61LkNa2GqhP+aJ53bOnHP/dzg6/wk2rnsA=
 github.com/filecoin-project/go-dagaggregator-unixfs v0.3.0/go.mod h1:UTWmEgyqq7RMx56AeHY/uEoLq1dJTPAirjyBPas4IQQ=
-github.com/filecoin-project/go-data-transfer/v2 v2.0.0-rc4 h1:Y5RMvFT4OthsAhDx7xKfkJ5QdiWq9Ox7N46Mi0PF0PE=
-github.com/filecoin-project/go-data-transfer/v2 v2.0.0-rc4/go.mod h1:1WDoUgWYB2KvogfPTdDmoyBTa9cb9+oGwqKCCipnJeY=
+github.com/filecoin-project/go-data-transfer/v2 v2.0.0-rc5 h1:lqjkVplfTRt5GV7Pxjo+H+Jhnh7tgUIhKFFLxGvjv1Y=
+github.com/filecoin-project/go-data-transfer/v2 v2.0.0-rc5/go.mod h1:YY4onZJ9LoSP19kdJWD7PZ0ZDJSQnbcEXYfjezMLTog=
 github.com/filecoin-project/go-ds-versioning v0.1.2 h1:to4pTadv3IeV1wvgbCbN6Vqd+fu+7tveXgv/rCEZy6w=
 github.com/filecoin-project/go-ds-versioning v0.1.2/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -850,7 +850,7 @@ func testSyncWithExtendedProviders(t *testing.T,
 	defer pub.Close()
 	connectHosts(t, h, pubHost)
 
-	err = dstest.WaitForPublisher(h, defaultTestIngestConfig.PubSubTopic, pubHost.ID())
+	err = dstest.WaitForP2PPublisher(pub, h, defaultTestIngestConfig.PubSubTopic)
 	require.NoError(t, err)
 
 	testFunc(privKey, pubKey, providerID, reg, lsys, pubHost, ingester, pub)
@@ -1053,7 +1053,7 @@ func TestSyncTooLargeMetadata(t *testing.T) {
 	defer pub.Close()
 	connectHosts(t, h, pubHost)
 
-	err := dstest.WaitForPublisher(h, defaultTestIngestConfig.PubSubTopic, pubHost.ID())
+	err := dstest.WaitForP2PPublisher(pub, h, defaultTestIngestConfig.PubSubTopic)
 	require.NoError(t, err)
 
 	metadata := make([]byte, schema.MaxMetadataLen*2)
@@ -1092,7 +1092,7 @@ func TestSyncSkipNoMetadata(t *testing.T) {
 	defer pub.Close()
 	connectHosts(t, h, pubHost)
 
-	err := dstest.WaitForPublisher(h, defaultTestIngestConfig.PubSubTopic, pubHost.ID())
+	err := dstest.WaitForP2PPublisher(pub, h, defaultTestIngestConfig.PubSubTopic)
 	require.NoError(t, err)
 
 	// Test ad that has no entries and no metadata.
@@ -1978,7 +1978,7 @@ func setupTestEnv(t *testing.T, shouldConnectHosts bool, opts ...func(*testEnvOp
 	if shouldConnectHosts {
 		connectHosts(t, ingesterHost, pubHost)
 
-		err = dstest.WaitForPublisher(ingesterHost, defaultTestIngestConfig.PubSubTopic, pubHost.ID())
+		err = dstest.WaitForP2PPublisher(pub, ingesterHost, defaultTestIngestConfig.PubSubTopic)
 		require.NoError(t, err)
 	}
 


### PR DESCRIPTION
Returning 204 No Content is better than failing with an internal server error.

Fixes #1422 

Some additional work done to stabilize tests by waiting for the publisher to be ready to serve requests.
