### PR TITLE
Add inga to the canary lookup path

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar-canary/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar-canary/deployment.yaml
@@ -22,6 +22,7 @@ spec:
             - '--translateNonStreaming'
             # Use service names local to the namespace over HTTP to avoid
             # TLS handshake overhead.
+            - '--backends=http://inga-indexer:3000/'
             - '--backends=http://dhfind.internal.prod.cid.contact/'
             - '--backends=http://dhfind-helga.internal.prod.cid.contact/'
             - '--cascadeBackends=http://caskadht.internal.prod.cid.contact/'


### PR DESCRIPTION
Add inga to the lookup path as dhfind isn't able to satisfy /providers lookups. Inga will return 404s to all double hashed requests.
