### PR TITLE
Bring indexstar-canary config on par with the main

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar-canary/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar-canary/deployment.yaml
@@ -40,7 +40,7 @@ spec:
             - name: SERVER_RESULT_MAX_WAIT
               value: '2s'
             - name: SERVER_RESULT_STREAM_MAX_WAIT
-              value: '30s'
+              value: '5s'
           resources:
             limits:
               cpu: "3"


### PR DESCRIPTION
Making `indexstar-canary` to be configured the same as the [main](https://github.com/ipni/storetheindex/blob/main/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml#L37)