### PR TITLE
Fix poll override causing provider deactivation

### DIFF
--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -1804,7 +1804,6 @@ func mkRegistry(t *testing.T) *registry.Registry {
 			Allow:   true,
 			Publish: true,
 		},
-		PollInterval: config.Duration(time.Minute),
 	}
 	reg, err := registry.New(context.Background(), discoveryCfg, nil)
 	require.NoError(t, err)

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -42,7 +42,6 @@ var discoveryCfg = config.Discovery{
 		Publish:       false,
 		PublishExcept: []string{publisherID},
 	},
-	PollInterval: config.Duration(time.Minute),
 }
 
 func TestUpdateNewProvider(t *testing.T) {
@@ -51,7 +50,6 @@ func TestUpdateNewProvider(t *testing.T) {
 
 	r, err := New(ctx, discoveryCfg, nil)
 	require.NoError(t, err)
-	t.Log("created new registry")
 
 	peerID, err := peer.Decode(limitedID)
 	require.NoError(t, err)
@@ -352,6 +350,9 @@ func TestPollProvider(t *testing.T) {
 			Allow:   true,
 			Publish: true,
 		},
+		PollInterval:   config.Duration(time.Hour),
+		PollRetryAfter: config.Duration(time.Millisecond),
+		PollStopAfter:  config.Duration(time.Millisecond),
 	}
 
 	ctx := context.Background()

--- a/server/admin/http/server_test.go
+++ b/server/admin/http/server_test.go
@@ -287,8 +287,7 @@ func initRegistry(t *testing.T, trustedID string) *registry.Registry {
 			Publish:       false,
 			PublishExcept: []string{trustedID},
 		},
-		PollInterval: config.Duration(time.Minute),
-		UseAssigner:  true,
+		UseAssigner: true,
 	}
 	reg, err := registry.New(context.Background(), discoveryCfg, nil)
 	require.NoError(t, err)

--- a/server/find/test/test.go
+++ b/server/find/test/test.go
@@ -49,9 +49,7 @@ func InitRegistry(t *testing.T) *registry.Registry {
 
 // InitRegistry initializes a new registry
 func InitRegistryWithRestrictivePolicy(t *testing.T, restrictive bool) *registry.Registry {
-	var discoveryCfg = config.Discovery{
-		PollInterval: config.Duration(time.Minute),
-	}
+	var discoveryCfg = config.Discovery{}
 	if restrictive {
 		discoveryCfg.Policy = config.Policy{
 			Allow:   false,

--- a/server/ingest/test/test.go
+++ b/server/ingest/test/test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
@@ -43,7 +42,6 @@ func InitRegistry(t *testing.T, trustedID string) *registry.Registry {
 			Publish:       false,
 			PublishExcept: []string{trustedID},
 		},
-		PollInterval: config.Duration(time.Minute),
 	}
 	reg, err := registry.New(context.Background(), discoveryCfg, nil)
 	require.NoError(t, err)


### PR DESCRIPTION
There are really two defects here:
1. A default for `deactivateAfter` is not being set correctly when there is an override.
2. Once an override is encountered, the poll keeps the value of the override for all following providers. It needs to be restored to the previous value for the next provider.

This PR fixes both of these issues.
