### PR TITLE
Increase canary traffic

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: dhfind
 spec:
-  replicas: 5
+  replicas: 3
   template:
     spec:
       topologySpreadConstraints:

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar-canary/ingress.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar-canary/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     cert-manager.io/cluster-issuer: "letsencrypt"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/canary: "true"
-    nginx.ingress.kubernetes.io/canary-weight: "20"
+    nginx.ingress.kubernetes.io/canary-weight: "30"
 spec:
   tls:
     - hosts:

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
@@ -13,7 +13,7 @@ patchesStrategicMerge:
 
 replicas:
   - name: indexstar
-    count: 3
+    count: 2
 
 images:
   - name: indexstar


### PR DESCRIPTION
* Further increase canary traffic in prod
* Reduce non-canary indexstar replicas to two so that there are three instances in total (as it was before dhfind rollout)
* Reduce number of dhfind instances down to three as they are underutilised
