### PR TITLE
Report pebble metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd
 	github.com/ipld/go-storethehash v0.3.13
 	github.com/ipni/dhstore v0.0.2-0.20230120184057-c54e9d7c72f7
-	github.com/ipni/go-indexer-core v0.7.2-0.20230221145318-9aef8658e4ea
+	github.com/ipni/go-indexer-core v0.7.3
 	github.com/libp2p/go-libp2p v0.25.1
 	github.com/libp2p/go-libp2p-gostream v0.5.0
 	github.com/libp2p/go-libp2p-pubsub v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -619,8 +619,8 @@ github.com/ipld/go-storethehash v0.3.13 h1:1T6kX5K57lAgxbsGitZEaZMAR3RdWch2kO8ok
 github.com/ipld/go-storethehash v0.3.13/go.mod h1:KCYpzmamubnSwm7fvWcCkm0aIwQh4WRNtzrKK4pVhAQ=
 github.com/ipni/dhstore v0.0.2-0.20230120184057-c54e9d7c72f7 h1:w4sIScjReSAME4FKuSPaUT0H6rUi4UxEy42lEi5QKJY=
 github.com/ipni/dhstore v0.0.2-0.20230120184057-c54e9d7c72f7/go.mod h1:CIz5tpqY9GRSTx2ZML3tmvCZzdDCudDuE3DP57R4ZYo=
-github.com/ipni/go-indexer-core v0.7.2-0.20230221145318-9aef8658e4ea h1:hdbpvjYl7ZB7w9eGn8thjsHNhIzUTEgJyrkF4WrEG8Q=
-github.com/ipni/go-indexer-core v0.7.2-0.20230221145318-9aef8658e4ea/go.mod h1:M8xYlU9CwIm+JbS44B2br+qlyoc6Pm3C8u2Vsov6Fzk=
+github.com/ipni/go-indexer-core v0.7.3 h1:4qHcIPY5OPTPFMPlbMcSbJBGbDI0xqswON4zb0Wd9tU=
+github.com/ipni/go-indexer-core v0.7.3/go.mod h1:vY8v8ITI2+z3hBaqM1XVFC/z31JyRCa2rWF2IDOfPDU=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=

--- a/server/admin/http/server.go
+++ b/server/admin/http/server.go
@@ -83,7 +83,7 @@ func New(listen string, id peer.ID, indexer indexer.Interface, ingester *ingest.
 	mux.HandleFunc("/ingest/preferred", h.listPreferredPeers)
 
 	// Metrics routes
-	mux.Handle("/metrics", metrics.Start(coremetrics.DefaultViews))
+	mux.Handle("/metrics", metrics.Start(append(coremetrics.DefaultViews, coremetrics.PebbleViews...)))
 	mux.Handle("/debug/pprof", pprof.WithProfile())
 
 	// Config routes


### PR DESCRIPTION
* Update to the latest version of `go-indexer-core` that supports metrics reporting
* Will switch to the release version before merging this PR