### PR TITLE
Fix substitution error for old bash versions and only publish on main

### DIFF
--- a/.github/workflows/ecr-publisher-release.yml
+++ b/.github/workflows/ecr-publisher-release.yml
@@ -7,7 +7,10 @@ name: ECR
 on:
   workflow_dispatch: { }
   push:
-    paths: [ 'version.json' ]
+    paths:
+      - 'version.json'
+    branches:
+      - main
 
 jobs:
   publisher:
@@ -25,7 +28,8 @@ jobs:
       - id: version
         name: Determine Container Tag
         run: |
-          IMAGE_TAG="${$(jq -r .version version.json)#v}"
+          VERSION="$(jq -r .version version.json)"
+          IMAGE_TAG="${VERSION#v}"
           echo "Using image tag: ${IMAGE_TAG}"
           echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
       - name: AWS Login


### PR DESCRIPTION
Use a more verbose syntax for stripping `v` suffix from version file.

Only publish images with concrete tag on merge to main

