### PR TITLE
Log when provider has been seen last time

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -412,6 +412,7 @@ func (r *Registry) Saw(provider peer.ID) {
 			pinfo := r.providers[provider]
 			pinfo.lastContactTime = time.Now()
 			pinfo.inactive = false
+			log.Infow("Saw provider", "provider", provider, "time", pinfo.lastContactTime)
 		}
 		close(done)
 	}


### PR DESCRIPTION
This log message will help to debug recent provider "disappearances" on `oden`