### PR TITLE
Bump up IngestWorkerCount on inga

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
@@ -74,7 +74,7 @@
     "HttpSyncRetryWaitMax": "30s",
     "HttpSyncRetryWaitMin": "1s",
     "HttpSyncTimeout": "10s",
-    "IngestWorkerCount": 15,
+    "IngestWorkerCount": 20,
     "KeepAdvertisements":true,
     "PubSubTopic": "/indexer/ingest/mainnet",
     "RateLimit": {


### PR DESCRIPTION
Increase `IngestWorkerCount` on inga to bring it on par with the rest pf the cluster. After the last increase of throughput `dhstore` seems to perform well enough to afford some more load.
