### PR TITLE
Plug in existing backends to canary

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar-canary/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar-canary/deployment.yaml
@@ -22,9 +22,11 @@ spec:
             - '--translateNonStreaming'
             # Use service names local to the namespace over HTTP to avoid
             # TLS handshake overhead.
-            - '--backends=http://inga-indexer:3000/'
             - '--backends=http://dhfind.internal.prod.cid.contact/'
             - '--backends=http://dhfind-helga.internal.prod.cid.contact/'
+            - '--backends=http://dido-indexer:3000/'
+            - '--backends=http://oden-indexer:3000/'
+            - '--backends=http://kepa-indexer:3000/'
             - '--cascadeBackends=http://caskadht.internal.prod.cid.contact/'
             - '--cascadeBackends=http://cassette.internal.prod.cid.contact/'
           env:


### PR DESCRIPTION
Adding temporary existing backends to canary to backfill for unretrievable ads