### PR TITLE
Increase worker count in `dhfind` on prod

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind/deployment.yaml
@@ -17,6 +17,7 @@ spec:
             - '--stiAddr=http://inga-indexer:3000/'
             - '--simulation=true'
             - '--simulationChannelSize=2000'
+            - '--simulationWorkerCount=200'
           resources:
             limits:
               cpu: "1.5"


### PR DESCRIPTION
Increase to 200 from the default of 50. The rationale for the change is that dhfind linearly handles requests: all requests are piped into a single channel and picked up by workers. This differs from a regular http server implementation where each request is handled in a goroutine. Considering the current degree of concurrent requests, at around ~1K per second, and the fact that the tasks are wait-heavy increasing the worker count to see impact on round-trip latency from dhfind on prod.

