### PR TITLE
Handle trailing slash with find batch request

### DIFF
--- a/server/find/http/server.go
+++ b/server/find/http/server.go
@@ -170,6 +170,10 @@ func (s *Server) findCid(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) findMultihash(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodPost {
+		s.findBatch(w, r)
+		return
+	}
 	enableCors(w)
 
 	if !httpserver.MethodOK(w, r, http.MethodGet) {


### PR DESCRIPTION
The `findBatch` handler is called when there is no slash following the `/multihash` endpoint. If there is a slash, then the `findMultihash` handler is called and expects a multihash in the URL path. Some clients may add a trailing slash, even when they mean to call the `findBatch` handler. Fix this by calling `findBatch` if `findMultihash` is called and the request method is `POST`.
