### PR TITLE
Switch off dhfind simulation mode in prod

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind/deployment.yaml
@@ -15,9 +15,6 @@ spec:
           args:
             - '--dhstoreAddr=http://dhstore.internal.prod.cid.contact/'
             - '--stiAddr=http://inga-indexer:3000/'
-            - '--simulation=true'
-            - '--simulationChannelSize=2000'
-            - '--simulationWorkerCount=100'
           resources:
             limits:
               cpu: "2"


### PR DESCRIPTION
This is done to compare simulation vs non simulation performance and its effect on the lookup metrics against the real traffic
