### PR TITLE
Switch `kepa` to `gp3` volume type

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kepa/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kepa/deployment.yaml
@@ -34,7 +34,7 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: kepa-data
+            claimName: kepa-data-gp3
       tolerations:
         - key: dedicated
           operator: Equal

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kepa/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kepa/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ingress.yaml
   - dido-snapshot.yaml
   - pvc.yaml
+  - pvc-gp3.yaml
 
 namePrefix: kepa-
 

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kepa/pvc-gp3.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kepa/pvc-gp3.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: indexer-single
+    app.kubernetes.io/managed-by: kustomization
+    app.kubernetes.io/part-of: storetheindex
+  name: data-gp3
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Ti
+  dataSource:
+    name: kepa-20230404
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+  storageClassName: gp3-iops5k-t300


### PR DESCRIPTION
Switch `kepa` to the new `gp3` volume storage class with 5K IOPS and 300 MiB/s throughput disk.

Note that the existing `io2` volume used by `kepa` is left to remain in order to retrain the ability to revert changes should he change becomes problematic.

Later PRs will delete the `io2` volume once the new volume shows sufficient performance.

