### PR TITLE
New mirror config for ago

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/config.json
@@ -69,6 +69,17 @@
   },
   "Ingest": {
     "AdvertisementDepthLimit": 33554432,
+    "AdvertisementMirror": {
+      "Read": false,
+      "Write": true,
+      "Compress": "gzip",
+      "Storage": {
+        "Type": "s3",
+        "S3": {
+          "BucketName": "dev-sti-adstore"
+        }
+      }
+    },
     "CarMirrorDestination": {
       "Compress": "gzip",
       "Type": "s3",


### PR DESCRIPTION
## Context
The mirror configuration has changed with PR #1409 and ago will need the new configuration to continue creating CAR files from ingested advertisement data, if updated with code from #1409 or later.

This PR leaves the old mirror configuration in place in case reverting is necessary.
