### PR TITLE
Remove `dido` version override

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/kustomization.yaml
@@ -27,8 +27,3 @@ configMapGenerator:
 
 patchesStrategicMerge:
   - deployment.yaml
-
-images:
-  - name: storetheindex
-    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-    newTag: 20230321184158-a0bbd92d687482d37953d66422e5b173654f7ad3


### PR DESCRIPTION
Seems to be redundant, which should roll out newer tagged version.
