### PR TITLE
Remove `kepa` `io2` volume and move `oden` to `gp3`

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kepa/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kepa/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
   - ../../../../../../base/storetheindex-single
   - ingress.yaml
   - dido-snapshot.yaml
-  - pvc.yaml
   - pvc-gp3.yaml
 
 namePrefix: kepa-

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: oden-data
+            claimName: oden-data-gp3
       tolerations:
         - key: dedicated
           operator: Equal

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ../../../../../../base/storetheindex-single
   - ingress.yaml
   - pvc.yaml
+  - pvc-gp3.yaml
 
 namePrefix: oden-
 

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/pvc-gp3.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/pvc-gp3.yaml
@@ -5,7 +5,7 @@ metadata:
     app: indexer-single
     app.kubernetes.io/managed-by: kustomization
     app.kubernetes.io/part-of: storetheindex
-  name: data
+  name: data-gp3
 spec:
   accessModes:
     - ReadWriteOnce
@@ -13,8 +13,7 @@ spec:
     requests:
       storage: 10Ti
   dataSource:
-    name: kepa-dido-021122
+    name: oden-20230404
     kind: VolumeSnapshot
     apiGroup: snapshot.storage.k8s.io
-  storageClassName: io2
-
+  storageClassName: gp3-iops5k-t300


### PR DESCRIPTION
After a day or so, `kepa` seems to be doing fine on `gp3` volume. Remove its old `io2` volume that is no longer in use.

Move `oden` to `gp3` volume.

