### PR TITLE
Reduce dhfind replicas down to 4

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: dhfind
 spec:
-  replicas: 5
+  replicas: 4
   template:
     spec:
       topologySpreadConstraints:


### PR DESCRIPTION
As we now have much better latency situation and no "context deadline exceeded" errors, reducing number of dhfind replicas down to see whether it's going to be enough to maintain the same service level.
