### PR TITLE
Deploy `caskadht` metrics to `dev` and `prod`

### DIFF
--- a/deploy/manifests/base/caskadht/deployment.yaml
+++ b/deploy/manifests/base/caskadht/deployment.yaml
@@ -20,6 +20,8 @@ spec:
           ports:
             - containerPort: 40080
               name: http
+            - containerPort: 40081
+              name: metrics
           readinessProbe:
             httpGet:
               port: http

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/caskadht/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/caskadht/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: storetheindex
 
 resources:
   - ../../../../../base/caskadht
+  - pod-monitor.yaml
 
 patchesStrategicMerge:
   - deployment.yaml
@@ -24,4 +25,4 @@ configMapGenerator:
 images:
   - name: caskadht
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/caskadht
-    newTag: 20230321141253-e9d4c3feeff161010a03c8fabefd98db3879b87f
+    newTag: 20230404114739-a011dbc65023bfa0a2464fe0b72dc923272224ca

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/caskadht/pod-monitor.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/caskadht/pod-monitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: caskadht
+  labels:
+    app: caskadht
+spec:
+  selector:
+    matchLabels:
+      app: caskadht
+  namespaceSelector:
+    matchNames:
+      - storetheindex
+  podMetricsEndpoints:
+    - path: /metrics
+      port: metrics

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/caskadht/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/caskadht/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: storetheindex
 
 resources:
   - ../../../../../base/caskadht
+  - pod-monitor.yaml
 
 patchesStrategicMerge:
   - deployment.yaml
@@ -28,4 +29,4 @@ replicas:
 images:
   - name: caskadht
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/caskadht
-    newTag: 20230321141253-e9d4c3feeff161010a03c8fabefd98db3879b87f
+    newTag: 20230404114739-a011dbc65023bfa0a2464fe0b72dc923272224ca

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/caskadht/pod-monitor.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/caskadht/pod-monitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: caskadht
+  labels:
+    app: caskadht
+spec:
+  selector:
+    matchLabels:
+      app: caskadht
+  namespaceSelector:
+    matchNames:
+      - storetheindex
+  podMetricsEndpoints:
+    - path: /metrics
+      port: metrics


### PR DESCRIPTION
Roll out metrics for cascade over DHT on dev and prod.

See:
 - https://github.com/ipni/caskadht/pull/31
