### PR TITLE
Reduce canary traffic to 10 percent in prod

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar-canary/ingress.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar-canary/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     cert-manager.io/cluster-issuer: "letsencrypt"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/canary: "true"
-    nginx.ingress.kubernetes.io/canary-weight: "25"
+    nginx.ingress.kubernetes.io/canary-weight: "10"
 spec:
   tls:
     - hosts:


### PR DESCRIPTION
Trying to find a sweet spot so that latency percentiles are unaffected