### PR TITLE
HTTP publisher returns 204 when nothing to publish

### DIFF
--- a/dagsync/httpsync/publisher.go
+++ b/dagsync/httpsync/publisher.go
@@ -160,6 +160,10 @@ func (p *publisher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		p.rl.RLock()
 		defer p.rl.RUnlock()
 
+		if p.root == cid.Undef {
+			http.Error(w, "", http.StatusNoContent)
+			return
+		}
 		marshalledMsg, err := newEncodedSignedHead(p.root, p.privKey)
 		if err != nil {
 			http.Error(w, "Failed to encode", http.StatusInternalServerError)


### PR DESCRIPTION
Returning 204 No Content is better than failing with an internal server error.

Fixes #1422 
