### PR TITLE
Create prod `dhstore` PVC from the snapshot

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - pvc.yaml
   - internal-service.yaml
   - pod-monitor.yaml
+  - pvc-gp3.yaml
 
 patchesStrategicMerge:
   - deployment.yaml

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/pvc-gp3.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/pvc-gp3.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dhstore-data-gp3
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 15Ti
+  dataSource:
+    name: dhstore-20230427
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+  storageClassName: gp3-iops5k-t300


### PR DESCRIPTION
The new PVC will replace `dhstore-data`. `dhstore-data` needs to be retired because of incorrect size of 20Ti that can not be reduced.
