### PR TITLE
Fix deadlock with manual sync

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/cockroachdb/pebble v0.0.0-20220726144858-a78491c0086f
 	github.com/filecoin-project/go-address v0.0.5
 	github.com/filecoin-project/go-dagaggregator-unixfs v0.3.0
+	github.com/gammazero/channelqueue v0.2.1
 	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-datastore v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -257,6 +257,8 @@ github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0X
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
+github.com/gammazero/channelqueue v0.2.1 h1:AcK6wnLrj8koTTn3RxjRCyfmS677TjhIZb1FSMi14qc=
+github.com/gammazero/channelqueue v0.2.1/go.mod h1:824o5HHE+yO1xokh36BIuSv8YWwXW0364ku91eRMFS4=
 github.com/gammazero/deque v0.2.1 h1:qSdsbG6pgp6nL7A0+K/B7s12mcCY/5l5SIUpMOl+dC0=
 github.com/gammazero/deque v0.2.1/go.mod h1:LFroj8x4cMYCukHJDbxFCkT+r9AndaJnFMuZDV34tuU=
 github.com/gammazero/keymutex v0.1.0 h1:9Qz6/dUQ+eEdHa8vq8uCR3o8S9OOFvIWJ8EOBB6PycQ=


### PR DESCRIPTION
## Context
A manual sync creates a channel that `adProcessed` events are written to. If multiple events are written to that channel before it is read, this can cause workers to block waiting to write to that channel. If workers are blocked, they will not read SyncFinished events. If SyncFinished events are not read, then dagsync syncs will not complete. When this happens the original manual sync may not finish and the channel will not be read, thereby entering a deadlocked state.

## Proposed Changes
Fixed this by having manual syncs create a channel that cannot fill up and block. This will also help prevent blocking other workers that trying to write adProcessed events.

## Tests
Manual in dev

## Revert Strategy
Change is safe to revert.