### PR TITLE
Sync now accepts multiple addresses

### DIFF
--- a/dagsync/announce_test.go
+++ b/dagsync/announce_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ipni/storetheindex/dagsync/dtsync"
 	"github.com/ipni/storetheindex/dagsync/httpsync"
 	"github.com/ipni/storetheindex/dagsync/test"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
 )
 
@@ -189,7 +190,10 @@ func TestAnnounce_LearnsHttpPublisherAddr(t *testing.T) {
 
 	// Now assert that we can sync another CID because, the subscriber should have learned the
 	// address of publisher via earlier announce.
-	gotc, err := sub.Sync(ctx, pubh.ID(), anotherC, nil, nil)
+	peerInfo := peer.AddrInfo{
+		ID: pubh.ID(),
+	}
+	gotc, err := sub.Sync(ctx, peerInfo, anotherC, nil)
 	require.NoError(t, err)
 	require.Equal(t, anotherC, gotc)
 	gotNode, err := subls.Load(ipld.LinkContext{Ctx: ctx}, anotherLink, basicnode.Prototype.String)

--- a/dagsync/legs_test.go
+++ b/dagsync/legs_test.go
@@ -226,14 +226,18 @@ func TestIdleHandlerCleaner(t *testing.T) {
 	defer cancel()
 
 	// Do a sync to create the handler.
-	_, err = te.sub.Sync(ctx, te.srcHost.ID(), cid.Undef, nil, te.pubAddr)
+	peerInfo := peer.AddrInfo{
+		ID:    te.srcHost.ID(),
+		Addrs: te.pub.Addrs(),
+	}
+	_, err = te.sub.Sync(ctx, peerInfo, cid.Undef, nil)
 	require.NoError(t, err)
 
 	// Check that the handler is preeent by seeing if it can be removed.
 	require.True(t, te.sub.RemoveHandler(te.srcHost.ID()), "Expected handler to be present")
 
 	// Do another sync to re-create the handler.
-	_, err = te.sub.Sync(ctx, te.srcHost.ID(), cid.Undef, nil, te.pubAddr)
+	_, err = te.sub.Sync(ctx, peerInfo, cid.Undef, nil)
 	require.NoError(t, err)
 
 	// For long enough for the idle cleaner to remove the handler, and check

--- a/dagsync/sync_test.go
+++ b/dagsync/sync_test.go
@@ -113,7 +113,10 @@ func TestSyncFn(t *testing.T) {
 	cids, _ := test.RandomCids(1)
 	ctx, syncncl := context.WithTimeout(context.Background(), updateTimeout)
 	defer syncncl()
-	_, err = sub.Sync(ctx, srcHost.ID(), cids[0], nil, nil)
+	peerInfo := peer.AddrInfo{
+		ID: srcHost.ID(),
+	}
+	_, err = sub.Sync(ctx, peerInfo, cids[0], nil)
 	require.Error(t, err, "expected error when no content to sync")
 	syncncl()
 
@@ -128,7 +131,7 @@ func TestSyncFn(t *testing.T) {
 	// Sync with publisher without publisher publishing to gossipsub channel.
 	ctx, syncncl = context.WithTimeout(context.Background(), updateTimeout)
 	defer syncncl()
-	syncCid, err := sub.Sync(ctx, srcHost.ID(), lnk.(cidlink.Link).Cid, nil, nil)
+	syncCid, err := sub.Sync(ctx, peerInfo, lnk.(cidlink.Link).Cid, nil)
 	require.NoError(t, err)
 
 	if !syncCid.Equals(lnk.(cidlink.Link).Cid) {
@@ -161,7 +164,7 @@ func TestSyncFn(t *testing.T) {
 
 	ctx, syncncl = context.WithTimeout(context.Background(), updateTimeout)
 	defer syncncl()
-	syncCid, err = sub.Sync(ctx, srcHost.ID(), cid.Undef, nil, nil)
+	syncCid, err = sub.Sync(ctx, peerInfo, cid.Undef, nil)
 	require.NoError(t, err)
 
 	if !syncCid.Equals(newHead) {

--- a/internal/ingest/seg_sync_test.go
+++ b/internal/ingest/seg_sync_test.go
@@ -8,6 +8,7 @@ import (
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipni/storetheindex/config"
 	"github.com/ipni/storetheindex/test/typehelpers"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,19 +46,21 @@ func TestAdsSyncedViaSegmentsAreProcessed(t *testing.T) {
 	require.NoError(t, err)
 	mhs := typehelpers.AllMultihashesFromAdLink(t, headAd, te.publisherLinkSys)
 
-	providerID := te.pubHost.ID()
 	subject := te.ingester
 
-	gotHeadAd, err := subject.Sync(ctx, providerID, nil, 0, false)
+	pubInfo := peer.AddrInfo{
+		ID: te.publisher.ID(),
+	}
+	gotHeadAd, err := subject.Sync(ctx, pubInfo, 0, false)
 	require.NoError(t, err)
 	require.Equal(t, headAdCid, gotHeadAd, "Expected latest synced cid to match head of ad chain")
 
 	requireTrueEventually(t, func() bool {
-		return checkAllIndexed(subject.indexer, providerID, mhs) == nil
+		return checkAllIndexed(subject.indexer, pubInfo.ID, mhs) == nil
 	}, testRetryInterval, testRetryTimeout, "Expected all ads from publisher to have been indexed.")
 
 	requireTrueEventually(t, func() bool {
-		latestSync, err := subject.GetLatestSync(providerID)
+		latestSync, err := subject.GetLatestSync(pubInfo.ID)
 		require.NoError(t, err)
 		return latestSync.Equals(headAdCid)
 	}, testRetryInterval, testRetryTimeout, "Expected all ads from publisher to have been indexed.")

--- a/mautil/mautil_test.go
+++ b/mautil/mautil_test.go
@@ -19,12 +19,10 @@ func TestFilterPrivateIPs(t *testing.T) {
 		"/ip4/127.0.0.1/tcp/9999",
 		"/dns4/localhost/tcp/1234",
 	}
-	maddrs := make([]multiaddr.Multiaddr, len(addrs))
-	for i := range addrs {
-		var err error
-		maddrs[i], err = multiaddr.NewMultiaddr(addrs[i])
-		require.NoError(t, err)
-	}
+
+	maddrs, err := mautil.StringsToMultiaddrs(addrs)
+	require.NoError(t, err)
+
 	expected := make([]multiaddr.Multiaddr, 0, 3)
 	expected = append(expected, maddrs[1])
 	expected = append(expected, maddrs[3])
@@ -46,4 +44,27 @@ func TestFilterPrivateIPs_DoesNotPanicOnNilAddr(t *testing.T) {
 	got := mautil.FilterPrivateIPs(original)
 	// According to the function documentation, it should return the original slice.
 	require.Equal(t, original, got)
+}
+
+func TestFindHTTPAddrs(t *testing.T) {
+	addrs := []string{
+		"/ip4/11.0.0.0/tcp/80/http",
+		"/ip6/fc00::/tcp/1717",
+		"/ip6/fe00::/tcp/8080/https",
+		"/dns4/example.net/tcp/1234",
+	}
+	maddrs, err := mautil.StringsToMultiaddrs(addrs)
+	require.NoError(t, err)
+
+	expected := []multiaddr.Multiaddr{maddrs[0], maddrs[2]}
+
+	filtered := mautil.FindHTTPAddrs(maddrs)
+	require.Equal(t, len(expected), len(filtered))
+
+	for i := range filtered {
+		require.Equal(t, expected[i], filtered[i])
+	}
+
+	filtered = mautil.FilterPrivateIPs(nil)
+	require.Nil(t, filtered)
 }

--- a/server/admin/http/handler.go
+++ b/server/admin/http/handler.go
@@ -333,7 +333,11 @@ func (h *adminHandler) handlePostSyncs(w http.ResponseWriter, r *http.Request) {
 	}
 	h.pendingsSyncsPeers[peerID.String()] = struct{}{}
 	go func() {
-		_, err := h.ingester.Sync(h.ctx, peerID, syncAddr, int(depth), resync)
+		peerInfo := peer.AddrInfo{
+			ID:    peerID,
+			Addrs: []multiaddr.Multiaddr{syncAddr},
+		}
+		_, err := h.ingester.Sync(h.ctx, peerInfo, int(depth), resync)
 		if err != nil {
 			msg := "Cannot sync with peer"
 			log.Errorw(msg, "err", err)


### PR DESCRIPTION
## Context
Sync should make use of multiple publisher addresses. Announce messages may contain multiple publisher addresses, and the indexer is only using a single one of these. All should be used. 

Fixes #321

Will also fix this: https://github.com/ipni/index-provider/blob/main/mirror/mirror.go#L236-L238

## Proposed Changes
This changes APIs in a few places to take a peer.AddrInfo instead of a peer.ID and a multiaddr.Multiaddr.

- Updated `ingester.Sync` `dagsync.Subscriber.Sync`, APIs, and `httpsync` and `dtsync` packages to accept multiple publisher addresses

## Tests
- Updated tests to use updated APIs

## Revert Strategy
Has breaking API changes, so reverting should be avoided after other modules depend on this. Otherwise, revert is OK.
