### PR TITLE
Add dhfind-helga and hook it up to indexstar-canary

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind-helga/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind-helga/deployment.yaml
@@ -29,12 +29,3 @@ spec:
             requests:
               cpu: "2"
               memory: 3Gi
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: topology.kubernetes.io/zone
-                    operator: In
-                    values:
-                      - us-east-2a # should be the same as the zone of the dhstore-helga

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind-helga/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind-helga/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: dhfind
 spec:
   # increase replicas as dhstore-helga grows, while also reducing replicas for dhfind
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: dhfind-helga

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind-helga/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind-helga/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dhfind
+spec:
+  # increase replicas as dhstore-helga grows, while also reducing replicas for dhfind
+  replicas: 2
+  selector:
+    matchLabels:
+      app: dhfind-helga
+  template:
+    metadata:
+      labels:
+        app: dhfind-helga
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+      containers:
+        - name: dhfind
+          args:
+            - '--dhstoreAddr=http://dhstore-helga.internal.prod.cid.contact/'
+            - '--stiAddr=http://inga-indexer:3000/'
+          resources:
+            limits:
+              cpu: "2"
+              memory: 3Gi
+            requests:
+              cpu: "2"
+              memory: 3Gi
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: topology.kubernetes.io/zone
+                    operator: In
+                    values:
+                      - us-east-2a # should be the same as the zone of the dhstore-helga

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind-helga/ingress.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind-helga/ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dhfind
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt"
+spec:
+  tls:
+    - hosts:
+        - dhfind-helga.prod.cid.contact
+      secretName: dhfind-helga-ingress-tls
+  rules:
+    - host: dhfind-helga.prod.cid.contact
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: dhfind-helga
+                port:
+                  number: 80

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind-helga/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind-helga/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+nameSuffix: -helga
+
+resources:
+  - ../../../../../base/dhfind
+  - pod-monitor.yaml
+  - ingress.yaml
+
+patchesStrategicMerge:
+  - deployment.yaml
+  - service.yaml
+  - pdb.yaml
+
+images:
+  - name: dhfind
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhfind
+    newTag: 20230426125018-3a9c02efd0fb8a045b491e82563142aca74bc411

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind-helga/pdb.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind-helga/pdb.yaml
@@ -1,0 +1,8 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: dhfind
+spec:
+  selector:
+    matchLabels:
+      app: dhfind-helga

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind-helga/pod-monitor.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind-helga/pod-monitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: dhfind
+  labels:
+    app: dhfind-helga
+spec:
+  selector:
+    matchLabels:
+      app: dhfind-helga
+  namespaceSelector:
+    matchNames:
+      - storetheindex
+  podMetricsEndpoints:
+    - path: /metrics
+      port: metrics

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind-helga/service.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind-helga/service.yaml
@@ -1,0 +1,21 @@
+# dhfind service is accessible only within K8S cluster VPC via:
+#  - http://dhfind.internal.dev.cid.contact
+#
+# See: https://github.com/ipni/dhfind
+kind: Service
+apiVersion: v1
+metadata:
+  name: dhfind
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internal
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+    external-dns.alpha.kubernetes.io/access: private
+    external-dns.alpha.kubernetes.io/hostname: dhfind-helga.internal.prod.cid.contact
+spec:
+  externalTrafficPolicy: Cluster
+  type: LoadBalancer
+  selector:
+    app: dhfind-helga
+

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar-canary/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar-canary/deployment.yaml
@@ -26,6 +26,7 @@ spec:
             - '--backends=http://oden-indexer:3000/'
             - '--backends=http://kepa-indexer:3000/'
             - '--backends=http://dhfind.internal.prod.cid.contact/'
+            - '--backends=http://dhfind-helga.internal.prod.cid.contact/'
             - '--cascadeBackends=http://caskadht.internal.prod.cid.contact/'
             - '--cascadeBackends=http://cassette.internal.prod.cid.contact/'
           env:

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 - dhstore
 - dhstore-helga
 - dhfind
+- dhfind-helga
 - cassette
 images:
 - name: storetheindex


### PR DESCRIPTION
* Add `dhfind-helga` that points to `dhstore-helga` for lookups. Initially run 2 instances as they will be returning 404s mostly. Scale that up as `dhstore-helga` grows.
* Hookup `dhfind-helga` to `indexstar-canary`

