### PR TITLE
Destroy now redundant `r5b` node groups on `prod`

### DIFF
--- a/deploy/infrastructure/prod/us-east-2/eks.tf
+++ b/deploy/infrastructure/prod/us-east-2/eks.tf
@@ -73,38 +73,6 @@ module "eks" {
       instance_types = ["m4.xlarge"]
     }
 
-    # Supports high IOPS via io2 Block Express EBS volume types with specific taint.
-    # See:
-    #  - https://aws.amazon.com/ec2/instance-types/#Memory_Optimized
-    #  - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html#solid-state-drives
-    prod-ue2a-r5b-4xl = {
-      min_size       = 1
-      max_size       = 4
-      desired_size   = 1
-      instance_types = ["r5b.4xlarge"]
-      subnet_ids     = [data.aws_subnet.ue2a1.id]
-      taints         = {
-        dedicated = {
-          key    = "dedicated"
-          value  = "r5b-4xl"
-          effect = "NO_SCHEDULE"
-        }
-      }
-    }
-    prod-ue2b-r5b-4xl = {
-      min_size       = 1
-      max_size       = 5
-      desired_size   = 1
-      instance_types = ["r5b.4xlarge"]
-      subnet_ids     = [data.aws_subnet.ue2b1.id]
-      taints         = {
-        dedicated = {
-          key    = "dedicated"
-          value  = "r5b-4xl"
-          effect = "NO_SCHEDULE"
-        }
-      }
-    }
     prod-ue2a-c6a-8xl-2 = {
       min_size       = 0
       max_size       = 5

--- a/deploy/manifests/prod/us-east-2/cluster/aws-ebs-csi-driver/patch.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/aws-ebs-csi-driver/patch.yaml
@@ -17,5 +17,5 @@ spec:
     spec:
       tolerations:
         # Override default tolerations to allow all tains. Otherwise, the daemonset pods will not
-        # run on nodes with specific taints; more specifically, r5b nodegroup with "dedicated" taint.
+        # run on nodes with specific taints; more specifically, nodegroups with "dedicated" taint.
         - operator: Exists

--- a/deploy/manifests/prod/us-east-2/cluster/kube-system/aws-auth.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/kube-system/aws-auth.yaml
@@ -28,16 +28,6 @@ data:
     - groups:
       - system:bootstrappers
       - system:nodes
-      rolearn: arn:aws:iam::407967248065:role/prod-ue2a-r5b-4xl-eks-node-group
-      username: system:node:{{EC2PrivateDNSName}}
-    - groups:
-      - system:bootstrappers
-      - system:nodes
-      rolearn: arn:aws:iam::407967248065:role/prod-ue2b-r5b-4xl-eks-node-group
-      username: system:node:{{EC2PrivateDNSName}}
-    - groups:
-      - system:bootstrappers
-      - system:nodes
       rolearn: arn:aws:iam::407967248065:role/prod-ue2a-c6a-8xl-eks-node-group
       username: system:node:{{EC2PrivateDNSName}}
     - groups:


### PR DESCRIPTION
Now that all volumes are moved to `gp3` there is no need for instance types that support `io2` BlockExpress. Destroy them.

Fixes #1039

