### PR TITLE
Use k8s name instead of load balancer for dhfind

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhfind/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhfind/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: storetheindex
 resources:
   - ../../../../../base/dhfind
   - pod-monitor.yaml
+  - service-cluster-ip.yaml
 
 patchesStrategicMerge:
   - deployment.yaml

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhfind/service-cluster-ip.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhfind/service-cluster-ip.yaml
@@ -1,7 +1,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: dhfind
+  name: dhfind-finder
 spec:
   ports:
     - name: http

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhfind/service-cluster-ip.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhfind/service-cluster-ip.yaml
@@ -1,0 +1,13 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: dhfind
+spec:
+  ports:
+    - name: http
+      port: 40080
+      targetPort: http
+  selector:
+    app: dhfind
+  type: ClusterIP
+  clusterIP: None

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhfind/service-cluster-ip.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhfind/service-cluster-ip.yaml
@@ -1,7 +1,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: dhfind-finder
+  name: dhfind-cluster-ip
 spec:
   ports:
     - name: http

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -20,7 +20,7 @@ spec:
             - '--backends=http://cali-indexer:3000/'
             - '--backends=http://ago-indexer:3000/'
             - '--backends=http://dhstore.internal.dev.cid.contact/'
-            - '--backends=http://dhfind-finder:40080/'
+            - '--backends=http://dhfind-cluster-ip:40080/'
             - '--cascadeBackends=http://caskadht.internal.dev.cid.contact/'
             - '--cascadeBackends=http://cassette.internal.dev.cid.contact/'
           env:

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -20,7 +20,7 @@ spec:
             - '--backends=http://cali-indexer:3000/'
             - '--backends=http://ago-indexer:3000/'
             - '--backends=http://dhstore.internal.dev.cid.contact/'
-            - '--backends=http://dhfind:40080/'
+            - '--backends=http://dhfind-finder:40080/'
             - '--cascadeBackends=http://caskadht.internal.dev.cid.contact/'
             - '--cascadeBackends=http://cassette.internal.dev.cid.contact/'
           env:

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -20,7 +20,7 @@ spec:
             - '--backends=http://cali-indexer:3000/'
             - '--backends=http://ago-indexer:3000/'
             - '--backends=http://dhstore.internal.dev.cid.contact/'
-            - '--backends=http://dhfind.internal.dev.cid.contact/'
+            - '--backends=http://dhfind:40080/'
             - '--cascadeBackends=http://caskadht.internal.dev.cid.contact/'
             - '--cascadeBackends=http://cassette.internal.dev.cid.contact/'
           env:


### PR DESCRIPTION
Use k8s name instead of load balancer for dhfind to see whether that would reduce a number of find timeouts in dev