### PR TITLE
Add `gp3` storage class with 5K IOPS

### DIFF
--- a/deploy/manifests/prod/us-east-2/cluster/kube-system/gp3-storage-class.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/kube-system/gp3-storage-class.yaml
@@ -1,0 +1,27 @@
+# The cheapest gp3 volume config with 3000 IOPS and 125 MiB/s throughput.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gp3
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: ebs.csi.aws.com
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  type: gp3
+---
+# gp3 volume config with 5000 IOPS and 300 MiB/s throughput.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gp3-iops5k-t300
+provisioner: ebs.csi.aws.com
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  # See: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/parameters.md
+  type: gp3
+  iops: '5000'
+  throughput: '300'
+  allowAutoIOPSPerGBIncrease: 'true'

--- a/deploy/manifests/prod/us-east-2/cluster/kube-system/io2-storage-class.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/kube-system/io2-storage-class.yaml
@@ -34,15 +34,3 @@ parameters:
   type: io2
   iopsPerGB: "5"
   allowAutoIOPSPerGBIncrease: "true"
----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: gp3
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
-provisioner: ebs.csi.aws.com
-allowVolumeExpansion: true
-volumeBindingMode: WaitForFirstConsumer
-parameters:
-  type: gp3

--- a/deploy/manifests/prod/us-east-2/cluster/kube-system/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/kube-system/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 resources:
   - aws-auth.yaml
   - io2-storage-class.yaml
+  - gp3-storage-class.yaml
   - volume-snapshot-class.yaml

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/snapshots/dido-snapshot.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/snapshots/dido-snapshot.yaml
@@ -24,3 +24,12 @@ spec:
   volumeSnapshotClassName: csi-aws-vsc
   source:
     persistentVolumeClaimName: dido-data-gp3
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: dido-20230404
+spec:
+  volumeSnapshotClassName: csi-aws-vsc
+  source:
+    persistentVolumeClaimName: dido-data-gp3

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/snapshots/kepa-snapshot.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/snapshots/kepa-snapshot.yaml
@@ -24,3 +24,12 @@ spec:
   volumeSnapshotClassName: csi-aws-vsc
   source:
     persistentVolumeClaimName: kepa-data
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: kepa-20230404
+spec:
+  volumeSnapshotClassName: csi-aws-vsc
+  source:
+    persistentVolumeClaimName: kepa-data

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/snapshots/oden-snapshot.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/snapshots/oden-snapshot.yaml
@@ -24,3 +24,12 @@ spec:
   volumeSnapshotClassName: csi-aws-vsc
   source:
     persistentVolumeClaimName: oden-data
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: oden-20230404
+spec:
+  volumeSnapshotClassName: csi-aws-vsc
+  source:
+    persistentVolumeClaimName: oden-data


### PR DESCRIPTION
The expropriations on `dido` volume showed that 5K IOPS with 300 MiB/s throughput on `gp3` volume type providers sufficient performance.

Define a storage class with the required IOPS and throughput in order to move production nodes to it.

Instantiate fresh snapshots for nodes as the latest one is 4 days old.

