### PR TITLE
Fix race during ingester shutdown

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -930,7 +930,11 @@ func (r *Registry) RemoveProvider(ctx context.Context, providerID peer.ID) error
 	if pinfo != nil {
 		// Tell ingester to delete its provider data.
 		pinfo.deleted = true
-		r.syncChan <- pinfo
+		select {
+		case r.syncChan <- pinfo:
+		case <-r.closing:
+			return errors.New("shutdown")
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Ingester needs to wait for autosync goroutine to stop before waiting for pending syncs. Otherwise there can be a concurrent read and write to the pending sync WaitGroup.