### PR TITLE
Deploy latest fixes to inga in prod

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
@@ -34,8 +34,7 @@
   },
   "Datastore": {
     "Type": "levelds",
-    "Dir": "/data/datastore",
-    "DirAdvertisements": "/addata"
+    "Dir": "/data/datastore"
   },
   "Discovery": {
     "FilterIPs": true,

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/kustomization.yaml
@@ -32,4 +32,4 @@ patchesStrategicMerge:
 images:
   - name: storetheindex
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-    newTag: 20230329213257-0e0aa94f8b72c67c1e6255f5572931c2a00f3926
+    newTag: 0.6.0


### PR DESCRIPTION
Inga is configured to save all advertisement data in a separate datastore, and it should not be configured to do this. This PR applies latest fixes and correct the configuration as well.
