### PR TITLE
Implement base `cassette` manifests and deploy to `dev`

### DIFF
--- a/deploy/manifests/base/cassette/deployment.yaml
+++ b/deploy/manifests/base/cassette/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cassette
+spec:
+  selector:
+    matchLabels:
+      app: cassette
+  template:
+    metadata:
+      labels:
+        app: cassette
+    spec:
+      containers:
+        - name: cassette
+          image: cassette
+          envFrom:
+            - configMapRef:
+                name: cassette-env-vars
+          ports:
+            - containerPort: 40080
+              name: http
+          readinessProbe:
+            httpGet:
+              port: http
+              path: /ready
+            initialDelaySeconds: 3
+            failureThreshold: 3
+            successThreshold: 1
+            timeoutSeconds: 5
+            periodSeconds: 10

--- a/deploy/manifests/base/cassette/kustomization.yaml
+++ b/deploy/manifests/base/cassette/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml
+  - pdb.yaml
+
+transformers:
+  - labels.yaml
+
+configMapGenerator:
+  - name: cassette-env-vars
+    behavior: create
+    literals:
+      - GOLOG_LOG_LEVEL=INFO
+      - GOLOG_LOG_FMT=json

--- a/deploy/manifests/base/cassette/labels.yaml
+++ b/deploy/manifests/base/cassette/labels.yaml
@@ -1,0 +1,12 @@
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: labels
+labels:
+  app.kubernetes.io/name: cassette
+  app.kubernetes.io/component: routing
+  app.kubernetes.io/part-of: ipni
+  app.kubernetes.io/managed-by: kustomization
+fieldSpecs:
+  - path: metadata/labels
+    create: true

--- a/deploy/manifests/base/cassette/pdb.yaml
+++ b/deploy/manifests/base/cassette/pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cassette
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: cassette

--- a/deploy/manifests/base/cassette/service.yaml
+++ b/deploy/manifests/base/cassette/service.yaml
@@ -1,0 +1,11 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: cassette
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+  selector:
+    app: cassette

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/cassette/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/cassette/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cassette
+spec:
+  template:
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+      containers:
+        - name: cassette
+          args:
+            - '--libp2pIdentityPath=/identity/identity.key'
+            - '--libp2pListenAddrs=/ip4/0.0.0.0/tcp/40090,/ip4/0.0.0.0/udp/40090/quic,/ip4/0.0.0.0/udp/40090/quic-v1'
+            - '--useResourceManager=false'
+            # Respond with 404 if `?cascade=legacy` is not specified as URL query parameter.
+            - '--ipniRequireQueryParam'
+            - '--libp2pConMgrLow=200'
+            - '--libp2pConMgrHigh=5000'
+          ports:
+            - containerPort: 40090
+              name: libp2p
+          volumeMounts:
+            - name: identity
+              mountPath: /identity
+          resources:
+            limits:
+              cpu: "3"
+              memory: 5Gi
+            requests:
+              cpu: "3"
+              memory: 5Gi
+      volumes:
+        - name: identity
+          secret:
+            secretName: cassette-identity

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/cassette/identity.key.encrypted
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/cassette/identity.key.encrypted
@@ -1,0 +1,22 @@
+{
+	"data": "ENC[AES256_GCM,data:Gtsy4dMEUjMgOGSfVrQzBOuWQZNomoddK8ZdQ+XhrRIxYBmiA7zuKkTZBpMpgGVAlIoHMliE97VnjfXCNCwOM+Rmsvg=,iv:tVyLHGwUhdQScPU0SRpoAhvWr5Fg1pOrSy+sfiGOP7E=,tag:cVD1XzSN9b/OmiGKQeyoxA==,type:str]",
+	"sops": {
+		"kms": [
+			{
+				"arn": "arn:aws:kms:us-east-2:407967248065:alias/sti_flux",
+				"created_at": "2023-03-21T13:27:43Z",
+				"enc": "AQICAHi99m+hXhXmjeAqO3v9MBDcMaC2zWJIlamGyiBfOVdULAFKz7i5XNXUXvKusYK2kQ8KAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMQwchfAUKg8RVOI0BAgEQgDsTFrIuPwrVQKadB3CVf9utJwiMvsJ5oX6FIfueqvRZnmzewOirTHRD4FO0hWKFsWIrmAwRDoeXlvH5jQ==",
+				"aws_profile": ""
+			}
+		],
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2023-03-21T13:27:44Z",
+		"mac": "ENC[AES256_GCM,data:Yy4Ta1N1kkRCWHibXDoiSFYSz54sTXJGAbv8IPTMmxFZClIgjJzjDU2KDNAGlY2hNz++aiLFFvGthKpFQZwBWkQEzK+01xZgYdjqt7Y1SXeQY0g0BDsH79AqMo3qsgrYJzVfMaNcWWflSrrNfSxcuP+hhYYm7wj8nNvE3KMYg4c=,iv:XQinzWOtkQsxOF26QhFb/gpNzpH7d2RKEoijHgbwO2A=,tag:6tIrKpb76HrxZcfLG0onUQ==,type:str]",
+		"pgp": null,
+		"encrypted_regex": "^(data|stringData)$",
+		"version": "3.7.3"
+	}
+}

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/cassette/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/cassette/kustomization.yaml
@@ -1,0 +1,28 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - ../../../../../base/cassette
+  - service-external.yaml
+
+patchesStrategicMerge:
+  - deployment.yaml
+  - service.yaml
+
+secretGenerator:
+  - name: cassette-identity
+    files:
+      - identity.key=identity.key.encrypted # 12D3KooWGTmdmxG1CJSt8PS7B5H1wh9SmPqSTdGS2296V2EcMX6S
+
+configMapGenerator:
+  - name: cassette-env-vars
+    behavior: merge
+    literals:
+      - GOLOG_LOG_LEVEL="info,net/identify=error"
+
+images:
+  - name: cassette
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/cassette
+    newTag: 20230321143401-366df7565d6cfedc22d8280e146212d1995bfe3e

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/cassette/service-external.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/cassette/service-external.yaml
@@ -1,0 +1,18 @@
+# External facing cassette libp2p endpoint, used for peering.
+kind: Service
+apiVersion: v1
+metadata:
+  name: cassette-external
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+    external-dns.alpha.kubernetes.io/hostname: cassette.dev.cid.contact
+spec:
+  ports:
+    - name: libp2p
+      port: 40090
+      targetPort: libp2p
+  selector:
+    app: cassette
+  externalTrafficPolicy: Local
+  type: LoadBalancer

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/cassette/service.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/cassette/service.yaml
@@ -1,0 +1,18 @@
+# cassette service is accessible only within K8S cluster VPC via:
+#  - http://cassette.internal.dev.cid.contact
+#
+# See: https://github.com/ipni/cassette
+kind: Service
+apiVersion: v1
+metadata:
+  name: cassette
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internal
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+    external-dns.alpha.kubernetes.io/access: private
+    external-dns.alpha.kubernetes.io/hostname: cassette.internal.dev.cid.contact
+spec:
+  externalTrafficPolicy: Cluster
+  type: LoadBalancer

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - caskadht
 - snapshots
 - lookout
+- cassette
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}


### PR DESCRIPTION
Add `cassette` base manifests and deploy it to `dev` with a stable libp2p identity and external facing libp2p endpoint.

