### PR TITLE
Temporarily remove dhfind from indexstar in prod

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -19,7 +19,6 @@ spec:
             - '--backends=http://dido-indexer:3000/'
             - '--backends=http://oden-indexer:3000/'
             - '--backends=http://kepa-indexer:3000/'
-            - '--backends=http://dhfind.internal.prod.cid.contact/'
             - '--cascadeBackends=http://caskadht.internal.prod.cid.contact/'
             - '--cascadeBackends=http://cassette.internal.prod.cid.contact/'
           env:


### PR DESCRIPTION
This is needed to give dhstore some breathing room to do compaction and restore LSM tree to healthy state. Just reducing write worker count doesn't seem to be enough as imbalance of LSM tree keeps on growing. 