### PR TITLE
Increase pvc size on inga

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/pvc_data.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/pvc_data.yaml
@@ -11,5 +11,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 10Gi
+      storage: 20Gi
   storageClassName: gp3


### PR DESCRIPTION
Even though inga is not storing the bulk of indexing data, it is still recording all the advertisements it has processed. Since it is processing all ads for all publishers, this can take considerable space.  The pvc size needs to be expanded.
