### PR TITLE
Upgrade `caskadht` and `lookout` to latest and add `cassette` checks

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/caskadht/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/caskadht/kustomization.yaml
@@ -24,4 +24,4 @@ configMapGenerator:
 images:
   - name: caskadht
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/caskadht
-    newTag: 20230228121423-58580c9970ad3a1d0e3a92e97df7599b23ca0820
+    newTag: 20230321141253-e9d4c3feeff161010a03c8fabefd98db3879b87f

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -22,6 +22,7 @@ spec:
             - '--backends=http://dhstore.internal.dev.cid.contact/'
             - '--backends=http://dhfind.internal.dev.cid.contact/'
             - '--cascadeBackends=http://caskadht.internal.dev.cid.contact/'
+            - '--cascadeBackends=http://cassette.internal.dev.cid.contact/'
           env:
             # Increase maximum accepted request body to 1 MiB in order to allow batch finds requests
             # by the `provider verify-ingest` CLI command. 
@@ -29,7 +30,7 @@ spec:
               value: '1048576'
             # The service provided by caskadht.
             - name: SERVER_CASCADE_LABELS
-              value: 'ipfs-dht'
+              value: 'ipfs-dht,legacy'
             - name: SERVER_HTTP_CLIENT_TIMEOUT
               value: '30s'
             - name: SERVER_RESULT_MAX_WAIT

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/lookout/config.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/lookout/config.yaml
@@ -3,30 +3,39 @@ checkers:
   cid_contact:
     type: ipni-non-streaming
     ipniEndpoint: https://dev.cid.contact
-    Timeout: 30s
-    ipfsDhtCascade: false
+    timeout: 30s
     parallelism: 10
   # Check dev endpoint behind cache with cascade over IPFS DHT enabled
   cid_contact_with_cascade:
     type: ipni-non-streaming
     ipniEndpoint: https://dev.cid.contact
-    Timeout: 30s
-    ipfsDhtCascade: true
+    timeout: 30s
+    cascadeLabels:
+      - ipfs-dht
+      - legacy
     parallelism: 10
   # Check dev endpoint without cache
   indexstar:
     type: ipni-non-streaming
     ipniEndpoint: https://indexstar.dev.cid.contact
-    Timeout: 30s
-    ipfsDhtCascade: false
+    timeout: 30s
     parallelism: 10
   # Check dev endpoint without cache with cascade over IPFS DHT enabled
   indexstar_with_cascade:
     type: ipni-non-streaming
     ipniEndpoint: https://indexstar.dev.cid.contact
-    Timeout: 30s
-    ipfsDhtCascade: true
+    timeout: 30s
+    cascadeLabels:
+      - ipfs-dht
+      - legacy
     parallelism: 10
+  cassette_internal:
+    type: ipni-non-streaming
+    ipniEndpoint: http://cassette.internal.dev.cid.contact
+    timeout: 30s
+    cascadeLabels:
+      - legacy
+    parallelism: 50
 samplers:
   # List of root CIDs of well known IPFS datasets.
   # See: 

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/lookout/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/lookout/kustomization.yaml
@@ -19,4 +19,4 @@ configMapGenerator:
 images:
   - name: lookout
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/lookout
-    newTag: 20230310164531-de86e7f2aee29d3f1ca4305b747b70d0aea8dba5
+    newTag: 20230321141406-50c647a272a92601ddc7818c180319a31d64b625

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/caskadht/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/caskadht/kustomization.yaml
@@ -28,4 +28,4 @@ replicas:
 images:
   - name: caskadht
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/caskadht
-    newTag: 20230228121423-58580c9970ad3a1d0e3a92e97df7599b23ca0820
+    newTag: 20230321141253-e9d4c3feeff161010a03c8fabefd98db3879b87f

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/lookout/config.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/lookout/config.yaml
@@ -3,29 +3,29 @@ checkers:
   cid_contact:
     type: ipni-non-streaming
     ipniEndpoint: https://cid.contact
-    Timeout: 30s
-    ipfsDhtCascade: false
+    timeout: 30s
     parallelism: 10
   # Check production endpoint behind cache with cascade over IPFS DHT enabled
   cid_contact_with_cascade:
     type: ipni-non-streaming
     ipniEndpoint: https://cid.contact
-    Timeout: 30s
-    ipfsDhtCascade: true
+    timeout: 30s
+    cascadeLabels:
+      - ipfs-dht
     parallelism: 10
   # Check production endpoint without cache
   indexstar:
     type: ipni-non-streaming
     ipniEndpoint: https://indexstar.prod.cid.contact
-    Timeout: 30s
-    ipfsDhtCascade: false
+    timeout: 30s
     parallelism: 10
   # Check production endpoint without cache with cascade over IPFS DHT enabled
   indexstar_with_cascade:
     type: ipni-non-streaming
     ipniEndpoint: https://indexstar.prod.cid.contact
-    Timeout: 30s
-    ipfsDhtCascade: true
+    timeout: 30s
+    cascadeLabels:
+      - ipfs-dht
     parallelism: 10
 samplers:
   # List of root CIDs of well known IPFS datasets.

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/lookout/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/lookout/kustomization.yaml
@@ -19,4 +19,4 @@ configMapGenerator:
 images:
   - name: lookout
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/lookout
-    newTag: 20230310164531-de86e7f2aee29d3f1ca4305b747b70d0aea8dba5
+    newTag: 20230321141406-50c647a272a92601ddc7818c180319a31d64b625


### PR DESCRIPTION
Upgrade to the latest of `caskadht` and `lookout` in order to rollout support for cascade label list and CID based checking.

Configure `lookout` checker for `cassette` on `dev` to better understand its behaviour.

