### PR TITLE
Adjust concurrency in prod dhfind

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind/deployment.yaml
@@ -17,7 +17,7 @@ spec:
             - '--stiAddr=http://inga-indexer:3000/'
             - '--simulation=true'
             - '--simulationChannelSize=2000'
-            - '--simulationWorkerCount=200'
+            - '--simulationWorkerCount=100'
           resources:
             limits:
               cpu: "2"


### PR DESCRIPTION
* cid.contact receives about 24k requests per second
* 6k of them hit dhfind (25%), split across 5 instances - 1.2k per instance
* p99 for processing a find request is 72ms, so a single goroutine can process around 12 of them per second
* 100 coroutines should be enough to cope with that load
* see whether reducing concurrency would improve throughput
