### PR TITLE
Fix pprof endpoint

### DIFF
--- a/server/admin/http/server.go
+++ b/server/admin/http/server.go
@@ -83,8 +83,8 @@ func New(listen string, id peer.ID, indexer indexer.Interface, ingester *ingest.
 	mux.HandleFunc("/ingest/preferred", h.listPreferredPeers)
 
 	// Metrics routes
-	mux.Handle("/metrics", metrics.Start(append(coremetrics.DefaultViews, coremetrics.PebbleViews...)))
-	mux.Handle("/debug/pprof", pprof.WithProfile())
+	mux.Handle("/metrics/", metrics.Start(append(coremetrics.DefaultViews, coremetrics.PebbleViews...)))
+	mux.Handle("/debug/pprof/", pprof.WithProfile())
 
 	// Config routes
 	mux.HandleFunc("/config/log/level", setLogLevel)


### PR DESCRIPTION
pprof endpoint was broken.  Golang ServeMux requires that the "/" is included for matching anything beyond the `pprof` part of the endpoint.
