### PR TITLE
Always remove temp ad data after ad is processed

### DIFF
--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -1132,11 +1132,11 @@ func (ing *Ingester) ingestWorkerLogic(ctx context.Context, provider peer.ID) {
 				"adCid", ai.cid,
 				"progress", fmt.Sprintf("%d of %d", count, splitAtIndex))
 
-			keep := ing.mirror.canWrite() || ing.dsAds != ing.ds
+			keep := ing.mirror.canWrite()
 			if markErr := ing.markAdProcessed(assignment.publisher, ai.cid, frozen, keep); markErr != nil {
 				log.Errorw("Failed to mark ad as processed", "err", markErr)
 			}
-			if !frozen && ing.mirror.canWrite() {
+			if !frozen && keep {
 				// Write the advertisement to a CAR file, but omit the entries.
 				carInfo, err := ing.mirror.write(ctx, ai.cid, true)
 				if err != nil {
@@ -1218,12 +1218,12 @@ func (ing *Ingester) ingestWorkerLogic(ctx context.Context, provider peer.ID) {
 			return
 		}
 
-		keep := ing.mirror.canWrite() || ing.dsAds != ing.ds
+		keep := ing.mirror.canWrite()
 		if markErr := ing.markAdProcessed(assignment.publisher, ai.cid, frozen, keep); markErr != nil {
 			log.Errorw("Failed to mark ad as processed", "err", markErr)
 		}
 
-		if !frozen && ing.mirror.canWrite() {
+		if !frozen && keep {
 			carInfo, err := ing.mirror.write(ctx, ai.cid, false)
 			if err != nil {
 				if !errors.Is(err, fs.ErrExist) {

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -408,7 +408,7 @@ func (ing *Ingester) ingestHamtFromPublisher(ctx context.Context, ad schema.Adve
 	gatherCids := func(_ peer.ID, c cid.Cid, _ dagsync.SegmentSyncActions) {
 		hamtCids = append(hamtCids, c)
 	}
-	if !ing.mirror.canWrite() && ing.dsAds == ing.ds {
+	if !ing.mirror.canWrite() {
 		defer func() {
 			for _, c := range hamtCids {
 				err := ing.dsAds.Delete(ctx, datastore.NewKey(c.String()))
@@ -623,7 +623,7 @@ func (ing *Ingester) ingestEntriesFromCar(ctx context.Context, ad schema.Adverti
 // each block that is received.
 func (ing *Ingester) ingestEntryChunk(ctx context.Context, ad schema.Advertisement, providerID peer.ID, entryChunkCid cid.Cid, chunk schema.EntryChunk, log *zap.SugaredLogger) error {
 	err := ing.indexAdMultihashes(ad, providerID, chunk.Entries, log)
-	if !ing.mirror.canWrite() && ing.dsAds == ing.ds {
+	if !ing.mirror.canWrite() {
 		// Done processing entries chunk, so remove from datastore.
 		if err := ing.dsAds.Delete(ctx, datastore.NewKey(entryChunkCid.String())); err != nil {
 			log.Errorw("Error deleting index from datastore", "err", err)
@@ -679,7 +679,7 @@ func (ing *Ingester) indexAdMultihashes(ad schema.Advertisement, providerID peer
 	// No code path should ever allow this, so it is a programming error if
 	// this ever happens.
 	if ad.IsRm {
-		panic("removing individual multihashes no allowed")
+		panic("removing individual multihashes not allowed")
 	}
 
 	if err := ing.indexer.Put(value, mhs...); err != nil {


### PR DESCRIPTION
## Context
Previously, data written to a separate ad datastore was being saved if it was not written to car files. Since the data is never reused if not written to car files, it should not be saved.