### PR TITLE
Store temporary ad data in separate datastore

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -132,7 +132,6 @@ func daemonAction(cctx *cli.Context) error {
 		return err
 	}
 	defer dstore.Close()
-
 	err = updateDatastore(cctx.Context, dstore)
 	if err != nil {
 		return fmt.Errorf("cannot update datastore: %w", err)
@@ -145,7 +144,6 @@ func daemonAction(cctx *cli.Context) error {
 		return err
 	}
 	defer dsAdTmp.Close()
-
 	freezeDirs = append(freezeDirs, dsAdDir)
 
 	if cfg.Indexer.UnfreezeOnStart {
@@ -735,7 +733,7 @@ func reloadPeering(cfg config.Peering, peeringService *peering.PeeringService, p
 
 func createDatastore(ctx context.Context, dir, dsType string) (datastore.Batching, string, error) {
 	if dsType != "levelds" {
-		return nil, "", fmt.Errorf("only levelds datastore type supported, %q not supported", cfg.Type)
+		return nil, "", fmt.Errorf("only levelds datastore type supported, %q not supported", dsType)
 	}
 	dataStorePath, err := config.Path("", dir)
 	if err != nil {

--- a/command/update_datastore.go
+++ b/command/update_datastore.go
@@ -1,0 +1,186 @@
+package command
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/query"
+)
+
+// updateBatchSize is the number of records to update at a time.
+const updateBatchSize = 500000
+
+func updateDatastore(ctx context.Context, ds datastore.Batching) error {
+	dsVerKey := datastore.NewKey(dsInfoPrefix + dsVersionKey)
+	curVerData, err := ds.Get(ctx, dsVerKey)
+	if err != nil && !errors.Is(err, datastore.ErrNotFound) {
+		return fmt.Errorf("cannot check datastore: %w", err)
+	}
+	var curVer string
+	if len(curVerData) != 0 {
+		curVer = string(curVerData)
+	}
+	if curVer == dsVersion {
+		return nil
+	}
+	if curVer > dsVersion {
+		return fmt.Errorf("unknown datastore verssion: %s", curVer)
+	}
+
+	log.Infof("Updating datastore to version %s", dsVersion)
+	if err = rmDtFsmRecords(ctx, ds); err != nil {
+		return err
+	}
+	if err = rmOldTempRecords(ctx, ds); err != nil {
+		return err
+	}
+
+	if err = ds.Put(ctx, dsVerKey, []byte(dsVersion)); err != nil {
+		return err
+	}
+	if err = ds.Sync(ctx, datastore.NewKey("")); err != nil {
+		return fmt.Errorf("cannot sync datastore: %w", err)
+	}
+
+	log.Infow("Datastore update finished")
+	return nil
+}
+
+func rmOldTempRecords(ctx context.Context, ds datastore.Batching) error {
+	q := query.Query{
+		KeysOnly: true,
+	}
+	results, err := ds.Query(ctx, q)
+	if err != nil {
+		return fmt.Errorf("cannot query datastore: %w", err)
+	}
+	defer results.Close()
+
+	batch, err := ds.Batch(ctx)
+	if err != nil {
+		return fmt.Errorf("cannot create datastore batch: %w", err)
+	}
+
+	var cidCount, dtKeyCount, writeCount int
+	for result := range results.Next() {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if writeCount >= updateBatchSize {
+			writeCount = 0
+			if err = batch.Commit(ctx); err != nil {
+				return fmt.Errorf("cannot commit datastore updates: %w", err)
+			}
+			log.Infow("Datastore update removed old records", "fsmData", dtKeyCount, "adData", cidCount)
+		}
+		if result.Error != nil {
+			return fmt.Errorf("cannot read query result from datastore: %w", result.Error)
+		}
+		ent := result.Entry
+		if len(ent.Key) == 0 {
+			log.Warnf("result entry has empty key")
+			continue
+		}
+		var key string
+		if ent.Key[0] == '/' {
+			key = ent.Key[1:]
+		} else {
+			key = ent.Key
+		}
+
+		before, after, found := strings.Cut(key, "/")
+		if found {
+			if before[0] >= '0' && before[0] <= '9' && len(after) > 22 {
+				if err = batch.Delete(ctx, datastore.NewKey(key)); err != nil {
+					return fmt.Errorf("cannot delete dt state key from datastore: %w", err)
+				}
+				writeCount++
+				dtKeyCount++
+			}
+			continue
+		}
+
+		if _, err := cid.Decode(key); err != nil {
+			log.Warnf("Unknown key: %s", key)
+			continue
+		}
+		if err = batch.Delete(ctx, datastore.NewKey(key)); err != nil {
+			return fmt.Errorf("cannot delete CID from datastore: %w", err)
+		}
+		writeCount++
+		cidCount++
+	}
+
+	if err = batch.Commit(ctx); err != nil {
+		return fmt.Errorf("cannot commit datastore updated: %w", err)
+	}
+	if err = ds.Sync(ctx, datastore.NewKey("")); err != nil {
+		return fmt.Errorf("cannot sync datastore: %w", err)
+	}
+
+	if dtKeyCount != 0 || cidCount != 0 {
+		log.Infow("Datastore update removed old records", "fsmData", dtKeyCount, "adData", cidCount)
+	}
+	return nil
+}
+
+func rmDtFsmRecords(ctx context.Context, ds datastore.Batching) error {
+	q := query.Query{
+		KeysOnly: true,
+		Prefix:   "/data-transfer-v2",
+	}
+	results, err := ds.Query(ctx, q)
+	if err != nil {
+		return fmt.Errorf("cannot query datastore: %w", err)
+	}
+	defer results.Close()
+
+	batch, err := ds.Batch(ctx)
+	if err != nil {
+		return fmt.Errorf("cannot create datastore batch: %w", err)
+	}
+
+	var dtKeyCount, writeCount int
+	for result := range results.Next() {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if writeCount >= updateBatchSize {
+			writeCount = 0
+			if err = batch.Commit(ctx); err != nil {
+				return fmt.Errorf("cannot commit datastore: %w", err)
+			}
+			log.Infow("Datastore update removed data-transfer fsm records", "count", dtKeyCount)
+		}
+		if result.Error != nil {
+			return fmt.Errorf("cannot read query result from datastore: %w", result.Error)
+		}
+		ent := result.Entry
+		if len(ent.Key) == 0 {
+			log.Warnf("result entry has empty key")
+			continue
+		}
+
+		if err = batch.Delete(ctx, datastore.NewKey(ent.Key)); err != nil {
+			return fmt.Errorf("cannot delete dt state key from datastore: %w", err)
+		}
+		writeCount++
+		dtKeyCount++
+	}
+
+	if err = batch.Commit(ctx); err != nil {
+		return fmt.Errorf("cannot commit datastore: %w", err)
+	}
+	if err = ds.Sync(context.Background(), datastore.NewKey(q.Prefix)); err != nil {
+		return err
+	}
+
+	if dtKeyCount != 0 {
+		log.Infow("Datastore update removed data-transfer fsm records", "count", dtKeyCount)
+	}
+	return nil
+}

--- a/config/datastore.go
+++ b/config/datastore.go
@@ -2,27 +2,27 @@ package config
 
 // Datastore tracks the configuration of the datastore.
 type Datastore struct {
+	// AdTmpDir is the directory where the datastore for temporaty
+	// advertisement data is kept. If this is not an absolute path then the
+	// location is relative to the indexer repo.
+	AdTmpDir string
+	// AdTmpType is the type of datastore for temporary advertisement data.
+	AdTmpType string
 	// Dir is the directory where the datastore is kept. If this is not an
 	// absolute path then the location is relative to the indexer repo
 	// directory.
 	Dir string
 	// Type is the type of datastore.
 	Type string
-	// TempAdDir is the directory where the datastore for temporaty ad data is
-	// kept. If this is not an absolute path then the location is relative to
-	// the indexer repo.
-	TempAdDir string
-	// TempAdType is the type of datastore for temporary ad data.
-	TempAdType string
 }
 
 // NewDatastore returns Datastore with values set to their defaults.
 func NewDatastore() Datastore {
 	return Datastore{
-		Dir:        "datastore",
-		Type:       "levelds",
-		TempAdDir:  "tempadstore",
-		TempAdType: "levelds",
+		AdTmpDir:  "adtmpstore",
+		AdTmpType: "levelds",
+		Dir:       "datastore",
+		Type:      "levelds",
 	}
 }
 
@@ -36,10 +36,10 @@ func (c *Datastore) populateUnset() {
 	if c.Type == "" {
 		c.Type = def.Type
 	}
-	if c.TempAdDir == "" {
-		c.TempAdDir = def.TempAdDir
+	if c.AdTmpDir == "" {
+		c.AdTmpDir = def.AdTmpDir
 	}
-	if c.TempAdType == "" {
-		c.TempAdType = def.TempAdType
+	if c.AdTmpType == "" {
+		c.AdTmpType = def.AdTmpType
 	}
 }

--- a/config/datastore.go
+++ b/config/datastore.go
@@ -2,29 +2,28 @@ package config
 
 // Datastore tracks the configuration of the datastore.
 type Datastore struct {
-	// AdTmpDir is the directory where the datastore for temporaty
-	// advertisement data is kept. If this is not an absolute path then the
-	// location is relative to the indexer repo. If not set, and Dir is an
-	// absolute path, then the default ad temp dir is located in the parent
-	// directory of Dir.
-	AdTmpDir string
-	// AdTmpType is the type of datastore for temporary advertisement data.
-	AdTmpType string
 	// Dir is the directory where the datastore is kept. If this is not an
 	// absolute path then the location is relative to the indexer repo
 	// directory.
 	Dir string
 	// Type is the type of datastore.
 	Type string
+	// TmpDir is the directory where the datastore for persisted temporaty data
+	// is kept. This datastore contains temporary items such as synced
+	// advertisement data and data-transfer session state. If this is not an
+	// absolute path then the location is relative to the indexer repo.
+	TmpDir string
+	// TmpType is the type of datastore for temporary persisted data.
+	TmpType string
 }
 
 // NewDatastore returns Datastore with values set to their defaults.
 func NewDatastore() Datastore {
 	return Datastore{
-		AdTmpDir:  "adtmpstore",
-		AdTmpType: "levelds",
-		Dir:       "datastore",
-		Type:      "levelds",
+		Dir:     "datastore",
+		Type:    "levelds",
+		TmpDir:  "tmpstore",
+		TmpType: "levelds",
 	}
 }
 
@@ -38,10 +37,10 @@ func (c *Datastore) populateUnset() {
 	if c.Type == "" {
 		c.Type = def.Type
 	}
-	if c.AdTmpDir == "" {
-		c.AdTmpDir = def.AdTmpDir
+	if c.TmpDir == "" {
+		c.TmpDir = def.TmpDir
 	}
-	if c.AdTmpType == "" {
-		c.AdTmpType = def.AdTmpType
+	if c.TmpType == "" {
+		c.TmpType = def.TmpType
 	}
 }

--- a/config/datastore.go
+++ b/config/datastore.go
@@ -1,10 +1,14 @@
 package config
 
+import "path/filepath"
+
 // Datastore tracks the configuration of the datastore.
 type Datastore struct {
 	// AdTmpDir is the directory where the datastore for temporaty
 	// advertisement data is kept. If this is not an absolute path then the
-	// location is relative to the indexer repo.
+	// location is relative to the indexer repo. If not set, and Dir is an
+	// absolute path, then the default ad temp dir is located in the parent
+	// directory of Dir.
 	AdTmpDir string
 	// AdTmpType is the type of datastore for temporary advertisement data.
 	AdTmpType string
@@ -37,7 +41,11 @@ func (c *Datastore) populateUnset() {
 		c.Type = def.Type
 	}
 	if c.AdTmpDir == "" {
-		c.AdTmpDir = def.AdTmpDir
+		if filepath.IsAbs(c.Dir) {
+			c.AdTmpDir = filepath.Join(filepath.Dir(c.Dir), def.AdTmpDir)
+		} else {
+			c.AdTmpDir = def.AdTmpDir
+		}
 	}
 	if c.AdTmpType == "" {
 		c.AdTmpType = def.AdTmpType

--- a/config/datastore.go
+++ b/config/datastore.go
@@ -8,13 +8,21 @@ type Datastore struct {
 	Dir string
 	// Type is the type of datastore.
 	Type string
+	// TempAdDir is the directory where the datastore for temporaty ad data is
+	// kept. If this is not an absolute path then the location is relative to
+	// the indexer repo.
+	TempAdDir string
+	// TempAdType is the type of datastore for temporary ad data.
+	TempAdType string
 }
 
 // NewDatastore returns Datastore with values set to their defaults.
 func NewDatastore() Datastore {
 	return Datastore{
-		Dir:  "datastore",
-		Type: "levelds",
+		Dir:        "datastore",
+		Type:       "levelds",
+		TempAdDir:  "tempadstore",
+		TempAdType: "levelds",
 	}
 }
 
@@ -27,5 +35,11 @@ func (c *Datastore) populateUnset() {
 	}
 	if c.Type == "" {
 		c.Type = def.Type
+	}
+	if c.TempAdDir == "" {
+		c.TempAdDir = def.TempAdDir
+	}
+	if c.TempAdType == "" {
+		c.TempAdType = def.TempAdType
 	}
 }

--- a/config/datastore.go
+++ b/config/datastore.go
@@ -1,7 +1,5 @@
 package config
 
-import "path/filepath"
-
 // Datastore tracks the configuration of the datastore.
 type Datastore struct {
 	// AdTmpDir is the directory where the datastore for temporaty
@@ -41,11 +39,7 @@ func (c *Datastore) populateUnset() {
 		c.Type = def.Type
 	}
 	if c.AdTmpDir == "" {
-		if filepath.IsAbs(c.Dir) {
-			c.AdTmpDir = filepath.Join(filepath.Dir(c.Dir), def.AdTmpDir)
-		} else {
-			c.AdTmpDir = def.AdTmpDir
-		}
+		c.AdTmpDir = def.AdTmpDir
 	}
 	if c.AdTmpType == "" {
 		c.AdTmpType = def.AdTmpType

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/config.json
@@ -33,14 +33,13 @@
     "MinimumPeers": 4
   },
   "Datastore": {
-    "AdTmpDir": "/data/adtmpstore",
-    "AdTmpType": "levelds",
     "Dir": "/data/datastore",
-    "Type": "levelds"
+    "Type": "levelds",
+    "TmpDir": "/data/tmpstore",
+    "TmpType": "levelds"
   },
   "Discovery": {
     "FilterIPs": true,
-    "LotusGateway": "wss://api.chain.love",
     "Policy": {
       "Allow": true,
       "Except": [
@@ -89,12 +88,6 @@
     "HttpSyncTimeout": "10s",
     "IngestWorkerCount":10,
     "PubSubTopic": "/indexer/ingest/mainnet",
-    "RateLimit": {
-      "Apply": false,
-      "Except": null,
-      "BlocksPerSecond": 0,
-      "BurstSize": 500
-    },
     "ResendDirectAnnounce": false,
     "StoreBatchSize": 8192,
     "SyncSegmentDepthLimit": 2000,

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/config.json
@@ -33,8 +33,10 @@
     "MinimumPeers": 4
   },
   "Datastore": {
-    "Type": "levelds",
-    "Dir": "/data/datastore"
+    "AdTmpDir": "/data/adtmpstore",
+    "AdTmpType": "levelds",
+    "Dir": "/data/datastore",
+    "Type": "levelds"
   },
   "Discovery": {
     "FilterIPs": true,

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/alva/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/alva/config.json
@@ -33,8 +33,10 @@
     "MinimumPeers": 4
   },
   "Datastore": {
+    "Dir": "/data/datastore",
     "Type": "levelds",
-    "Dir": "/data/datastore"
+    "TmpDir": "/data/tmpstore",
+    "TmpType": "levelds"
   },
   "Discovery": {
     "FilterIPs": true,

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/config.json
@@ -33,14 +33,13 @@
     "MinimumPeers": 4
   },
   "Datastore": {
-    "AdTmpDir": "/data/adtmpstore",
-    "AdTmpType": "levelds",
     "Dir": "/data/datastore",
-    "Type": "levelds"
+    "Type": "levelds",
+    "TmpDir": "/data/tmpstore",
+    "TmpType": "levelds"
   },
   "Discovery": {
     "FilterIPs": true,
-    "LotusGateway": "wss://api.chain.love",
     "Policy": {
       "Allow": true,
       "Except": [
@@ -82,12 +81,6 @@
     "HttpSyncTimeout": "10s",
     "IngestWorkerCount": 20,
     "PubSubTopic": "/indexer/ingest/mainnet",
-    "RateLimit": {
-      "Apply": false,
-      "Except": null,
-      "BlocksPerSecond": 0,
-      "BurstSize": 500
-    },
     "ResendDirectAnnounce": false,
     "StoreBatchSize": 8192,
     "SyncSegmentDepthLimit": 2000,

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ber/config.json
@@ -33,8 +33,10 @@
     "MinimumPeers": 4
   },
   "Datastore": {
-    "Type": "levelds",
-    "Dir": "/data/datastore"
+    "AdTmpDir": "/data/adtmpstore",
+    "AdTmpType": "levelds",
+    "Dir": "/data/datastore",
+    "Type": "levelds"
   },
   "Discovery": {
     "FilterIPs": true,

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/config.json
@@ -33,8 +33,10 @@
     "MinimumPeers": 4
   },
   "Datastore": {
+    "Dir": "/data/datastore",
     "Type": "levelds",
-    "Dir": "/data/datastore"
+    "TmpDir": "/data/tmpstore",
+    "TmpType": "levelds"
   },
   "Discovery": {
     "FilterIPs": true,

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/config.json
@@ -33,14 +33,13 @@
     "MinimumPeers": 4
   },
   "Datastore": {
-    "AdTmpDir": "/data/adtmpstore",
-    "AdTmpType": "levelds",
     "Dir": "/data/datastore",
-    "Type": "levelds"
+    "Type": "levelds",
+    "TmpDir": "/data/tmpstore",
+    "TmpType": "levelds"
   },
   "Discovery": {
     "FilterIPs": true,
-    "LotusGateway": "wss://api.chain.love",
     "Policy": {
       "Allow": true,
       "Except": [
@@ -82,12 +81,6 @@
     "HttpSyncTimeout": "10s",
     "IngestWorkerCount": 20,
     "PubSubTopic": "/indexer/ingest/mainnet",
-    "RateLimit": {
-      "Apply": false,
-      "Except": null,
-      "BlocksPerSecond": 0,
-      "BurstSize": 500
-    },
     "ResendDirectAnnounce": false,
     "StoreBatchSize": 8192,
     "SyncSegmentDepthLimit": 2000,

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cali/config.json
@@ -33,8 +33,10 @@
     "MinimumPeers": 4
   },
   "Datastore": {
-    "Type": "levelds",
-    "Dir": "/data/datastore"
+    "AdTmpDir": "/data/adtmpstore",
+    "AdTmpType": "levelds",
+    "Dir": "/data/datastore",
+    "Type": "levelds"
   },
   "Discovery": {
     "FilterIPs": true,

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/config.json
@@ -33,8 +33,10 @@
     "MinimumPeers": 4
   },
   "Datastore": {
+    "Dir": "/data/datastore",
     "Type": "levelds",
-    "Dir": "/data/datastore"
+    "TmpDir": "/data/tmpstore",
+    "TmpType": "levelds"
   },
   "Discovery": {
     "FilterIPs": true,

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/config.json
@@ -33,14 +33,13 @@
     "MinimumPeers": 4
   },
   "Datastore": {
-    "AdTmpDir": "/data/adtmpstore",
-    "AdTmpType": "levelds",
     "Dir": "/data/datastore",
-    "Type": "levelds"
+    "Type": "levelds",
+    "TmpDir": "/data/tmpstore",
+    "TmpType": "levelds"
   },
   "Discovery": {
     "FilterIPs": true,
-    "LotusGateway": "wss://api.chain.love",
     "Policy": {
       "Allow": true,
       "Except": [
@@ -72,12 +71,6 @@
     "HttpSyncTimeout": "10s",
     "IngestWorkerCount": 20,
     "PubSubTopic": "/indexer/ingest/mainnet",
-    "RateLimit": {
-      "Apply": false,
-      "Except": null,
-      "BlocksPerSecond": 0,
-      "BurstSize": 500
-    },
     "ResendDirectAnnounce": false,
     "StoreBatchSize": 8192,
     "SyncSegmentDepthLimit": 2000,

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/dido/config.json
@@ -33,8 +33,10 @@
     "MinimumPeers": 4
   },
   "Datastore": {
-    "Type": "levelds",
-    "Dir": "/data/datastore"
+    "AdTmpDir": "/data/adtmpstore",
+    "AdTmpType": "levelds",
+    "Dir": "/data/datastore",
+    "Type": "levelds"
   },
   "Discovery": {
     "FilterIPs": true,

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
@@ -33,14 +33,13 @@
     "MinimumPeers": 4
   },
   "Datastore": {
-    "AdTmpDir": "/data/adtmpstore",
-    "AdTmpType": "levelds",
     "Dir": "/data/datastore",
-    "Type": "levelds"
+    "Type": "levelds",
+    "TmpDir": "/data/tmpstore",
+    "TmpType": "levelds"
   },
   "Discovery": {
     "FilterIPs": true,
-    "LotusGateway": "wss://api.chain.love",
     "Policy": {
       "Allow": true,
       "Except": [
@@ -87,12 +86,6 @@
     "HttpSyncTimeout": "10s",
     "IngestWorkerCount": 3,
     "PubSubTopic": "/indexer/ingest/mainnet",
-    "RateLimit": {
-      "Apply": false,
-      "Except": null,
-      "BlocksPerSecond": 0,
-      "BurstSize": 500
-    },
     "ResendDirectAnnounce": false,
     "StoreBatchSize": 8192,
     "SyncSegmentDepthLimit": 2000,

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
@@ -33,8 +33,10 @@
     "MinimumPeers": 4
   },
   "Datastore": {
-    "Type": "levelds",
-    "Dir": "/data/datastore"
+    "AdTmpDir": "/data/adtmpstore",
+    "AdTmpType": "levelds",
+    "Dir": "/data/datastore",
+    "Type": "levelds"
   },
   "Discovery": {
     "FilterIPs": true,

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kepa/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kepa/config.json
@@ -33,14 +33,13 @@
     "MinimumPeers": 4
   },
   "Datastore": {
-    "AdTmpDir": "/data/adtmpstore",
-    "AdTmpType": "levelds",
     "Dir": "/data/datastore",
-    "Type": "levelds"
+    "Type": "levelds",
+    "TmpDir": "/data/tmpstore",
+    "TmpType": "levelds"
   },
   "Discovery": {
     "FilterIPs": true,
-    "LotusGateway": "wss://api.chain.love",
     "Policy": {
       "Allow": true,
       "Except": [
@@ -71,12 +70,6 @@
     "HttpSyncTimeout": "10s",
     "IngestWorkerCount": 20,
     "PubSubTopic": "/indexer/ingest/mainnet",
-    "RateLimit": {
-      "Apply": false,
-      "Except": null,
-      "BlocksPerSecond": 0,
-      "BurstSize": 500
-    },
     "ResendDirectAnnounce": false,
     "StoreBatchSize": 8192,
     "SyncSegmentDepthLimit": 2000,

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kepa/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/kepa/config.json
@@ -33,8 +33,10 @@
     "MinimumPeers": 4
   },
   "Datastore": {
-    "Type": "levelds",
-    "Dir": "/data/datastore"
+    "AdTmpDir": "/data/adtmpstore",
+    "AdTmpType": "levelds",
+    "Dir": "/data/datastore",
+    "Type": "levelds"
   },
   "Discovery": {
     "FilterIPs": true,

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/config.json
@@ -33,14 +33,13 @@
     "MinimumPeers": 4
   },
   "Datastore": {
-    "AdTmpDir": "/data/adtmpstore",
-    "AdTmpType": "levelds",
     "Dir": "/data/datastore",
-    "Type": "levelds"
+    "Type": "levelds",
+    "TmpDir": "/data/tmpstore",
+    "TmpType": "levelds"
   },
   "Discovery": {
     "FilterIPs": true,
-    "LotusGateway": "wss://api.chain.love",
     "Policy": {
       "Allow": true,
       "Except": [
@@ -71,12 +70,6 @@
     "HttpSyncTimeout": "10s",
     "IngestWorkerCount": 20,
     "PubSubTopic": "/indexer/ingest/mainnet",
-    "RateLimit": {
-      "Apply": false,
-      "Except": null,
-      "BlocksPerSecond": 0,
-      "BurstSize": 500
-    },
     "ResendDirectAnnounce": false,
     "StoreBatchSize": 8192,
     "SyncSegmentDepthLimit": 2000,

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/config.json
@@ -33,8 +33,10 @@
     "MinimumPeers": 4
   },
   "Datastore": {
-    "Type": "levelds",
-    "Dir": "/data/datastore"
+    "AdTmpDir": "/data/adtmpstore",
+    "AdTmpType": "levelds",
+    "Dir": "/data/datastore",
+    "Type": "levelds"
   },
   "Discovery": {
     "FilterIPs": true,

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
-	"github.com/ipfs/go-datastore/namespace"
 	"github.com/ipfs/go-datastore/query"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/ipld/go-ipld-prime"
@@ -40,8 +39,6 @@ var log = logging.Logger("indexer/ingest")
 
 // prefix used to track latest sync in datastore.
 const (
-	// adTmpNS is a datastore namespace for temporary advertisement data.
-	adTmpNS = "adTmp"
 	// syncPrefix identifies the latest sync for each provider.
 	syncPrefix = "/sync/"
 	// adProcessedPrefix identifies all processed advertisements.
@@ -178,7 +175,7 @@ type Ingester struct {
 
 // NewIngester creates a new Ingester that uses a dagsync Subscriber to handle
 // communication with providers.
-func NewIngester(cfg config.Ingest, h host.Host, idxr indexer.Interface, reg *registry.Registry, ds datastore.Batching, options ...Option) (*Ingester, error) {
+func NewIngester(cfg config.Ingest, h host.Host, idxr indexer.Interface, reg *registry.Registry, ds, dsAdTmp datastore.Batching, options ...Option) (*Ingester, error) {
 	opts, err := getOpts(options)
 	if err != nil {
 		return nil, err
@@ -187,7 +184,6 @@ func NewIngester(cfg config.Ingest, h host.Host, idxr indexer.Interface, reg *re
 	if cfg.IngestWorkerCount == 0 {
 		return nil, errors.New("ingester worker count must be > 0")
 	}
-	dsAdTmp := namespace.Wrap(ds, datastore.NewKey(adTmpNS))
 
 	ing := &Ingester{
 		host:        h,

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -373,7 +373,7 @@ func TestRestartDuringSync(t *testing.T) {
 	// Now we bring up the ingester again.
 	ingesterHost := mkTestHost(libp2p.Identity(te.ingesterPriv))
 	connectHosts(t, te.pubHost, ingesterHost)
-	ingester, err := NewIngester(defaultTestIngestConfig, ingesterHost, te.ingester.indexer, mkRegistry(t), te.ingester.ds)
+	ingester, err := NewIngester(defaultTestIngestConfig, ingesterHost, te.ingester.indexer, mkRegistry(t), te.ingester.ds, te.ingester.dsAdTmp)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		ingester.Close()
@@ -1801,10 +1801,11 @@ func mkIngest(t *testing.T, h host.Host) (*Ingester, *engine.Engine, *registry.R
 
 func mkIngestWithConfig(t *testing.T, h host.Host, cfg config.Ingest) (*Ingester, *engine.Engine, *registry.Registry, *counter.IndexCounts) {
 	store := dssync.MutexWrap(datastore.NewMapDatastore())
+	adTmpStore := dssync.MutexWrap(datastore.NewMapDatastore())
 	reg := mkRegistry(t)
 	core := mkIndexer(t, true)
 	indexCounts := counter.NewIndexCounts(store)
-	ing, err := NewIngester(cfg, h, core, reg, store, WithIndexCounts(indexCounts))
+	ing, err := NewIngester(cfg, h, core, reg, store, adTmpStore, WithIndexCounts(indexCounts))
 	require.NoError(t, err)
 	return ing, core, reg, indexCounts
 }

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -1801,11 +1801,11 @@ func mkIngest(t *testing.T, h host.Host) (*Ingester, *engine.Engine, *registry.R
 
 func mkIngestWithConfig(t *testing.T, h host.Host, cfg config.Ingest) (*Ingester, *engine.Engine, *registry.Registry, *counter.IndexCounts) {
 	store := dssync.MutexWrap(datastore.NewMapDatastore())
-	adTmpStore := dssync.MutexWrap(datastore.NewMapDatastore())
+	tmpStore := dssync.MutexWrap(datastore.NewMapDatastore())
 	reg := mkRegistry(t)
 	core := mkIndexer(t, true)
 	indexCounts := counter.NewIndexCounts(store)
-	ing, err := NewIngester(cfg, h, core, reg, store, adTmpStore, WithIndexCounts(indexCounts))
+	ing, err := NewIngester(cfg, h, core, reg, store, tmpStore, WithIndexCounts(indexCounts))
 	require.NoError(t, err)
 	return ing, core, reg, indexCounts
 }

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -373,7 +373,7 @@ func TestRestartDuringSync(t *testing.T) {
 	// Now we bring up the ingester again.
 	ingesterHost := mkTestHost(libp2p.Identity(te.ingesterPriv))
 	connectHosts(t, te.pubHost, ingesterHost)
-	ingester, err := NewIngester(defaultTestIngestConfig, ingesterHost, te.ingester.indexer, mkRegistry(t), te.ingester.ds, te.ingester.dsAdTmp)
+	ingester, err := NewIngester(defaultTestIngestConfig, ingesterHost, te.ingester.indexer, mkRegistry(t), te.ingester.ds, te.ingester.dsTmp)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		ingester.Close()

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -421,7 +421,7 @@ func (ing *Ingester) ingestHamtFromPublisher(ctx context.Context, ad schema.Adve
 	if !ing.mirror.canWrite() {
 		defer func() {
 			for _, c := range hamtCids {
-				err := ing.ds.Delete(ctx, datastore.NewKey(c.String()))
+				err := ing.dsAdTmp.Delete(ctx, datastore.NewKey(c.String()))
 				if err != nil {
 					log.Errorw("Error deleting HAMT cid from datastore", "cid", c, "err", err)
 				}
@@ -645,7 +645,7 @@ func (ing *Ingester) ingestEntryChunk(ctx context.Context, ad schema.Advertiseme
 	err := ing.indexAdMultihashes(ad, providerID, chunk.Entries, log)
 	if !ing.mirror.canWrite() {
 		// Done processing entries chunk, so remove from datastore.
-		if err := ing.ds.Delete(ctx, datastore.NewKey(entryChunkCid.String())); err != nil {
+		if err := ing.dsAdTmp.Delete(ctx, datastore.NewKey(entryChunkCid.String())); err != nil {
 			log.Errorw("Error deleting index from datastore", "err", err)
 		}
 	}
@@ -747,8 +747,7 @@ func (ing *Ingester) loadHamt(c cid.Cid) (*hamt.Node, error) {
 }
 
 func (ing *Ingester) loadNode(c cid.Cid, prototype ipld.NodePrototype) (ipld.Node, error) {
-	key := datastore.NewKey(c.String())
-	val, err := ing.ds.Get(context.Background(), key)
+	val, err := ing.dsAdTmp.Get(context.Background(), datastore.NewKey(c.String()))
 	if err != nil {
 		return nil, fmt.Errorf("cannot fetch the node from datastore: %w", err)
 	}

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -421,7 +421,7 @@ func (ing *Ingester) ingestHamtFromPublisher(ctx context.Context, ad schema.Adve
 	if !ing.mirror.canWrite() {
 		defer func() {
 			for _, c := range hamtCids {
-				err := ing.dsAdTmp.Delete(ctx, datastore.NewKey(c.String()))
+				err := ing.dsTmp.Delete(ctx, datastore.NewKey(c.String()))
 				if err != nil {
 					log.Errorw("Error deleting HAMT cid from datastore", "cid", c, "err", err)
 				}
@@ -645,7 +645,7 @@ func (ing *Ingester) ingestEntryChunk(ctx context.Context, ad schema.Advertiseme
 	err := ing.indexAdMultihashes(ad, providerID, chunk.Entries, log)
 	if !ing.mirror.canWrite() {
 		// Done processing entries chunk, so remove from datastore.
-		if err := ing.dsAdTmp.Delete(ctx, datastore.NewKey(entryChunkCid.String())); err != nil {
+		if err := ing.dsTmp.Delete(ctx, datastore.NewKey(entryChunkCid.String())); err != nil {
 			log.Errorw("Error deleting index from datastore", "err", err)
 		}
 	}
@@ -747,7 +747,7 @@ func (ing *Ingester) loadHamt(c cid.Cid) (*hamt.Node, error) {
 }
 
 func (ing *Ingester) loadNode(c cid.Cid, prototype ipld.NodePrototype) (ipld.Node, error) {
-	val, err := ing.dsAdTmp.Get(context.Background(), datastore.NewKey(c.String()))
+	val, err := ing.dsTmp.Get(context.Background(), datastore.NewKey(c.String()))
 	if err != nil {
 		return nil, fmt.Errorf("cannot fetch the node from datastore: %w", err)
 	}

--- a/server/admin/server_test.go
+++ b/server/admin/server_test.go
@@ -301,11 +301,11 @@ func initIndex(t *testing.T, withCache bool) indexer.Interface {
 func initIngest(t *testing.T, indx indexer.Interface, reg *registry.Registry) *ingest.Ingester {
 	cfg := config.NewIngest()
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
-	dsAdTmp := dssync.MutexWrap(datastore.NewMapDatastore())
+	dsTmp := dssync.MutexWrap(datastore.NewMapDatastore())
 	host, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
 	require.NoError(t, err)
 
-	ing, err := ingest.NewIngester(cfg, host, indx, reg, ds, dsAdTmp)
+	ing, err := ingest.NewIngester(cfg, host, indx, reg, ds, dsTmp)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		ing.Close()

--- a/server/admin/server_test.go
+++ b/server/admin/server_test.go
@@ -301,11 +301,11 @@ func initIndex(t *testing.T, withCache bool) indexer.Interface {
 func initIngest(t *testing.T, indx indexer.Interface, reg *registry.Registry) *ingest.Ingester {
 	cfg := config.NewIngest()
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
-	adTmpDS := dssync.MutexWrap(datastore.NewMapDatastore())
+	dsAdTmp := dssync.MutexWrap(datastore.NewMapDatastore())
 	host, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
 	require.NoError(t, err)
 
-	ing, err := ingest.NewIngester(cfg, host, indx, reg, ds, adTmpDS)
+	ing, err := ingest.NewIngester(cfg, host, indx, reg, ds, dsAdTmp)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		ing.Close()

--- a/server/admin/server_test.go
+++ b/server/admin/server_test.go
@@ -301,10 +301,11 @@ func initIndex(t *testing.T, withCache bool) indexer.Interface {
 func initIngest(t *testing.T, indx indexer.Interface, reg *registry.Registry) *ingest.Ingester {
 	cfg := config.NewIngest()
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
+	adTmpDS := dssync.MutexWrap(datastore.NewMapDatastore())
 	host, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
 	require.NoError(t, err)
 
-	ing, err := ingest.NewIngester(cfg, host, indx, reg, ds)
+	ing, err := ingest.NewIngester(cfg, host, indx, reg, ds, adTmpDS)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		ing.Close()

--- a/server/ingest/handler_test.go
+++ b/server/ingest/handler_test.go
@@ -79,8 +79,8 @@ func TestHandleRegisterProvider(t *testing.T) {
 	require.NoError(t, err)
 
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
-	adTmpDS := dssync.MutexWrap(datastore.NewMapDatastore())
-	ing, err := ingest.NewIngester(config.NewIngest(), host, idx, reg, ds, adTmpDS)
+	dsAdTmp := dssync.MutexWrap(datastore.NewMapDatastore())
+	ing, err := ingest.NewIngester(config.NewIngest(), host, idx, reg, ds, dsAdTmp)
 	require.NoError(t, err)
 
 	s, err := New("127.0.0.1:", idx, ing, reg)

--- a/server/ingest/handler_test.go
+++ b/server/ingest/handler_test.go
@@ -79,7 +79,8 @@ func TestHandleRegisterProvider(t *testing.T) {
 	require.NoError(t, err)
 
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
-	ing, err := ingest.NewIngester(config.NewIngest(), host, idx, reg, ds)
+	adTmpDS := dssync.MutexWrap(datastore.NewMapDatastore())
+	ing, err := ingest.NewIngester(config.NewIngest(), host, idx, reg, ds, adTmpDS)
 	require.NoError(t, err)
 
 	s, err := New("127.0.0.1:", idx, ing, reg)

--- a/server/ingest/handler_test.go
+++ b/server/ingest/handler_test.go
@@ -79,8 +79,8 @@ func TestHandleRegisterProvider(t *testing.T) {
 	require.NoError(t, err)
 
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
-	dsAdTmp := dssync.MutexWrap(datastore.NewMapDatastore())
-	ing, err := ingest.NewIngester(config.NewIngest(), host, idx, reg, ds, dsAdTmp)
+	dsTmp := dssync.MutexWrap(datastore.NewMapDatastore())
+	ing, err := ingest.NewIngester(config.NewIngest(), host, idx, reg, ds, dsTmp)
 	require.NoError(t, err)
 
 	s, err := New("127.0.0.1:", idx, ing, reg)

--- a/server/ingest/protocol_test.go
+++ b/server/ingest/protocol_test.go
@@ -132,11 +132,11 @@ func initRegistry(t *testing.T, trustedID string) *registry.Registry {
 func initIngest(t *testing.T, indx indexer.Interface, reg *registry.Registry) *ingest.Ingester {
 	cfg := config.NewIngest()
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
-	adTmpDS := dssync.MutexWrap(datastore.NewMapDatastore())
+	dsAdTmp := dssync.MutexWrap(datastore.NewMapDatastore())
 	host, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
 	require.NoError(t, err)
 
-	ing, err := ingest.NewIngester(cfg, host, indx, reg, ds, adTmpDS)
+	ing, err := ingest.NewIngester(cfg, host, indx, reg, ds, dsAdTmp)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		ing.Close()

--- a/server/ingest/protocol_test.go
+++ b/server/ingest/protocol_test.go
@@ -132,11 +132,11 @@ func initRegistry(t *testing.T, trustedID string) *registry.Registry {
 func initIngest(t *testing.T, indx indexer.Interface, reg *registry.Registry) *ingest.Ingester {
 	cfg := config.NewIngest()
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
-	dsAdTmp := dssync.MutexWrap(datastore.NewMapDatastore())
+	dsTmp := dssync.MutexWrap(datastore.NewMapDatastore())
 	host, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
 	require.NoError(t, err)
 
-	ing, err := ingest.NewIngester(cfg, host, indx, reg, ds, dsAdTmp)
+	ing, err := ingest.NewIngester(cfg, host, indx, reg, ds, dsTmp)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		ing.Close()

--- a/server/ingest/protocol_test.go
+++ b/server/ingest/protocol_test.go
@@ -132,10 +132,11 @@ func initRegistry(t *testing.T, trustedID string) *registry.Registry {
 func initIngest(t *testing.T, indx indexer.Interface, reg *registry.Registry) *ingest.Ingester {
 	cfg := config.NewIngest()
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
+	adTmpDS := dssync.MutexWrap(datastore.NewMapDatastore())
 	host, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
 	require.NoError(t, err)
 
-	ing, err := ingest.NewIngester(cfg, host, indx, reg, ds)
+	ing, err := ingest.NewIngester(cfg, host, indx, reg, ds, adTmpDS)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		ing.Close()


### PR DESCRIPTION
- Configure indexers to use separate datastore for ad and fsm data.
- Remove old previous version data-transfer fsm records
- Remove current version data-transfer fsm records
- Remove advertisement and entries data blocks
- Record new datastore version string

Fixes #1380 