### PR TITLE
Increase dhfind RAM in prod

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind/deployment.yaml
@@ -18,7 +18,7 @@ spec:
           resources:
             limits:
               cpu: "2"
-              memory: 1.5Gi
+              memory: 3Gi
             requests:
               cpu: "2"
-              memory: 1.5Gi
+              memory: 3Gi


### PR DESCRIPTION
Increase RAM for dhfind as they get OOM killed:

```
    State:          Running
      Started:      Thu, 27 Apr 2023 11:48:51 +0100
    Last State:     Terminated
      Reason:       OOMKilled
      Exit Code:    137
      Started:      Thu, 27 Apr 2023 07:35:46 +0100
      Finished:     Thu, 27 Apr 2023 11:48:50 +0100
    Ready:          True
    Restart Count:  3
```