### PR TITLE
Fix find latency reporting

### DIFF
--- a/server/find/http/server.go
+++ b/server/find/http/server.go
@@ -363,6 +363,7 @@ func (s *Server) getIndexes(w http.ResponseWriter, mhs []multihash.Multihash, st
 			http.Error(w, "no results for query", http.StatusNotFound)
 			return
 		}
+		found = true
 		return
 	}
 


### PR DESCRIPTION
"found" flag was always false for streaming requests, which resulted into incorrect success rate reported by the indexers.
