### PR TITLE
Add counter metrics for remove ads and non-remove ads

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -644,7 +644,6 @@ func reloadConfig(cfgPath string, ingester *ingest.Ingester, reg *registry.Regis
 		if err != nil {
 			return nil, fmt.Errorf("failed to set rate limit config: %w", err)
 		}
-		ingester.SetBatchSize(cfg.Ingest.StoreBatchSize)
 		ingester.RunWorkers(cfg.Ingest.IngestWorkerCount)
 	}
 

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -61,11 +61,6 @@ type Ingest struct {
 	// the announce so that other indexers can also receive it. This is always
 	// false if configured to use an assigner.
 	ResendDirectAnnounce bool
-	// StoreBatchSize is the number of entries in each write to the value
-	// store. Specifying a value less than 2 disables batching. This should be
-	// smaller than the maximum number of multihashes in an entry block to
-	// write concurrently to the value store.
-	StoreBatchSize int
 	// SyncSegmentDepthLimit is the depth limit of a single sync in a series of
 	// calls that collectively sync advertisements or their entries. The value
 	// -1 disables the segmentation where the sync will be done in a single call
@@ -134,7 +129,6 @@ func NewIngest() Ingest {
 		IngestWorkerCount:     10,
 		PubSubTopic:           "/indexer/ingest/mainnet",
 		RateLimit:             NewRateLimit(),
-		StoreBatchSize:        4096,
 		SyncSegmentDepthLimit: 2_000,
 		SyncTimeout:           Duration(2 * time.Hour),
 	}
@@ -172,9 +166,6 @@ func (c *Ingest) populateUnset() {
 		c.PubSubTopic = def.PubSubTopic
 	}
 	c.RateLimit.populateUnset()
-	if c.StoreBatchSize == 0 {
-		c.StoreBatchSize = def.StoreBatchSize
-	}
 	if c.SyncSegmentDepthLimit == 0 {
 		c.SyncSegmentDepthLimit = def.SyncSegmentDepthLimit
 	}

--- a/doc/config.md
+++ b/doc/config.md
@@ -111,7 +111,6 @@ config file at runtime.
       "BurstSize": 500
     },
     "ResendDirectAnnounce": true,
-    "StoreBatchSize": 4096,
     "SyncSegmentDepthLimit": 2000,
     "SyncTimeout": "2h0m0s"
   },
@@ -275,7 +274,6 @@ Default:
   "PubSubTopic": "/indexer/ingest/mainnet",
   "RateLimit": {},
   "ResendDirectAnnounce": false,
-  "StoreBatchSize": 4096,
   "SyncSegmentDepthLimit": 2000,
   "SyncTimeout": "2h0m0s"
 }
@@ -329,6 +327,5 @@ The storetheindex daemon can reload some portions of its config without restarti
 - [`Indexer.ShutdownTimeout`](#indexer)
 - [`Ingest.IngestWorkerCount`](#ingest)
 - [`Ingest.RateLimit`](#ingestratelimit)
-- [`Ingest.StoreBatchSize`](#ingest)
 - [`Logging`](#logging)
 - [`Peering`](#peering)

--- a/internal/counter/index_counts.go
+++ b/internal/counter/index_counts.go
@@ -55,8 +55,8 @@ func (c *IndexCounts) SetTotalAddend(totalAddend uint64) {
 	c.mutex.Unlock()
 }
 
-// AddCount adds the index count to the existing count for the for the
-// provider's context iD, and updates in-memory totals.
+// AddCount adds the index count to the existing count for the
+// provider's context ID, and updates in-memory totals.
 func (c *IndexCounts) AddCount(providerID peer.ID, contextID []byte, count uint64) {
 	if count == 0 {
 		return

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -65,7 +65,6 @@ var (
 			BlocksPerSecond: 100,
 			BurstSize:       1000,
 		},
-		StoreBatchSize:        256,
 		SyncTimeout:           config.Duration(time.Minute),
 		SyncSegmentDepthLimit: 1, // By default run all tests using segmented sync.
 	}

--- a/internal/metrics/server.go
+++ b/internal/metrics/server.go
@@ -36,6 +36,8 @@ var (
 	EntriesSyncLatency   = stats.Float64("ingest/entriessynclatency", "How long it took to sync an Ad's entries", stats.UnitMilliseconds)
 	IndexCount           = stats.Int64("provider/indexCount", "Number of indexes stored for all providers", stats.UnitDimensionless)
 	PercentUsage         = stats.Float64("ingest/percentusage", "Percent usage of storage available in value store", stats.UnitDimensionless)
+	NonRemoveAdCount     = stats.Int64("ingest/nonremoveadcount", "Number of non-removal advertisements", stats.UnitDimensionless)
+	RemoveAdCount        = stats.Int64("ingest/removeadcount", "Number of removal advertisements", stats.UnitDimensionless)
 )
 
 // Views
@@ -99,6 +101,14 @@ var (
 		Measure:     PercentUsage,
 		Aggregation: view.LastValue(),
 	}
+	nonRemoveAdCountView = &view.View{
+		Measure:     NonRemoveAdCount,
+		Aggregation: view.LastValue(),
+	}
+	removeAdCountView = &view.View{
+		Measure:     RemoveAdCount,
+		Aggregation: view.LastValue(),
+	}
 )
 
 var log = logging.Logger("indexer/metrics")
@@ -121,6 +131,8 @@ func Start(views []*view.View) http.Handler {
 		adLoadError,
 		indexCountView,
 		percentUsageView,
+		nonRemoveAdCountView,
+		removeAdCountView,
 	)
 	if err != nil {
 		log.Errorf("cannot register metrics default views: %s", err)


### PR DESCRIPTION
Track remove and non-remove advertisement counts over indered process lifetime.

- Removed StoreBatchSize config since it is only used for HAMT batching and does not need to be configurable.
- Use atomic.Int64 values instead of operating on int64 with atomic.Int64X functions.

Addresses #1590 
