### PR TITLE
Define initial dhstore cluster in `dev`

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/eks.tf
+++ b/deploy/infrastructure/dev/us-east-2/eks.tf
@@ -74,9 +74,23 @@ module "eks" {
     }
     
     # Memory optimised node groups primarily used to run indexer nodes.
+    dev-ue2a-r5n-2xl = {
+      min_size       = 1
+      max_size       = 5
+      desired_size   = 1
+      instance_types = ["r5n.2xlarge"]
+      subnet_ids     = [data.aws_subnet.ue2a2.id]
+      taints         = {
+        dedicated = {
+          key    = "dedicated"
+          value  = "r5n-2xl"
+          effect = "NO_SCHEDULE"
+        }
+      }
+    }
     dev-ue2b-r5n-2xl = {
       min_size       = 1
-      max_size       = 3
+      max_size       = 5
       desired_size   = 1
       instance_types = ["r5n.2xlarge"]
       subnet_ids     = [data.aws_subnet.ue2b2.id]
@@ -90,7 +104,7 @@ module "eks" {
     }
     dev-ue2c-r5n-2xl = {
       min_size       = 1
-      max_size       = 3
+      max_size       = 5
       desired_size   = 1
       instance_types = ["r5n.2xlarge"]
       subnet_ids     = [data.aws_subnet.ue2c2.id]

--- a/deploy/manifests/base/envoy/envoy-config.yaml
+++ b/deploy/manifests/base/envoy/envoy-config.yaml
@@ -1,0 +1,7 @@
+# Envoy config; see:  https://www.envoyproxy.io/docs/envoy/latest/configuration/configuration
+# Override this file in your kustomization overlay; example:
+# configMapGenerator:
+#   - name: envoy-config
+#     behavior: replace
+#     files:
+#       - envoy-config.yaml

--- a/deploy/manifests/base/envoy/envoy-deployment.yaml
+++ b/deploy/manifests/base/envoy/envoy-deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: envoy
+  labels:
+    app: envoy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: envoy
+  progressDeadlineSeconds: 180
+  template:
+    metadata:
+      labels:
+        app: envoy
+    spec:
+      containers:
+        - name: envoy
+          image: envoyproxy/envoy:distroless-v1.26.1
+          args:
+            - --log-level
+            - info
+            - --config-path
+            - '/config/envoy-config.yaml'
+          env:
+            - name: ENVOY_UID
+              value: '0'
+          securityContext:
+            runAsUser: 10001
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - all
+          ports:
+            - name: http
+              containerPort: 8080
+            - name: admin
+              containerPort: 9901
+          livenessProbe:
+            initialDelaySeconds: 3
+            tcpSocket:
+              port: admin
+          readinessProbe:
+            initialDelaySeconds: 3
+            tcpSocket:
+              port: admin
+          resources:
+            requests:
+              cpu: 300m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          volumeMounts:
+            - name: config
+              mountPath: /config
+      volumes:
+        - name: config
+          configMap:
+            name: "envoy-config"

--- a/deploy/manifests/base/envoy/envoy-pdb.yaml
+++ b/deploy/manifests/base/envoy/envoy-pdb.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: envoy
+  labels:
+    app: envoy
+spec:
+  selector:
+    matchLabels:
+      app: envoy
+  maxUnavailable: 1

--- a/deploy/manifests/base/envoy/kustomization.yaml
+++ b/deploy/manifests/base/envoy/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - envoy-deployment.yaml
+  - envoy-pdb.yaml
+
+configMapGenerator:
+  - name: envoy-config
+    behavior: create
+    files:
+      - envoy-config.yaml

--- a/deploy/manifests/dev/us-east-2/cluster/kube-system/aws-auth.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kube-system/aws-auth.yaml
@@ -47,6 +47,11 @@ data:
     - groups:
       - system:bootstrappers
       - system:nodes
+      rolearn: arn:aws:iam::407967248065:role/dev-ue2a-r5n-2xl-eks-node-group
+      username: system:node:{{EC2PrivateDNSName}}
+    - groups:
+      - system:bootstrappers
+      - system:nodes
       rolearn: arn:aws:iam::407967248065:role/dev-ue2b-r5n-2xl-eks-node-group
       username: system:node:{{EC2PrivateDNSName}}
     - groups:

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/base/dhstore/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/base/dhstore/deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dhstore
+spec:
+  template:
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+      containers:
+        - name: dhstore
+          args:
+            - '--storePath=/data'
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            limits:
+              cpu: "2"
+              memory: 30Gi
+            requests:
+              cpu: "2"
+              memory: 30Gi
+          ports:
+            - containerPort: 40081
+              name: metrics
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.kubernetes.io/instance-type
+                    operator: In
+                    values:
+                      - r5n.2xlarge
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: dhstore-data
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: r5n-2xl
+          effect: NoSchedule

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/base/dhstore/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/base/dhstore/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - github.com/ipni/dhstore/deploy/kubernetes?ref=58dfcad7aae9c172c68237dad25494625d8ac160
+  - pvc.yaml
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+commonLabels:
+  app: dhstore-cluster
+
+images:
+  - name: dhstore
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
+    newTag: 20230428094200-7bb69332d69590cafcda40d26988cc0489374380

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/base/dhstore/pvc.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/base/dhstore/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dhstore-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Ti
+  storageClassName: gp3-iops5k-t300

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/envoy/envoy-config.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/envoy/envoy-config.yaml
@@ -1,0 +1,158 @@
+admin:
+  access_log_path: /dev/stdout
+  address:
+    socket_address:
+      protocol: TCP
+      address: 0.0.0.0
+      port_value: 9901
+overload_manager:
+  refresh_interval: 0.25s
+  resource_monitors:
+    - name: "envoy.resource_monitors.fixed_heap"
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+        max_heap_size_bytes: 536870912 # 512 MiB
+  actions:
+    - name: "envoy.overload_actions.shrink_heap"
+      triggers:
+        - name: "envoy.resource_monitors.fixed_heap"
+          threshold:
+            value: 0.95
+    - name: "envoy.overload_actions.stop_accepting_requests"
+      triggers:
+        - name: "envoy.resource_monitors.fixed_heap"
+          threshold:
+            value: 0.98
+static_resources:
+  listeners:
+    - name: listener_8080
+      address:
+        socket_address:
+          protocol: TCP
+          address: 0.0.0.0
+          port_value: 8080
+      per_connection_buffer_limit_bytes: 32768 # 32 KiB
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: ingress_http
+                codec_type: AUTO
+                use_remote_address: true
+                normalize_path: true
+                merge_slashes: true
+                path_with_escaped_slashes_action: UNESCAPE_AND_REDIRECT
+                common_http_protocol_options:
+                  idle_timeout: 3600s # 1 hour
+                  headers_with_underscores_action: REJECT_REQUEST
+                # L2 recommended setting.
+                # See: https://www.envoyproxy.io/docs/envoy/latest/configuration/best_practices/level_two
+                stream_error_on_invalid_http_message: true
+                http2_protocol_options:
+                  max_concurrent_streams: 100
+                  initial_stream_window_size: 65536 # 64 KiB
+                  initial_connection_window_size: 1048576 # 1 MiB
+                stream_idle_timeout: 300s # 5 minutes
+                request_timeout: 300s # 5 minutes
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: local_service
+                      domains:
+                        - "*"
+                      routes:
+                        - match:
+                            prefix: "/"
+                          route:
+                            cluster: dhstore_service
+                            timeout: 60s
+                            hash_policy:
+                              - header:
+                                  # The header must be added by the downstream intermediate services. More explicitly,
+                                  # the key must be either a multihash or metadata key.
+                                  header_name: "x-ipni-dhstore-shard-key"
+                            retry_policy:
+                              retry_on: "cancelled,deadline-exceeded,internal,connect-failure,gateway-error,refused-stream,resource-exhausted,unavailable"
+                              num_retries: 3
+                              host_selection_retry_max_attempts: 3
+                              per_try_timeout: 5s
+                http_filters:
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+  clusters:
+    - name: dhstore_service
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      connect_timeout: 0.25s
+      per_connection_buffer_limit_bytes: 32768 # 32 KiB
+      lb_policy: MAGLEV
+      maglev_lb_config:
+        # Must be a prime number with maximum value of 5000011
+        # See: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-msg-config-cluster-v3-cluster-maglevlbconfig
+        table_size: 65537
+      common_lb_config:
+        consistent_hashing_lb_config:
+          use_hostname_for_hashing: true
+      load_assignment:
+        cluster_name: dhstore_service
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: cadi-dhstore
+                      port_value: 40080
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: aada-dhstore
+                      port_value: 40080
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: saar-dhstore
+                      port_value: 40080
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: aviv-dhstore
+                      port_value: 40080
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: dina-dhstore
+                      port_value: 40080
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: vesa-dhstore
+                      port_value: 40080
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: bala-dhstore
+                      port_value: 40080
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: maja-dhstore
+                      port_value: 40080
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: zora-dhstore
+                      port_value: 40080
+layered_runtime:
+  layers:
+    - name: static_layer_0
+      static_layer:
+        envoy:
+          resource_limits:
+            listener:
+              listener_8080:
+                connection_limit: 10000
+        overload:
+          global_downstream_max_connections: 50000

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/envoy/envoy-monitor.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/envoy/envoy-monitor.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: dhstore-cluster-envoy
+  labels:
+    app: envoy
+spec:
+  endpoints:
+    - path: "/stats/prometheus"
+      port: admin
+  selector:
+    matchLabels:
+      app: envoy

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/envoy/envoy-service.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/envoy/envoy-service.yaml
@@ -1,0 +1,13 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: dhstore-cluster-envoy
+  labels:
+    app: envoy
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+  selector:
+    app: envoy

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/envoy/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/envoy/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../../../../base/envoy
+  - envoy-monitor.yaml
+  - envoy-service.yaml
+
+configMapGenerator:
+  - name: envoy-config
+    behavior: replace
+    files:
+      - envoy-config.yaml

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - zone-a
+  - zone-b
+  - zone-c
+  - service-monitor.yaml
+
+images:
+  - name: dhstore
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
+    newTag: 20230428094200-7bb69332d69590cafcda40d26988cc0489374380

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/service-monitor.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/service-monitor.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: dhstore-cluster-instances2
+  labels:
+    app: dhstore-cluster
+spec:
+  endpoints:
+    - path: /metrics
+      port: metrics
+  selector:
+      matchLabels:
+        app: dhstore-cluster

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-a/aada/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-a/aada/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namePrefix: aada-
+
+commonLabels:
+  name: aada
+
+resources:
+  - ../../../base/dhstore
+
+patchesStrategicMerge:
+  - pvc.yaml

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-a/aada/pvc.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-a/aada/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dhstore-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Ti
+  storageClassName: gp3-iops5k-t300

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-a/cadi/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-a/cadi/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namePrefix: cadi-
+
+commonLabels:
+  name: cadi
+
+resources:
+  - ../../../base/dhstore
+
+patchesStrategicMerge:
+  - pvc.yaml

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-a/cadi/pvc.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-a/cadi/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dhstore-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Ti
+  storageClassName: gp3-iops5k-t300
+

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-a/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-a/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - aada
+  - cadi
+  - saar
+
+patches:
+  - path: zone-patch.yaml
+    target:
+      kind: Deployment

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-a/saar/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-a/saar/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namePrefix: saar-
+
+commonLabels:
+  name: saar
+
+resources:
+  - ../../../base/dhstore
+
+patchesStrategicMerge:
+  - pvc.yaml

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-a/saar/pvc.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-a/saar/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dhstore-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Ti
+  storageClassName: gp3-iops5k-t300

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-a/zone-patch.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-a/zone-patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dhstore
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: topology.kubernetes.io/zone
+                    operator: In
+                    values:
+                      - us-east-2a

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-b/aviv/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-b/aviv/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namePrefix: aviv-
+
+commonLabels:
+  name: aviv
+
+resources:
+  - ../../../base/dhstore
+
+patchesStrategicMerge:
+  - pvc.yaml

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-b/aviv/pvc.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-b/aviv/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dhstore-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Ti
+  storageClassName: gp3-iops5k-t300

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-b/dina/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-b/dina/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namePrefix: dina-
+
+commonLabels:
+  name: dina
+
+resources:
+  - ../../../base/dhstore
+
+patchesStrategicMerge:
+  - pvc.yaml

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-b/dina/pvc.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-b/dina/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dhstore-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Ti
+  storageClassName: gp3-iops5k-t300

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-b/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-b/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - aviv
+  - dina
+  - vesa
+
+patches:
+  - path: zone-patch.yaml
+    target:
+      kind: Deployment

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-b/vesa/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-b/vesa/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namePrefix: vesa-
+
+commonLabels:
+  name: vesa
+
+resources:
+  - ../../../base/dhstore
+
+patchesStrategicMerge:
+  - pvc.yaml

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-b/vesa/pvc.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-b/vesa/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dhstore-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Ti
+  storageClassName: gp3-iops5k-t300

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-b/zone-patch.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-b/zone-patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dhstore
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: topology.kubernetes.io/zone
+                    operator: In
+                    values:
+                      - us-east-2b

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-c/bala/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-c/bala/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namePrefix: bala-
+
+commonLabels:
+  name: bala
+
+resources:
+  - ../../../base/dhstore
+
+patchesStrategicMerge:
+  - pvc.yaml

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-c/bala/pvc.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-c/bala/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dhstore-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Ti
+  storageClassName: gp3-iops5k-t300

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-c/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-c/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - bala
+  - maja
+  - zora
+
+patches:
+  - path: zone-patch.yaml
+    target:
+      kind: Deployment

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-c/maja/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-c/maja/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namePrefix: maja-
+
+commonLabels:
+  name: maja
+
+resources:
+  - ../../../base/dhstore
+
+patchesStrategicMerge:
+  - pvc.yaml

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-c/maja/pvc.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-c/maja/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dhstore-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Ti
+  storageClassName: gp3-iops5k-t300

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-c/zone-patch.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-c/zone-patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dhstore
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: topology.kubernetes.io/zone
+                    operator: In
+                    values:
+                      - us-east-2c

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-c/zora/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-c/zora/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namePrefix: zora-
+
+commonLabels:
+  name: zora
+
+resources:
+  - ../../../base/dhstore
+
+patchesStrategicMerge:
+  - pvc.yaml

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-c/zora/pvc.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-c/zora/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dhstore-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Ti
+  storageClassName: gp3-iops5k-t300

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - envoy
+  - instances

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
 - lookout
 - cassette
 - heyfil
+- dhstore-cluster
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}


### PR DESCRIPTION
Define manifests that configures a cluster of dhstore instances fronted by envoy front proxy. The envoy front proxy is configured to distribute the requests using Maglev consistent hashing algorithm
