### PR TITLE
Add dhstore cluster support

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -148,6 +148,7 @@ func daemonAction(cctx *cli.Context) error {
 	indexerCore := engine.New(resultCache, valueStore,
 		engine.WithDHBatchSize(cfg.Indexer.DHBatchSize),
 		engine.WithDHStore(cfg.Indexer.DHStoreURL),
+		engine.WithDHStoreCluster(cfg.Indexer.DHStoreClusterURLs),
 		engine.WithVSNoNewMH(cfg.Indexer.VSNoNewMH),
 		engine.WithHttpClientTimeout(time.Duration(cfg.Indexer.DHStoreHttpClientTimeout)),
 	)

--- a/command/init.go
+++ b/command/init.go
@@ -184,5 +184,11 @@ func initAction(cctx *cli.Context) error {
 		cfg.Indexer.DHBatchSize = -1
 	}
 
+	dhstoreClusterUrls := cctx.StringSlice("dhstore-cluster")
+	if len(dhstoreClusterUrls) > 0 {
+		log.Infow("dhstoreClusterUrls", dhstoreClusterUrls)
+		cfg.Indexer.DHStoreClusterURLs = dhstoreClusterUrls
+	}
+
 	return cfg.Save(configFile)
 }

--- a/config/indexer.go
+++ b/config/indexer.go
@@ -23,6 +23,10 @@ type Indexer struct {
 	// DHStoreURL is the base URL for the DHStore service. This option value
 	// tells the indexer core to use a DHStore service, if configured.
 	DHStoreURL string
+	// DHStoreClusterURLs provide addional URLs that the core will send delete requests to.
+	// Deletes will be send to the dhstoreURL as well as to all dhstoreClusterURLs. This is required as deletes need to be applied to all nodes until
+	// consistent hashing is implemented. dhstoreURL shouldn't be included in this list.
+	DHStoreClusterURLs []string
 	// DHStoreHttpClientTimeout is a timeout for the DHStore http client
 	DHStoreHttpClientTimeout Duration
 	// FreezeAtPercent is the percent used, of the file system that

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/ipld/go-ipld-prime v0.20.0
 	github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd
 	github.com/ipld/go-storethehash v0.3.13
-	github.com/ipni/go-indexer-core v0.7.6
+	github.com/ipni/go-indexer-core v0.7.7-0.20230428105441-32af01a52225
 	github.com/ipni/go-libipni v0.0.7
 	github.com/libp2p/go-libp2p v0.27.1
 	github.com/libp2p/go-msgio v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -618,8 +618,8 @@ github.com/ipld/go-storethehash v0.3.13 h1:1T6kX5K57lAgxbsGitZEaZMAR3RdWch2kO8ok
 github.com/ipld/go-storethehash v0.3.13/go.mod h1:KCYpzmamubnSwm7fvWcCkm0aIwQh4WRNtzrKK4pVhAQ=
 github.com/ipni/dhstore v0.0.2-0.20230324212407-ceb5f50e3bad h1:nS2Zq9bHG0eFzRjz1naWKl6I1YYPGWI1yWJK+zX3UGM=
 github.com/ipni/dhstore v0.0.2-0.20230324212407-ceb5f50e3bad/go.mod h1:XI6XW5Eu97zY5PEK2ZRuESh8mYkxIZYRTMcknPVbbrc=
-github.com/ipni/go-indexer-core v0.7.6 h1:CetG+X5dDT4geGbwvw1ReWcRfyhj1Ou5TBpEtV1yRF4=
-github.com/ipni/go-indexer-core v0.7.6/go.mod h1:7bXN1AjSY6jutNe3E7e7P8GDeAdkpe8i6mNteXEL1Yw=
+github.com/ipni/go-indexer-core v0.7.7-0.20230428105441-32af01a52225 h1:pqgUvHIPFI+SxCbkHmSRF1SqmD4PGJmVyH7rs/cVpdc=
+github.com/ipni/go-indexer-core v0.7.7-0.20230428105441-32af01a52225/go.mod h1:03SY41l6ZC2gPRvDBuO8QMSpBSvd+P8NtUJEWgJxbNc=
 github.com/ipni/go-libipni v0.0.7 h1:L0AnFQagedfJU5mJ7kz0H8P1452brJveOQeS6p3MmbA=
 github.com/ipni/go-libipni v0.0.7/go.mod h1:TlGZaGMGIVpeb6fiwttfY1JgaMnH+HDVPzxgRJJPaQY=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=


### PR DESCRIPTION
Note: the release for both go-indexer-core and storetheindex will be cut after the functionality has been tested in dev.