### PR TITLE
Increase inga dhstore timeout to 60s

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
@@ -65,7 +65,7 @@
     "VSNoNewMH": true,
     "DHBatchSize": 5000,
     "DHStoreURL": "http://dhstore.internal.prod.cid.contact",
-    "DHStoreHttpClientTimeout": "30s"
+    "DHStoreHttpClientTimeout": "60s"
   },
   "Ingest": {
     "AdvertisementDepthLimit": 33554432,


### PR DESCRIPTION
Increase timeout to dhstore to see whether it'll provide some breathing room to the database and reduce the number of errors