### PR TITLE
S3 terraform configuration for prod

### DIFF
--- a/deploy/infrastructure/prod/us-east-2/s3_adstore.tf
+++ b/deploy/infrastructure/prod/us-east-2/s3_adstore.tf
@@ -1,0 +1,45 @@
+resource "aws_s3_bucket" "sti_s3_adstore" {
+  bucket = "${local.environment_name}-sti-adstore"
+}
+
+resource "aws_s3_bucket_acl" "adstore" {
+  bucket = aws_s3_bucket.sti_s3_adstore.id
+  acl    = "private"
+}
+
+data "aws_iam_policy_document" "sti_s3_rw" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      # TODO: Enable if needed.
+      #      "s3:DeleteObject",
+      "s3:ListBucket",
+    ]
+
+    resources = [aws_s3_bucket.sti_s3_adstore.arn, "${aws_s3_bucket.sti_s3_adstore.arn}/*"]
+  }
+}
+
+resource "aws_iam_policy" "sti_s3_rw" {
+  name   = "${local.environment_name}_sti_s3_rw"
+  policy = data.aws_iam_policy_document.sti_s3_rw.json
+}
+
+module "sti_s3_rw_role" {
+  source  = "registry.terraform.io/terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version = "4.17.1"
+
+  create_role = true
+
+  role_name    = "${local.environment_name}_sti_s3_rw"
+  provider_url = module.eks.oidc_provider
+
+  role_policy_arns = [
+    aws_iam_policy.sti_s3_rw.arn
+  ]
+
+  oidc_fully_qualified_subjects = ["system:serviceaccount:storetheindex:storetheindex"]
+}

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
@@ -69,6 +69,17 @@
   },
   "Ingest": {
     "AdvertisementDepthLimit": 33554432,
+    "AdvertisementMirror": {
+      "Read": true,
+      "Write": false,
+      "Compress": "gzip",
+      "Storage": {
+        "Type": "s3",
+        "S3": {
+          "BucketName": "prod-sti-adstore"
+        }
+      }
+    },
     "EntriesDepthLimit": 65536,
     "HttpSyncRetryMax": 4,
     "HttpSyncRetryWaitMax": "30s",

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   template:
     spec:
+      serviceAccountName: storetheindex
       terminationGracePeriodSeconds: 600
       containers:
         - name: indexer

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: storetheindex
 resources:
+- service-account.yaml
 - assigner
 - instances
 - indexstar

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/service-account.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/service-account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: storetheindex
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::407967248065:role/prod_sti_s3_rw"


### PR DESCRIPTION
- Configure terraform to create S3 bucker, bucket ACL, iam policy, iam assumable role, and service account.
- Configure inga pod to use new service account for accessing S3 bucket.
