### PR TITLE
don't peer with bootstraps in cassette

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/cassette/config.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/cassette/config.yaml
@@ -30,13 +30,6 @@ metrics:
   enablePprofDebug: true
 bitswap:
   peers:
-    # Kubo bootstrap nodes
-    - '/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN'
-    - '/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa'
-    - '/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb'
-    - '/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt'
-    - '/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ'
-    - '/ip4/104.131.131.82/udp/4001/quic/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ'
     # Infura
     - '/ip4/54.88.122.141/tcp/4001/p2p/QmNcmkK7eZLW3CpQbeS1Udu8CcJ7rEVZf7X2roPNMXYunG'
     - '/ip4/54.88.122.141/udp/4001/quic/p2p/QmNcmkK7eZLW3CpQbeS1Udu8CcJ7rEVZf7X2roPNMXYunG'


### PR DESCRIPTION
it's rightly pointed out that the bootstrap peers don't have any blocks themselves, so there's no  value in connecting with them.