### PR TITLE
Reduce canary traffic

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar-canary/ingress.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar-canary/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     cert-manager.io/cluster-issuer: "letsencrypt"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/canary: "true"
-    nginx.ingress.kubernetes.io/canary-weight: "20"
+    nginx.ingress.kubernetes.io/canary-weight: "5"
 spec:
   tls:
     - hosts:


### PR DESCRIPTION
Reduce canary traffic as indexers struggle to respond onto provider requests. Needs to be bumped back up when provider cache is implemented.
