### PR TITLE
Expose dhfind for external access in prod

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind/ingress.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind/ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dhfind
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt"
+spec:
+  tls:
+    - hosts:
+        - dhfind.prod.cid.contact
+      secretName: dhfind-ingress-tls
+  rules:
+    - host: dhfind.prod.cid.contact
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: dhfind
+                port:
+                  number: 40080

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: storetheindex
 resources:
   - ../../../../../base/dhfind
   - pod-monitor.yaml
+  - ingress.yaml
 
 patchesStrategicMerge:
   - deployment.yaml


### PR DESCRIPTION
Exposing in prod only where it runs in non-simulation mode to verify metrics.