### PR TITLE
Add canary indexstar in prod

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar-canary/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar-canary/deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: indexstar
+spec:
+  selector:
+    matchLabels:
+      app: indexstar-canary
+  template:
+    metadata:
+      labels:
+        app: indexstar-canary
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+      containers:
+        - name: indexstar
+          args:
+            - '--translateReframe'
+            - '--translateNonStreaming'
+            # Use service names local to the namespace over HTTP to avoid
+            # TLS handshake overhead.
+            - '--backends=http://dido-indexer:3000/'
+            - '--backends=http://oden-indexer:3000/'
+            - '--backends=http://kepa-indexer:3000/'
+            - '--backends=http://dhfind.internal.prod.cid.contact/'
+            - '--cascadeBackends=http://caskadht.internal.prod.cid.contact/'
+            - '--cascadeBackends=http://cassette.internal.prod.cid.contact/'
+          env:
+            # Increase maximum accepted request body to 1 MiB in order to allow batch finds requests
+            # by the `provider verify-ingest` CLI command. 
+            - name: SERVER_MAX_REQUEST_BODY_SIZE
+              value: '1048576'
+            # The service provided by caskadht.
+            - name: SERVER_CASCADE_LABELS
+              value: 'ipfs-dht,legacy'
+            - name: SERVER_HTTP_CLIENT_TIMEOUT
+              value: '30s'
+            - name: SERVER_RESULT_MAX_WAIT
+              value: '2s'
+            - name: SERVER_RESULT_STREAM_MAX_WAIT
+              value: '30s'
+          resources:
+            limits:
+              cpu: "3"
+              memory: 2Gi
+            requests:
+              cpu: "3"
+              memory: 2Gi

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar-canary/ingress.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar-canary/ingress.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: indexstar
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-weight: "33"
+spec:
+  tls:
+    - hosts:
+        - indexstar.prod.cid.contact
+      secretName: indexstar-ingress-tls
+  rules:
+    - host: indexstar.prod.cid.contact
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: indexstar
+                port:
+                  number: 8080

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar-canary/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar-canary/kustomization.yaml
@@ -6,14 +6,27 @@ namespace: storetheindex
 resources:
   - ../../../../../base/indexstar
   - ingress.yaml
-  - pod-monitor.yaml
+
+nameSuffix: -canary
 
 patchesStrategicMerge:
   - deployment.yaml
+  - service.yaml
+  - pdb.yaml
+
+
+patches:
+  - patch: |-
+      - op: replace
+        path: /metadata/labels/app
+        value: indexstar-canary
+  
+    target:
+      labelSelector: app=indexstar
 
 replicas:
   - name: indexstar
-    count: 2
+    count: 1
 
 images:
   - name: indexstar

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar-canary/pdb.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar-canary/pdb.yaml
@@ -1,0 +1,8 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: indexstar
+spec:
+  selector:
+    matchLabels:
+      app: indexstar-canary

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar-canary/service.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar-canary/service.yaml
@@ -1,0 +1,8 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: indexstar
+spec:
+  selector:
+    app: indexstar-canary
+  

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - assigner
 - instances
 - indexstar
+- indexstar-canary
 - heyfil
 - snapshots
 - caskadht


### PR DESCRIPTION
Enable indexstar-canary in prod that will take 33% of the traffic and includes dhfind as one of the backends