### PR TITLE
Make sti nodes first indexstar backends

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -16,11 +16,11 @@ spec:
             - '--translateNonStreaming'
             # Use service names local to the namespace over HTTP to avoid
             # TLS handshake overhead.
+            - '--backends=http://dido-indexer:3000/'
+            - '--backends=http://kepa-indexer:3000/'
+            - '--backends=http://oden-indexer:3000/'
             - '--backends=http://dhfind.internal.prod.cid.contact/'
             - '--backends=http://dhfind-helga.internal.prod.cid.contact/'
-            - '--backends=http://dido-indexer:3000/'
-            - '--backends=http://oden-indexer:3000/'
-            - '--backends=http://kepa-indexer:3000/'
             - '--cascadeBackends=http://caskadht.internal.prod.cid.contact/'
             - '--cascadeBackends=http://cassette.internal.prod.cid.contact/'
           env:


### PR DESCRIPTION
Indexstar forwards `/` endpoint to first backend, and this needs to be a storetheindex node.
