### PR TITLE
Need to skip already processed ads

### DIFF
--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -1171,6 +1171,14 @@ func (ing *Ingester) ingestWorkerLogic(ctx context.Context, provider peer.ID, as
 			return
 		}
 
+		processed, _ := ing.adAlreadyProcessed(ai.cid)
+		if processed {
+			log.Infow("Skipping advertisement that has already been processed",
+				"adCid", ai.cid,
+				"progress", fmt.Sprintf("%d of %d", count, total))
+			continue
+		}
+
 		// If this ad is skipped because it gets deleted later in the chain,
 		// then mark this ad as processed.
 		if ai.skip {


### PR DESCRIPTION
## Context
When processing an ad chain takes a long time, another announce or manual sync can cause an overlapped processing of the chain. Overlapped processing may lead to reingesting already ingested ads.  If an ad has already been processed, then do not ingest it again.

In the future, we may need to make fetching ad chains wait until any previous chain from the same publisher has been completely processed. See #1553 
