### PR TITLE
Deploy latest to ago

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/kustomization.yaml
@@ -27,3 +27,8 @@ configMapGenerator:
 
 patchesStrategicMerge:
   - deployment.yaml
+  
+images:
+  - name: storetheindex
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
+    newTag: 20230404173143-f10b6be3b8b746bf51bffdcf71fae07e21654a55


### PR DESCRIPTION
Ago now has encountered the same deadlock as inga. Check whether the latest fix resolves it.

Ingest rate at zero
![image](https://user-images.githubusercontent.com/31857042/230089997-2754acef-5579-4de5-afc0-1a68415d03b0.png)

Large queue
![image](https://user-images.githubusercontent.com/31857042/230090104-799751fd-3709-402e-941c-eabb8b836020.png)

No retrieving any ads
![image](https://user-images.githubusercontent.com/31857042/230090218-23af906d-6dc8-449d-9a0a-41ef2453ef30.png)
