### PR TITLE
Remove poll override since announce is relayed by assigner

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/oden/config.json
@@ -50,14 +50,7 @@
     "PollInterval": "24h0m0s",
     "PollRetryAfter": "5h0m0s",
     "PollStopAfter": "168h0m0s",
-    "PollOverrides": [
-      {
-        "ProviderID": "QmQzqxhK82kAmKvARFZSkUVS6fo9sySaiogAnx5EnZ6ZmC",
-        "Interval": "30m0s",
-        "RetryAfter": "10m0s",
-        "StopAfter": "168h0m0s"
-      }
-    ],
+    "PollOverrides": null,
     "RediscoverWait": "5m0s",
     "Timeout": "2m0s",
     "RemoveOldAssignments": true,


### PR DESCRIPTION
Poll override was being used to fetch NFT provider updates by polling. Since the HTTP announce is forwarded by the assigner service, this is not needed.