### PR TITLE
Switch writes to the original dhstore

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
@@ -63,8 +63,8 @@
     "DisableWAL": true,
     "VSNoNewMH": true,
     "DHBatchSize": 5000,
-    "DHStoreURL": "http://dhstore-helga.internal.prod.cid.contact",
-    "DHStoreClusterURLs": ["http://dhstore.internal.prod.cid.contact"],
+    "DHStoreURL": "http://dhstore.internal.prod.cid.contact",
+    "DHStoreClusterURLs": ["http://dhstore-helga.internal.prod.cid.contact"],
     "DHStoreHttpClientTimeout": "60s"
   },
   "Ingest": {


### PR DESCRIPTION
* `dhstore-helga` is 80% full and will trigger an alert soon
* switch writes to the original `dhstore` that is 60% full
* once both dhstores fill up - set up a new one with approx 5TiBs that is going to be used until consistent hashing cluster is fully live and caught up
