### PR TITLE
Revert "Reduce workers on oden from 20 to 10"

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/config.json
@@ -77,7 +77,7 @@
     "HttpSyncRetryWaitMax": "30s",
     "HttpSyncRetryWaitMin": "1s",
     "HttpSyncTimeout": "10s",
-    "IngestWorkerCount": 10,
+    "IngestWorkerCount": 20,
     "PubSubTopic": "/indexer/ingest/mainnet",
     "RateLimit": {
       "Apply": false,


### PR DESCRIPTION
Reverts ipni/storetheindex#1698

After some hours, it does not seem to make much difference. Putting back to 20 to compare stack traces.