### PR TITLE
Fix a bug with autosync mutex

### DIFF
--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -818,12 +818,13 @@ func (ing *Ingester) autoSync() {
 
 		autoSyncMutex.Lock()
 		_, already := autoSyncInProgress[provInfo.AddrInfo.ID]
-		autoSyncMutex.Unlock()
 		if already {
 			log.Infow("Auto-sync already in progress", "provider", provInfo.AddrInfo.ID)
+			autoSyncMutex.Unlock()
 			continue
 		}
 		autoSyncInProgress[provInfo.AddrInfo.ID] = struct{}{}
+		autoSyncMutex.Unlock()
 
 		if stopCid := provInfo.StopCid(); stopCid != cid.Undef {
 			err := ing.markAdProcessed(provInfo.Publisher, stopCid, false, false)


### PR DESCRIPTION
This PR fixes a concurrency bug that might have caused deadlock in inga as the map in the context was updated outside of the lock