### PR TITLE
Temporarily increase pebble block cache size

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -586,7 +586,7 @@ func createValueStore(ctx context.Context, cfgIndexer config.Indexer) (indexer.I
 			l.EnsureDefaults()
 		}
 		pebbleOpts.Levels[numLevels-1].FilterPolicy = nil
-		pebbleOpts.Cache = pbl.NewCache(1 << 30) // 1 GiB
+		pebbleOpts.Cache = pbl.NewCache(2 << 30) // 2 GiB
 
 		vs, err = pebble.New(dir, pebbleOpts)
 	default:


### PR DESCRIPTION
* This is to test whether bigger block cache will help to make read latencies smoother.
* Will be deployed only to dido in prod where spiky latencies are observed. 

