### PR TITLE
Deploy `heyfil` to dev for better parity with prod environment

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/heyfil/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/heyfil/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: heyfil
+spec:
+  template:
+    spec:
+      containers:
+        - name: heyfil
+          args:
+            - '--httpIndexerEndpoint=https://dev.cid.contact'
+          resources:
+            limits:
+              cpu: "1"
+              memory: 2Gi
+            requests:
+              cpu: "1"
+              memory: 2Gi
+            

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/heyfil/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/heyfil/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - ../../../../../base/heyfil
+  - monitor.yaml
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: heyfil
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/heyfil
+    newTag: 20230331144202-35c74b9b22d1c8f6d23e0533a62083f6bdf911ec

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/heyfil/monitor.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/heyfil/monitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: heyfil
+  labels:
+    app: heyfil
+spec:
+  selector:
+    matchLabels:
+      app: heyfil
+  namespaceSelector:
+    matchNames:
+      - storetheindex
+  podMetricsEndpoints:
+    - path: /metrics
+      port: metrics

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 - snapshots
 - lookout
 - cassette
+- heyfil
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}


### PR DESCRIPTION
Deploy `heyfil` to dev so that we have better parity with prod environment and can better reason about provider counts since heyfil
 makes explicit announcements on behalf of filecoin providers.

