### PR TITLE
Snapshot `dhstore` in `dev` and delete old snapshots

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/snapshots/dhstore-snapshot.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/snapshots/dhstore-snapshot.yaml
@@ -1,0 +1,8 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: dhstore-20230406
+spec:
+  volumeSnapshotClassName: csi-aws-vsc
+  source:
+    persistentVolumeClaimName: dhstore-data

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/snapshots/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/snapshots/kustomization.yaml
@@ -6,3 +6,4 @@ namespace: storetheindex
 resources:
   - ber-snapshot.yaml
   - cali-snapshot.yaml
+  - dhstore-snapshot.yaml

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/snapshots/dido-snapshot.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/snapshots/dido-snapshot.yaml
@@ -1,29 +1,11 @@
 apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:
-  name: dido-20221207
-spec:
-  volumeSnapshotClassName: csi-aws-vsc
-  source:
-    persistentVolumeClaimName: dido-data
----
-apiVersion: snapshot.storage.k8s.io/v1
-kind: VolumeSnapshot
-metadata:
   name: dido-20230213
 spec:
   volumeSnapshotClassName: csi-aws-vsc
   source:
     persistentVolumeClaimName: dido-data
----
-apiVersion: snapshot.storage.k8s.io/v1
-kind: VolumeSnapshot
-metadata:
-  name: dido-20230331
-spec:
-  volumeSnapshotClassName: csi-aws-vsc
-  source:
-    persistentVolumeClaimName: dido-data-gp3
 ---
 apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshot

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/snapshots/kepa-snapshot.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/snapshots/kepa-snapshot.yaml
@@ -1,24 +1,6 @@
 apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:
-  name: kepa-20221207
-spec:
-  volumeSnapshotClassName: csi-aws-vsc
-  source:
-    persistentVolumeClaimName: kepa-data
----
-apiVersion: snapshot.storage.k8s.io/v1
-kind: VolumeSnapshot
-metadata:
-  name: kepa-20230213
-spec:
-  volumeSnapshotClassName: csi-aws-vsc
-  source:
-    persistentVolumeClaimName: kepa-data
----
-apiVersion: snapshot.storage.k8s.io/v1
-kind: VolumeSnapshot
-metadata:
   name: kepa-20230331
 spec:
   volumeSnapshotClassName: csi-aws-vsc

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/snapshots/oden-snapshot.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/snapshots/oden-snapshot.yaml
@@ -1,24 +1,6 @@
 apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:
-  name: oden-20221207
-spec:
-  volumeSnapshotClassName: csi-aws-vsc
-  source:
-    persistentVolumeClaimName: oden-data
----
-apiVersion: snapshot.storage.k8s.io/v1
-kind: VolumeSnapshot
-metadata:
-  name: oden-20230213
-spec:
-  volumeSnapshotClassName: csi-aws-vsc
-  source:
-    persistentVolumeClaimName: oden-data
----
-apiVersion: snapshot.storage.k8s.io/v1
-kind: VolumeSnapshot
-metadata:
   name: oden-20230331
 spec:
   volumeSnapshotClassName: csi-aws-vsc


### PR DESCRIPTION
Snapshot `dhstore` volume in `dev` in order to move it off `io2` and onto `gp3` volume.

Delete old unused snapshots in `prod`.

