### PR TITLE
Increase canary traffic to 20%

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar-canary/ingress.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar-canary/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     cert-manager.io/cluster-issuer: "letsencrypt"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/canary: "true"
-    nginx.ingress.kubernetes.io/canary-weight: "10"
+    nginx.ingress.kubernetes.io/canary-weight: "20"
 spec:
   tls:
     - hosts:


### PR DESCRIPTION
Encrypted store has been running ok against 10% for the last 24 hours. Increasing that number to 20%.