### PR TITLE
Increase memory and CPU limits for dhfind

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhfind/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhfind/deployment.yaml
@@ -16,8 +16,8 @@ spec:
             - '--stiAddr=http://ago-indexer:3000/'
           resources:
             limits:
-              cpu: "0.5"
-              memory: 1Gi
+              cpu: "1"
+              memory: 2Gi
             requests:
-              cpu: "0.5"
-              memory: 1Gi
+              cpu: "1"
+              memory: 2Gi


### PR DESCRIPTION
dhfind has restarted 11 times due to OOM.