### PR TITLE
Use latest address available in ad chain

### DIFF
--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -1052,7 +1052,7 @@ func (ing *Ingester) processRawAdChain(ctx context.Context, syncFinishedEvent da
 		// If this is the first ad for this provider, then save the provider
 		// addresses.
 		_, ok := provAddrs[providerID]
-		if !ok {
+		if !ok && len(ad.Addresses) != 0 {
 			provAddrs[providerID] = ad.Addresses
 		}
 


### PR DESCRIPTION
## Context
If the first advertisement does not have a provider address, then use the next one available in the ad chain.

This fixes a problem when ingesting long ad chains where the first advertisement received is missing the provider address. When this happened, the indexer would revert to its old behavior of updating the current provider address to whatever is in the ad being ingested. This may be an old and no longer valid address that would not be updated to the current address until ingesting ads later in the chain.

## Proposed Changes
This fix uses the latest provider address in the chain, even if the first ad is missing the provider address.

## Tests
Manual test, instrumented with debug output.

## Revert Strategy
Change is safe to revert.
