### PR TITLE
Remove unused config items from ago config

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/config.json
@@ -34,8 +34,7 @@
   },
   "Datastore": {
     "Type": "levelds",
-    "Dir": "/data/datastore",
-    "DirAdvertisements": "/addata"
+    "Dir": "/data/datastore"
   },
   "Discovery": {
     "FilterIPs": true,
@@ -78,13 +77,6 @@
         "S3": {
           "BucketName": "dev-sti-adstore"
         }
-      }
-    },
-    "CarMirrorDestination": {
-      "Compress": "gzip",
-      "Type": "s3",
-      "S3": {
-        "BucketName": "dev-sti-adstore"
       }
     },
     "EntriesDepthLimit": 65536,


### PR DESCRIPTION
These things were for previous versions of storetheindex.