### PR TITLE
Increase ingest workers on inga

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
@@ -74,7 +74,7 @@
     "HttpSyncRetryWaitMax": "30s",
     "HttpSyncRetryWaitMin": "1s",
     "HttpSyncTimeout": "10s",
-    "IngestWorkerCount": 10,
+    "IngestWorkerCount": 15,
     "KeepAdvertisements":true,
     "PubSubTopic": "/indexer/ingest/mainnet",
     "RateLimit": {


### PR DESCRIPTION
Increase number of ingest workers on Inga as dhstore looks underutilised.
