### PR TITLE
Reduce `indexstar` replica count to decrease racing condition likelihood

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
@@ -13,7 +13,7 @@ patchesStrategicMerge:
 
 replicas:
   - name: indexstar
-    count: 5
+    count: 3
 
 images:
   - name: indexstar


### PR DESCRIPTION
Reduce the number of `indexstar` replicas from 5 to 3 in order to decrease the likelihood of race condition where connections to backend compete with each other to complete.

Each indexstar instance opens up to 100 connections per host. The theory is that having 5 instances relative to the current load of ~1.3K requests per second opens too many connections to the backends and therefore slows down the responses rather than speeding things up.
