### PR TITLE
Replace `r6a` node group and add `c6a` for new subnets

### DIFF
--- a/deploy/infrastructure/prod/us-east-2/eks.tf
+++ b/deploy/infrastructure/prod/us-east-2/eks.tf
@@ -47,7 +47,7 @@ module "eks" {
       max_size       = 3
       desired_size   = 1
       instance_types = ["r6a.xlarge"]
-      subnet_ids     = [data.aws_subnet.ue2c2.id]
+      subnet_ids     = [data.aws_subnet.ue2c2.id, data.aws_subnet.ue2c3.id]
     }
 
     # General purpose node-group.
@@ -146,6 +146,48 @@ module "eks" {
       desired_size   = 1
       instance_types = ["c6a.8xlarge"]
       subnet_ids     = [data.aws_subnet.ue2c2.id]
+      taints         = {
+        dedicated = {
+          key    = "dedicated"
+          value  = "c6a-8xl"
+          effect = "NO_SCHEDULE"
+        }
+      }
+    }
+    prod-ue2a-c6a-8xl-2 = {
+      min_size       = 0
+      max_size       = 5
+      desired_size   = 0
+      instance_types = ["c6a.8xlarge"]
+      subnet_ids     = [data.aws_subnet.ue2a2.id, data.aws_subnet.ue2a3.id]
+      taints         = {
+        dedicated = {
+          key    = "dedicated"
+          value  = "c6a-8xl"
+          effect = "NO_SCHEDULE"
+        }
+      }
+    }
+    prod-ue2b-c6a-8xl-2 = {
+      min_size       = 0
+      max_size       = 5
+      desired_size   = 0
+      instance_types = ["c6a.8xlarge"]
+      subnet_ids     = [data.aws_subnet.ue2b2.id, data.aws_subnet.ue2b3.id]
+      taints         = {
+        dedicated = {
+          key    = "dedicated"
+          value  = "c6a-8xl"
+          effect = "NO_SCHEDULE"
+        }
+      }
+    }
+    prod-ue2c-c6a-8xl-2 = {
+      min_size       = 0
+      max_size       = 5
+      desired_size   = 0
+      instance_types = ["c6a.8xlarge"]
+      subnet_ids     = [data.aws_subnet.ue2c2.id, data.aws_subnet.ue2c3.id]
       taints         = {
         dedicated = {
           key    = "dedicated"

--- a/deploy/manifests/prod/us-east-2/cluster/kube-system/aws-auth.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/kube-system/aws-auth.yaml
@@ -53,6 +53,21 @@ data:
     - groups:
       - system:bootstrappers
       - system:nodes
+      rolearn: arn:aws:iam::407967248065:role/prod-ue2a-c6a-8xl-2-eks-node-group
+      username: system:node:{{EC2PrivateDNSName}}
+    - groups:
+      - system:bootstrappers
+      - system:nodes
+      rolearn: arn:aws:iam::407967248065:role/prod-ue2b-c6a-8xl-2-eks-node-group
+      username: system:node:{{EC2PrivateDNSName}}
+    - groups:
+      - system:bootstrappers
+      - system:nodes
+      rolearn: arn:aws:iam::407967248065:role/prod-ue2c-c6a-8xl-2-eks-node-group
+      username: system:node:{{EC2PrivateDNSName}}
+    - groups:
+      - system:bootstrappers
+      - system:nodes
       rolearn: arn:aws:iam::407967248065:role/prod-ue2c-r5n-2xl-eks-node-group
       username: system:node:{{EC2PrivateDNSName}}
     - groups:


### PR DESCRIPTION
Replace the old `r6a` nodegroup to span across all subnets.

Create new `c6a` node group in prep for replacing the old ones.
