### PR TITLE
[do not merge] Deploy deletehack to dev

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/deletehack/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/deletehack/config.json
@@ -1,0 +1,117 @@
+{
+  "Version": 2,
+  "Identity": {
+    "PeerID": "",
+    "PrivKey": ""
+  },
+  "Addresses": {
+    "Admin": "/ip4/0.0.0.0/tcp/3002",
+    "Finder": "/ip4/0.0.0.0/tcp/3000",
+    "FinderWebpage": "https://web-ipni.cid.contact/dev",
+    "Ingest": "/ip4/0.0.0.0/tcp/3001",
+    "P2PAddr": "/ip4/0.0.0.0/tcp/3003",
+    "NoResourceManager": true
+  },
+  "Bootstrap": {
+    "Peers": [
+      "/dns4/bootstrap-0.ipfsmain.cn/tcp/34721/p2p/12D3KooWQnwEGNqcM2nAcPtRR9rAX8Hrg4k9kJLCHoTR5chJfz6d",
+      "/dns4/bootstrap-3.mainnet.filops.net/tcp/1347/p2p/12D3KooWKhgq8c7NQ9iGjbyK7v7phXvG6492HQfiDaGHLHLQjk7R",
+      "/dns4/bootstrap-4.mainnet.filops.net/tcp/1347/p2p/12D3KooWL6PsFNPhYftrJzGgF5U18hFoaVhfGk7xwzD8yVrHJ3Uc",
+      "/dns4/bootstrap-6.mainnet.filops.net/tcp/1347/p2p/12D3KooWP5MwCiqdMETF9ub1P3MbCvQCcfconnYHbWg6sUJcDRQQ",
+      "/dns4/bootstrap-7.mainnet.filops.net/tcp/1347/p2p/12D3KooWRs3aY1p3juFjPy8gPN95PEQChm2QKGUCAdcDCC4EBMKf",
+      "/dns4/bootstrap-8.mainnet.filops.net/tcp/1347/p2p/12D3KooWScFR7385LTyR4zU1bYdzSiiAb5rnNABfVahPvVSzyTkR",
+      "/dns4/node.glif.io/tcp/1235/p2p/12D3KooWBF8cpp65hp2u9LK5mh19x67ftAam84z9LsfaquTDSBpt",
+      "/dns4/bootstrap-2.mainnet.filops.net/tcp/1347/p2p/12D3KooWEWVwHGn2yR36gKLozmb4YjDJGerotAPGxmdWZx2nxMC4",
+      "/dns4/bootstrap-5.mainnet.filops.net/tcp/1347/p2p/12D3KooWLFynvDQiUpXoHroV1YxKHhPJgysQGH2k3ZGwtWzR4dFH",
+      "/dns4/bootstrap-1.starpool.in/tcp/12757/p2p/12D3KooWQZrGH1PxSNZPum99M1zNvjNFM33d1AAu5DcvdHptuU7u",
+      "/dns4/bootstrap-0.mainnet.filops.net/tcp/1347/p2p/12D3KooWCVe8MmsEMes2FzgTpt9fXtmCY7wrq91GRiaC8PHSCCBj",
+      "/dns4/bootstrap-1.mainnet.filops.net/tcp/1347/p2p/12D3KooWCwevHg1yLCvktf2nvLu7L9894mcrJR4MsBCcm4syShVc",
+      "/dns4/bootstrap-0.starpool.in/tcp/12757/p2p/12D3KooWGHpBMeZbestVEWkfdnC9u7p6uFHXL1n7m1ZBqsEmiUzz",
+      "/dns4/lotus-bootstrap.ipfsforce.com/tcp/41778/p2p/12D3KooWGhufNmZHF3sv48aQeS13ng5XVJZ9E6qy2Ms4VzqeUsHk",
+      "/dns4/bootstrap-1.ipfsmain.cn/tcp/34723/p2p/12D3KooWMKxMkD5DMpSWsW7dBddKxKT7L2GgbNuckz9otxvkvByP"
+    ],
+    "MinimumPeers": 4
+  },
+  "Datastore": {
+    "Type": "levelds",
+    "Dir": "/data/datastore"
+  },
+  "Discovery": {
+    "FilterIPs": true,
+    "LotusGateway": "wss://api.chain.love",
+    "Policy": {
+      "Allow": true,
+      "Except": [
+      ],
+      "Publish": true,
+      "PublishExcept": null
+    },
+    "PollInterval": "24h0m0s",
+    "PollRetryAfter": "5m0s",
+    "PollStopAfter": "168h0m0s",
+    "PollOverrides": null,
+    "RediscoverWait": "5m0s",
+    "Timeout": "2m0s",
+    "UseAssigner": false
+  },
+  "Indexer": {
+    "CacheSize": -1,
+    "ConfigCheckInterval": "30s",
+    "ShutdownTimeout": "15m",
+    "ValueStoreDir": "/data/valuestore",
+    "ValueStoreType": "pebble",
+    "DisableWAL": true,
+    "VSNoNewMH": true,
+    "DHBatchSize": 5000,
+    "DHStoreURL": "http://dhstore.internal.dev.cid.contact",
+    "DHStoreHttpClientTimeout": "30s"
+  },
+  "Ingest": {
+    "AdvertisementDepthLimit": 33554432,
+    "AdvertisementMirror": {
+      "Read": false,
+      "Write": true,
+      "Compress": "gzip",
+      "Storage": {
+        "Type": "s3",
+        "S3": {
+          "BucketName": "dev-sti-adstore"
+        }
+      }
+    },
+    "EntriesDepthLimit": 65536,
+    "HttpSyncRetryMax": 4,
+    "HttpSyncRetryWaitMax": "30s",
+    "HttpSyncRetryWaitMin": "1s",
+    "HttpSyncTimeout": "10s",
+    "IngestWorkerCount": 10,
+    "KeepAdvertisements":true,
+    "PubSubTopic": "/indexer/ingest/mainnet",
+    "RateLimit": {
+      "Apply": false,
+      "Except": null,
+      "BlocksPerSecond": 0,
+      "BurstSize": 500
+    },
+    "RmOnly": true,
+    "ResendDirectAnnounce": false,
+    "StoreBatchSize": 8192,
+    "SyncSegmentDepthLimit": 2000,
+    "SyncTimeout": "2h0m0s"
+  },
+  "Logging": {
+    "Level": "info",
+    "Loggers": {
+      "basichost": "warn",
+      "bootstrap": "warn",
+      "dt-impl": "warn",
+      "dt_graphsync": "warn",
+      "graphsync": "warn"
+    }
+  },
+  "Peering": {
+    "Peers": [
+      "/dns4/assigner/tcp/3003/p2p/12D3KooWDBjcDRQ7CKJeF9Yy3UKbriHfyETDrXKzTDB6biH3ibBd"
+    ]
+  }
+}

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/deletehack/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/deletehack/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: indexer
+spec:
+  template:
+    spec:
+      serviceAccountName: storetheindex
+      terminationGracePeriodSeconds: 600
+      containers:
+        - name: indexer
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            limits:
+              cpu: "3"
+              memory: 28Gi
+            requests:
+              cpu: "3"
+              memory: 28Gi
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.kubernetes.io/instance-type
+                    operator: In
+                    values:
+                      - r6a.xlarge
+                  - key: topology.kubernetes.io/zone
+                    operator: In
+                    values:
+                      - us-east-2a
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: deletehack-data
+

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/deletehack/identity.key.encrypted
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/deletehack/identity.key.encrypted
@@ -1,0 +1,22 @@
+{
+	"data": "ENC[AES256_GCM,data:t8FNl0p4MwdryJAgKgP1+PCMfZPfVVdmJBqv7mClm8w9h7mImSivwsbCz9ZBzxL1PTZOjjpzXX395HZIMErRt9KES7w=,iv:0EZDbCjrj0lQIZ4UXPGLT1SO1izZviRgR1YSAesr9Jo=,tag:TZU5BdqoHUQVkVE7u8dC6g==,type:str]",
+	"sops": {
+		"kms": [
+			{
+				"arn": "arn:aws:kms:us-east-2:407967248065:alias/sti_flux",
+				"created_at": "2023-05-03T11:37:46Z",
+				"enc": "AQICAHi99m+hXhXmjeAqO3v9MBDcMaC2zWJIlamGyiBfOVdULAEwqg3WKPxF70Fm8X8khZIRAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMkAFy6TwWSiwn63GhAgEQgDuq7jplYqyqSljfTErNPkHCGiUTR3dOM61HYfcT9r96+iN2Y06OFpcR7W9hBUOyjcy3QZooBB5epJZmew==",
+				"aws_profile": ""
+			}
+		],
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2023-05-03T11:37:47Z",
+		"mac": "ENC[AES256_GCM,data:AFyaN1sYRo4YPFTfClrT9atmWu/Xx4gIK9/O4nKla6+dZbYqZSYPc3UBJD0dqVpt1Mu4vjBNE8NUCF3gkMreY6hhXPWVA77EsReG60gxpRbvQuWlDoTXJw3hdlFkJLK5jopssl/MIOkvo9yQ+4xlH/m3dwOyaMKAUXHVZocJ5K0=,iv:kviBCMtPzO/reN2Bzclz6endEHkVe5QELEg+qcxgk+k=,tag:ZeViQnwLzpHNLyhYjx4Jdg==,type:str]",
+		"pgp": null,
+		"encrypted_regex": "^(data|stringData)$",
+		"version": "3.7.3"
+	}
+}

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/deletehack/ingress.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/deletehack/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: indexer
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt"
+spec:
+  tls:
+    - hosts:
+        - deletehack.dev.cid.contact
+      secretName: deletehack-indexer-ingress-tls
+  rules:
+    - host: deletehack.dev.cid.contact
+      http:
+        paths:
+          - path: /ingest
+            pathType: Prefix
+            backend:
+              service:
+                name: indexer
+                port:
+                  number: 3001
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: indexer
+                port:
+                  number: 3000

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/deletehack/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/deletehack/kustomization.yaml
@@ -31,4 +31,4 @@ patchesStrategicMerge:
 images:
   - name: storetheindex
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-    newTag: 20230428153542-77d132f39be6f4982676d8d3e8ad085b56f98c74
+    newTag: 20230503123646-321c95238e135299699545ab33fc412df06fee49

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/deletehack/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/deletehack/kustomization.yaml
@@ -31,4 +31,4 @@ patchesStrategicMerge:
 images:
   - name: storetheindex
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-    newTag: 20230503123646-321c95238e135299699545ab33fc412df06fee49
+    newTag: 20230503175314-e049ce9642047895f71cada5a96a16223fe846b2

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/deletehack/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/deletehack/kustomization.yaml
@@ -1,0 +1,34 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - ../../../../../../base/storetheindex-single
+  - ingress.yaml
+  - pvc_data.yaml
+
+namePrefix: deletehack-
+
+commonLabels:
+  name: deletehack
+
+secretGenerator:
+  - name: identity
+    behavior: replace
+    files:
+      - identity.key=identity.key.encrypted # 12D3KooWDUGVHNv25nmdxpsdHnsJ9GHvxcba7sreN4XT5P5GyTLa
+
+configMapGenerator:
+  - name: config
+    behavior: replace
+    files:
+      - config=config.json
+
+patchesStrategicMerge:
+  - deployment.yaml
+  
+images:
+  - name: storetheindex
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
+    newTag: 20230428153542-77d132f39be6f4982676d8d3e8ad085b56f98c74

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/deletehack/pvc_data.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/deletehack/pvc_data.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: indexer-single
+    app.kubernetes.io/managed-by: kustomization
+    app.kubernetes.io/part-of: storetheindex
+  name: data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Ti
+  storageClassName: io2

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - ber
   - cali
   - ago
+  - deletehack


### PR DESCRIPTION
deletehack is a dedicated storetheindex instance that is going to go through the ads from s3 mirror and apply only deletions to dhstore. This is required to compensate for deletions that didn't use to be applied in the past. After deletehack has caught up with the rest of the cluster the instance will be deleted.
