### PR TITLE
Manually update infura IPs

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/cassette/config.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/cassette/config.yaml
@@ -31,12 +31,12 @@ metrics:
 bitswap:
   peers:
     # Infura
-    - '/ip4/54.88.122.141/tcp/4001/p2p/QmWboxuLjnFvZMErSbuGLZ3VLxZgWKDBX75AV8sZYacQTV'
-    - '/ip4/54.88.122.141/udp/4001/quic/p2p/QmWboxuLjnFvZMErSbuGLZ3VLxZgWKDBX75AV8sZYacQTV'
-    - '/ip4/18.209.30.79/tcp/4001/p2p/QmUeUGaK7Bs8jgJ55R1rB2nDcsaTLaop7PiZLiYS4so69r'
-    - '/ip4/18.209.30.79/udp/4001/quic/p2p/QmUeUGaK7Bs8jgJ55R1rB2nDcsaTLaop7PiZLiYS4so69r'
-    - '/ip4/3.88.156.226/tcp/4001/p2p/QmY6Fnvi2w5dS6uFQP62GWwPb7S4VQqehx3vZeKTZFHSGh'
-    - '/ip4/3.88.156.226/udp/4001/quic/p2p/QmY6Fnvi2w5dS6uFQP62GWwPb7S4VQqehx3vZeKTZFHSGh'
+    - '/ip4/3.85.133.70/tcp/4001/p2p/QmWboxuLjnFvZMErSbuGLZ3VLxZgWKDBX75AV8sZYacQTV'
+    - '/ip4/3.85.133.70/udp/4001/quic/p2p/QmWboxuLjnFvZMErSbuGLZ3VLxZgWKDBX75AV8sZYacQTV'
+    - '/ip4/54.81.70.99/tcp/4001/p2p/QmUeUGaK7Bs8jgJ55R1rB2nDcsaTLaop7PiZLiYS4so69r'
+    - '/ip4/54.81.70.99/udp/4001/quic/p2p/QmUeUGaK7Bs8jgJ55R1rB2nDcsaTLaop7PiZLiYS4so69r'
+    - '/ip4/35.173.255.127/tcp/4001/p2p/QmY6Fnvi2w5dS6uFQP62GWwPb7S4VQqehx3vZeKTZFHSGh'
+    - '/ip4/35.173.255.127/udp/4001/quic/p2p/QmY6Fnvi2w5dS6uFQP62GWwPb7S4VQqehx3vZeKTZFHSGh'
   maxBroadcastBatchSize: 100
   maxBroadcastBatchWait: 100ms
   fallbackOnWantBlock: true

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/cassette/config.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/cassette/config.yaml
@@ -31,12 +31,12 @@ metrics:
 bitswap:
   peers:
     # Infura
-    - '/ip4/54.88.122.141/tcp/4001/p2p/QmWboxuLjnFvZMErSbuGLZ3VLxZgWKDBX75AV8sZYacQTV'
-    - '/ip4/54.88.122.141/udp/4001/quic/p2p/QmWboxuLjnFvZMErSbuGLZ3VLxZgWKDBX75AV8sZYacQTV'
-    - '/ip4/18.209.30.79/tcp/4001/p2p/QmUeUGaK7Bs8jgJ55R1rB2nDcsaTLaop7PiZLiYS4so69r'
-    - '/ip4/18.209.30.79/udp/4001/quic/p2p/QmUeUGaK7Bs8jgJ55R1rB2nDcsaTLaop7PiZLiYS4so69r'
-    - '/ip4/3.88.156.226/tcp/4001/p2p/QmY6Fnvi2w5dS6uFQP62GWwPb7S4VQqehx3vZeKTZFHSGh'
-    - '/ip4/3.88.156.226/udp/4001/quic/p2p/QmY6Fnvi2w5dS6uFQP62GWwPb7S4VQqehx3vZeKTZFHSGh'
+    - '/ip4/3.85.133.70/tcp/4001/p2p/QmWboxuLjnFvZMErSbuGLZ3VLxZgWKDBX75AV8sZYacQTV'
+    - '/ip4/3.85.133.70/udp/4001/quic/p2p/QmWboxuLjnFvZMErSbuGLZ3VLxZgWKDBX75AV8sZYacQTV'
+    - '/ip4/54.81.70.99/tcp/4001/p2p/QmUeUGaK7Bs8jgJ55R1rB2nDcsaTLaop7PiZLiYS4so69r'
+    - '/ip4/54.81.70.99/udp/4001/quic/p2p/QmUeUGaK7Bs8jgJ55R1rB2nDcsaTLaop7PiZLiYS4so69r'
+    - '/ip4/35.173.255.127/tcp/4001/p2p/QmY6Fnvi2w5dS6uFQP62GWwPb7S4VQqehx3vZeKTZFHSGh'
+    - '/ip4/35.173.255.127/udp/4001/quic/p2p/QmY6Fnvi2w5dS6uFQP62GWwPb7S4VQqehx3vZeKTZFHSGh'
   maxBroadcastBatchSize: 100
   maxBroadcastBatchWait: 100ms
   fallbackOnWantBlock: true


### PR DESCRIPTION
Looks like infura node IPs changed on 1st of April ~2225 UTC. Upon looking up a CID known to be hosted by them, it seems the peer IDs remained the same but the IPs changed. Updating manually.

