### PR TITLE
Bump up dhfind machine spec in prod

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind/deployment.yaml
@@ -20,8 +20,8 @@ spec:
             - '--simulationWorkerCount=200'
           resources:
             limits:
-              cpu: "1.5"
-              memory: 1Gi
+              cpu: "2"
+              memory: 1.5Gi
             requests:
-              cpu: "1.5"
-              memory: 1Gi
+              cpu: "2"
+              memory: 1.5Gi


### PR DESCRIPTION
Bump up dhfind machine spec in prod to see whether that would help to improve parallelism / performance. 

By the look of it, dhfind's memory utilisation keeps climbing up which means that it's has large waiting queues. 

![image](https://user-images.githubusercontent.com/31857042/234346050-c7d0703a-73ae-44e5-818a-5126712dc213.png)
