### PR TITLE
Further reduce canary traffic in prod

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar-canary/ingress.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar-canary/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     cert-manager.io/cluster-issuer: "letsencrypt"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/canary: "true"
-    nginx.ingress.kubernetes.io/canary-weight: "10"
+    nginx.ingress.kubernetes.io/canary-weight: "5"
 spec:
   tls:
     - hosts:


### PR DESCRIPTION
Further reducing canary traffic in prod to be safe overnight before it's clear what causing performance issues.
