### PR TITLE
Move `dhstore` in dev to `gp3`

### DIFF
--- a/deploy/manifests/dev/us-east-2/cluster/kube-system/gp3-storage-class.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kube-system/gp3-storage-class.yaml
@@ -1,0 +1,27 @@
+# The cheapest gp3 volume config with 3000 IOPS and 125 MiB/s throughput.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gp3
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: ebs.csi.aws.com
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  type: gp3
+---
+# gp3 volume config with 5000 IOPS and 300 MiB/s throughput.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gp3-iops5k-t300
+provisioner: ebs.csi.aws.com
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  # See: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/parameters.md
+  type: gp3
+  iops: '5000'
+  throughput: '300'
+  allowAutoIOPSPerGBIncrease: 'true'

--- a/deploy/manifests/dev/us-east-2/cluster/kube-system/io2-storage-class.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kube-system/io2-storage-class.yaml
@@ -34,15 +34,3 @@ parameters:
   type: io2
   iopsPerGB: "3"
   allowAutoIOPSPerGBIncrease: "true"
----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: gp3
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
-provisioner: ebs.csi.aws.com
-allowVolumeExpansion: true
-volumeBindingMode: WaitForFirstConsumer
-parameters:
-  type: gp3

--- a/deploy/manifests/dev/us-east-2/cluster/kube-system/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kube-system/kustomization.yaml
@@ -6,4 +6,5 @@ namespace: kube-system
 resources:
   - aws-auth.yaml
   - io2-storage-class.yaml
+  - gp3-storage-class.yaml
   - volume-snapshot-class.yaml

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore/deployment.yaml
@@ -43,7 +43,7 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: dhstore-data
+            claimName: dhstore-data-gp3
       tolerations:
         - key: dedicated
           operator: Equal

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - pvc.yaml
   - internal-service.yaml
   - pod-monitor.yaml
+  - pvc-gp3.yaml
 
 patchesStrategicMerge:
   - deployment.yaml

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore/pvc-gp3.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore/pvc-gp3.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dhstore-data-gp3
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Ti
+  dataSource:
+    name: dhstore-20230406
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+  storageClassName: gp3-iops5k-t300


### PR DESCRIPTION
Define `gp3` storage class in `dev` to match `prod` and move `dhstore` to it.

The current `dhstore` `io2` volume to be removed once we confirm the new volume works as expected.
