### PR TITLE
Automate image update for `lassie-event-recorder`

### DIFF
--- a/deploy/manifests/dev/us-east-2/cluster/autoretrieve/event-recorder-cd.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/autoretrieve/event-recorder-cd.yaml
@@ -1,0 +1,22 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageRepository
+metadata:
+  name: lassie-event-recorder
+spec:
+  interval: 5m
+  image: ghcr.io/filecoin-project/lassie-event-recorder
+
+---
+apiVersion: image.toolkit.fluxcd.io/v1alpha1
+kind: ImagePolicy
+metadata:
+  name: lassie-event-recorder
+spec:
+  filterTags:
+    pattern: '^(?P<date>\d+)-(?P<time>\d+)-.+$'
+    extract: '$date$time'
+  policy:
+    numerical:
+      order: asc
+  imageRepositoryRef:
+    name: lassie-event-recorder

--- a/deploy/manifests/dev/us-east-2/cluster/autoretrieve/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/autoretrieve/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - flux-cd.yaml
   - flux-rbac.yaml
   - github-auth.yaml
+  - event-recorder-cd.yaml


### PR DESCRIPTION
Set image repo and selection policy for lassie event recorder in order to automate the image image update and deployment.

This change will eliminate the need to manually restart the event recorder pods in order to reflect the changes of the latest built image.
