### PR TITLE
Point dhfind to indexstar for provider lookups

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind-helga/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind-helga/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         - name: dhfind
           args:
             - '--dhstoreAddr=http://dhstore-helga.internal.prod.cid.contact/'
-            - '--stiAddr=http://inga-indexer:3000/'
+            - '--stiAddr=http://indexstar:8080/'
           resources:
             limits:
               cpu: "1.5"

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind/deployment.yaml
@@ -14,7 +14,7 @@ spec:
         - name: dhfind
           args:
             - '--dhstoreAddr=http://dhstore.internal.prod.cid.contact/'
-            - '--stiAddr=http://inga-indexer:3000/'
+            - '--stiAddr=http://indexstar:8080/'
           resources:
             limits:
               cpu: "1.5"


### PR DESCRIPTION
* if inga is down then dhfind is unable to serve traffic
* with the recent caching improvements, dhfind should be less sensitive to indexstar latency