### PR TITLE
Overwrite CAR in mirror on resync

### DIFF
--- a/carstore/carreader_test.go
+++ b/carstore/carreader_test.go
@@ -31,7 +31,7 @@ func TestRead(t *testing.T) {
 	ctx := context.Background()
 
 	// Create car file
-	_, err = carw.Write(ctx, adCid, false)
+	_, err = carw.Write(ctx, adCid, false, true)
 	require.NoError(t, err)
 
 	// Create reader.

--- a/carstore/carwriter.go
+++ b/carstore/carwriter.go
@@ -405,14 +405,6 @@ func decodeIPLDNode(r io.Reader, codec uint64, prototype ipld.NodePrototype) (ip
 	return nb.Build(), nil
 }
 
-// isAdvertisement checks if an IPLD node is an advertisement, by looking to
-// see if it has a "Signature" field. Additional checks may be needed if the
-// schema is extended with new types that are traversable.
-func isAdvertisement(node ipld.Node) bool {
-	indexID, _ := node.LookupByString("Signature")
-	return indexID != nil
-}
-
 // isHAMT checks if the given IPLD node is a HAMT root node by looking for a
 // field named "hamt".
 //

--- a/carstore/carwriter.go
+++ b/carstore/carwriter.go
@@ -116,6 +116,8 @@ func (cw *CarWriter) write(ctx context.Context, adCid cid.Cid, ad schema.Adverti
 		}
 		// OK, car file does not exist.
 	} else if !overWrite {
+		// If overWrite is false then only do datastore cleanup without
+		// overwriting car file.
 		if err = cw.removeAdData(roots); err != nil {
 			log.Errorw("Cannot remove advertisement data from datastore", "err", err)
 		}

--- a/carstore/carwriter_test.go
+++ b/carstore/carwriter_test.go
@@ -60,7 +60,7 @@ func TestWrite(t *testing.T) {
 	require.True(t, ok)
 
 	// Test that car file is created.
-	carInfo, err := carw.Write(ctx, adCid, false)
+	carInfo, err := carw.Write(ctx, adCid, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, carInfo)
 	headInfo, err := fileStore.Head(ctx, carInfo.Path)
@@ -178,7 +178,7 @@ func TestWriteToExistingAdCar(t *testing.T) {
 	carw, err := carstore.NewWriter(dstore, fileStore, carstore.WithCompress(testCompress))
 	require.NoError(t, err)
 
-	carInfo, err := carw.Write(ctx, adCid, false)
+	carInfo, err := carw.Write(ctx, adCid, false, false)
 	require.ErrorIs(t, err, fs.ErrExist)
 	require.Zero(t, carInfo.Size)
 
@@ -214,7 +214,7 @@ func TestWriteChain(t *testing.T) {
 
 	ctx := context.Background()
 
-	count, err := carw.WriteChain(ctx, adCid2)
+	count, err := carw.WriteChain(ctx, adCid2, false)
 	require.NoError(t, err)
 	require.Equal(t, 2, count)
 

--- a/carstore/carwriter_test.go
+++ b/carstore/carwriter_test.go
@@ -229,58 +229,6 @@ func TestWriteChain(t *testing.T) {
 	require.Equal(t, 2, len(infos))
 }
 
-func TestWriteExistingAdsInStore(t *testing.T) {
-	const entBlockCount = 5
-
-	dstore := datastore.NewMapDatastore()
-	metadata := []byte("car-test-metadata")
-
-	adCid, ad, _, _, _ := storeRandomIndexAndAd(t, entBlockCount, metadata, nil, dstore)
-	entriesCid := ad.Entries.(cidlink.Link).Cid
-
-	ctx := context.Background()
-
-	// Check that datastore has ad and entries CID before reading to car.
-	ok, err := dstore.Has(ctx, datastore.NewKey(adCid.String()))
-	require.NoError(t, err)
-	require.True(t, ok)
-	ok, err = dstore.Has(ctx, datastore.NewKey(entriesCid.String()))
-	require.NoError(t, err)
-	require.True(t, ok)
-
-	carDir := t.TempDir()
-	fileStore, err := filestore.NewLocal(carDir)
-	require.NoError(t, err)
-
-	carw, err := carstore.NewWriter(dstore, fileStore, carstore.WithCompress(testCompress))
-	require.NoError(t, err)
-
-	err = carw.WriteExisting(ctx)
-	require.NoError(t, err)
-
-	carName := adCid.String() + carstore.CarFileSuffix
-	if carw.Compression() == carstore.Gzip {
-		carName += carstore.GzipFileSuffix
-	}
-	var carFound bool
-	fc, ec := fileStore.List(ctx, "", false)
-	for fileInfo := range fc {
-		require.Equal(t, carName, fileInfo.Path, "unexpected file")
-		carFound = true
-	}
-	err = <-ec
-	require.NoError(t, err)
-	require.True(t, carFound)
-
-	// Check that ad and entries block are no longer in datastore.
-	ok, err = dstore.Has(ctx, datastore.NewKey(adCid.String()))
-	require.NoError(t, err)
-	require.False(t, ok)
-	ok, err = dstore.Has(ctx, datastore.NewKey(entriesCid.String()))
-	require.NoError(t, err)
-	require.False(t, ok)
-}
-
 func newRandomLinkedList(t *testing.T, lsys ipld.LinkSystem, size int) (ipld.Link, []multihash.Multihash) {
 	var out []multihash.Multihash
 	var nextLnk ipld.Link

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -1222,7 +1222,7 @@ func (ing *Ingester) ingestWorkerLogic(ctx context.Context, provider peer.ID, as
 			}
 			if !frozen && keep {
 				// Write the advertisement to a CAR file, but omit the entries.
-				carInfo, err := ing.mirror.write(ctx, ai.cid, true)
+				carInfo, err := ing.mirror.write(ctx, ai.cid, true, ai.resync)
 				if err != nil {
 					if !errors.Is(err, fs.ErrExist) {
 						// Log the error, but do not return. Continue on to save the procesed ad.
@@ -1298,7 +1298,7 @@ func (ing *Ingester) ingestWorkerLogic(ctx context.Context, provider peer.ID, as
 		}
 
 		if !frozen && keep {
-			carInfo, err := ing.mirror.write(ctx, ai.cid, false)
+			carInfo, err := ing.mirror.write(ctx, ai.cid, false, ai.resync)
 			if err != nil {
 				if !errors.Is(err, fs.ErrExist) {
 					// Log the error, but do not return. Continue on to save the procesed ad.

--- a/internal/ingest/mirror.go
+++ b/internal/ingest/mirror.go
@@ -37,7 +37,7 @@ func (m adMirror) writeHead(ctx context.Context, adCid cid.Cid, publisher peer.I
 	return m.carWriter.WriteHead(ctx, adCid, publisher)
 }
 
-func newMirror(cfgMirror config.Mirror, dstore datastore.Datastore) (adMirror, error) {
+func newMirror(cfgMirror config.Mirror, dstore datastore.Batching) (adMirror, error) {
 	var m adMirror
 
 	if !(cfgMirror.Read || cfgMirror.Write) {

--- a/internal/ingest/mirror.go
+++ b/internal/ingest/mirror.go
@@ -29,8 +29,8 @@ func (m adMirror) read(ctx context.Context, adCid cid.Cid, skipEntries bool) (*c
 	return m.carReader.Read(ctx, adCid, skipEntries)
 }
 
-func (m adMirror) write(ctx context.Context, adCid cid.Cid, skipEntries bool) (*filestore.File, error) {
-	return m.carWriter.Write(ctx, adCid, skipEntries)
+func (m adMirror) write(ctx context.Context, adCid cid.Cid, skipEntries, overWrite bool) (*filestore.File, error) {
+	return m.carWriter.Write(ctx, adCid, skipEntries, overWrite)
 }
 
 func (m adMirror) writeHead(ctx context.Context, adCid cid.Cid, publisher peer.ID) (*filestore.File, error) {


### PR DESCRIPTION
If resyncing, then overwrite any existing CAR file in the mirror for the advertisements that are resynced.
