### PR TITLE
Fix typo in `dido` volume snapshot PVC name

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/snapshots/dido-snapshot.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/snapshots/dido-snapshot.yaml
@@ -23,4 +23,4 @@ metadata:
 spec:
   volumeSnapshotClassName: csi-aws-vsc
   source:
-    persistentVolumeClaimName: dido-data
+    persistentVolumeClaimName: dido-data-gp3


### PR DESCRIPTION
The name of the PVC for dido was changed during earlier gp3 experiments.

