### PR TITLE
Increase dido pebble block cache size

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/config.json
@@ -61,7 +61,8 @@
     "ShutdownTimeout": "15m",
     "ValueStoreDir": "/data/valuestore",
     "ValueStoreType": "pebble",
-    "DisableWAL": true
+    "DisableWAL": true,
+    "PebbleBlockCacheSize": "2Gi"
   },
   "Ingest": {
     "AdvertisementDepthLimit": 33554432,

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/kustomization.yaml
@@ -28,3 +28,8 @@ configMapGenerator:
 
 patchesStrategicMerge:
   - deployment.yaml
+
+images:
+  - name: storetheindex
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
+    newTag: 20230321184158-a0bbd92d687482d37953d66422e5b173654f7ad3


### PR DESCRIPTION
In the last couple of days dido had frequent latency spikes. That might have been caused by not big enough pebble block cache. In this commit:
* Update dido to the latest STI that supports configuration for pebble block cache size;
* Set block cache size to 2Gi that is double the previous size.
