### PR TITLE
Deploy latest to `heyfil` with lotus v1 support

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/heyfil/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/heyfil/kustomization.yaml
@@ -13,4 +13,4 @@ patchesStrategicMerge:
 images:
   - name: heyfil
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/heyfil
-    newTag: 20221125195544-aefda08298112768315be9c956eeb53791a2b9fa
+    newTag: 20230320153955-8ce6e3a12d962f9240f7bc628c3d6fdcfc0ba7c4


### PR DESCRIPTION
glif API has undergone a set of changes, namely tailing slash in API no longer works. Support for listing state market participants is no longer offered for v0 api.

This version changes the way participants are listed to use list miners endpoint and updates the api endpoint.
