### PR TITLE
Increase Saturn Lassie event recorder db size

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/saturn-lassie-event-recorder.tf
+++ b/deploy/infrastructure/dev/us-east-2/saturn-lassie-event-recorder.tf
@@ -20,7 +20,7 @@ module "saturn_lassie_events_db" {
   major_engine_version = "14"
   instance_class       = "db.m5.large"
 
-  allocated_storage   = 1000
+  allocated_storage   = 1500
   skip_final_snapshot = true
   db_name             = "SaturnLassieEvents"
   username            = "postgres"


### PR DESCRIPTION
It is full; increase to 1.5K GiB.

