### PR TITLE
Increase dhfind-helga memory to match dhfind

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind-helga/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind-helga/deployment.yaml
@@ -25,7 +25,7 @@ spec:
           resources:
             limits:
               cpu: "1.5"
-              memory: 1Gi
+              memory: 2Gi
             requests:
               cpu: "1.5"
-              memory: 1Gi
+              memory: 2Gi


### PR DESCRIPTION
Had OOM event on dhfind-helga, so increasing memory to match dhfind.
