### PR TITLE
Change ExtendedProviders behaviour to 'replace' instead of 'add'

### DIFF
--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -816,7 +816,7 @@ func TestSync(t *testing.T) {
 	defer pub.Close()
 	connectHosts(t, h, pubHost)
 
-	c1, mhs, providerID, privKey := publishRandomIndexAndAdv(t, pub, lsys, false, nil)
+	c1, mhs, providerID, privKey := publishRandomIndexAndAdv(t, pub, lsys, false, nil, cid.Undef)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
@@ -981,6 +981,58 @@ func TestSyncExtendedProvidersShouldBeOverridednOnEachAd(t *testing.T) {
 	})
 }
 
+func TestSyncSupplyEmpyExtendedProvidersActsAsRemove(t *testing.T) {
+	testSyncWithExtendedProviders(t, func(privKey crypto.PrivKey,
+		pubKey crypto.PubKey,
+		providerID peer.ID,
+		reg *registry.Registry,
+		lsys linking.LinkSystem,
+		pubHost host.Host,
+		ingester *Ingester, pub dagsync.Publisher) {
+
+		_, ad1Cid, mhs1 := publishAdvWithExtendedProviders(t, providerID, privKey, pubKey, pub, lsys, cid.Undef, "test-context-id", nil, false)
+		_, _, mhs2 := publishAdWithEmptyExtendedProviders(t, providerID, privKey, pubKey, pub, lsys, ad1Cid, "", nil)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		syncIngester(t, ctx, ingester, providerID, pubHost, mhs1, mhs2)
+
+		// there should be no extended providers
+		pInfo, _ := reg.ProviderInfo(providerID)
+		extendedProviders := pInfo.ExtendedProviders
+		require.NotNil(t, extendedProviders)
+		require.Equal(t, 0, len(extendedProviders.Providers))
+		require.Equal(t, 0, len(extendedProviders.ContextualProviders))
+	})
+}
+
+func TestSyncNilExtendedProvidersDontOverrideTheExistingOnes(t *testing.T) {
+	testSyncWithExtendedProviders(t, func(privKey crypto.PrivKey,
+		pubKey crypto.PubKey,
+		providerID peer.ID,
+		reg *registry.Registry,
+		lsys linking.LinkSystem,
+		pubHost host.Host,
+		ingester *Ingester, pub dagsync.Publisher) {
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		ad1, ad1Cid, mhs1 := publishAdvWithExtendedProviders(t, providerID, privKey, pubKey, pub, lsys, cid.Undef, "", nil, false)
+		syncIngester(t, ctx, ingester, providerID, pubHost, mhs1)
+		_, mhs2, pID, _ := publishRandomIndexAndAdv(t, pub, lsys, false, nil, ad1Cid)
+		syncIngester(t, ctx, ingester, pID, pubHost, mhs2)
+
+		// there should be no extended providers
+		pInfo, _ := reg.ProviderInfo(providerID)
+		extendedProviders := pInfo.ExtendedProviders
+		require.NotNil(t, extendedProviders)
+		require.Equal(t, len(ad1.ExtendedProvider.Providers), len(extendedProviders.Providers))
+		require.Equal(t, 0, len(extendedProviders.ContextualProviders))
+	})
+}
+
 func syncIngester(t *testing.T, ctx context.Context, ingester *Ingester, providerID peer.ID, pubHost host.Host, mhs ...[]multihash.Multihash) {
 	peerInfo := peer.AddrInfo{
 		ID:    pubHost.ID(),
@@ -1058,7 +1110,7 @@ func TestSyncTooLargeMetadata(t *testing.T) {
 	metadata := make([]byte, schema.MaxMetadataLen*2)
 	copy(metadata, []byte("too-long"))
 
-	publishRandomIndexAndAdv(t, pub, lsys, false, metadata)
+	publishRandomIndexAndAdv(t, pub, lsys, false, metadata, cid.Undef)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -1096,7 +1148,7 @@ func TestSyncSkipNoMetadata(t *testing.T) {
 	connectHosts(t, h, pubHost)
 
 	// Test ad that has no entries and no metadata.
-	adCid, _, providerID, _ := publishRandomIndexAndAdvWithEntriesChunkCount(t, pub, lsys, false, 0, []byte{})
+	adCid, _, providerID, _ := publishRandomIndexAndAdvWithEntriesChunkCount(t, pub, lsys, false, 0, []byte{}, cid.Undef)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -1123,7 +1175,7 @@ func TestSyncSkipNoMetadata(t *testing.T) {
 	require.Equal(t, adCid, pInfo.LastAdvertisement)
 
 	// Test ad that has entries and no metadata.
-	adCid, _, providerID, _ = publishRandomIndexAndAdvWithEntriesChunkCount(t, pub, lsys, false, 10, []byte{})
+	adCid, _, providerID, _ = publishRandomIndexAndAdvWithEntriesChunkCount(t, pub, lsys, false, 10, []byte{}, cid.Undef)
 	endCid, err = i.Sync(ctx, peerInfo, 0, false)
 	require.NoError(t, err)
 	require.Equal(t, adCid, endCid)
@@ -1225,7 +1277,7 @@ func TestRecursionDepthLimitsEntriesSync(t *testing.T) {
 	// for testing.
 	ing.entriesSel = Selectors.EntriesWithLimit(selector.RecursionLimitDepth(entriesDepth))
 
-	adCid, _, providerID, _ := publishRandomIndexAndAdvWithEntriesChunkCount(t, pub, lsys, false, totalChunkCount, nil)
+	adCid, _, providerID, _ := publishRandomIndexAndAdvWithEntriesChunkCount(t, pub, lsys, false, totalChunkCount, nil, cid.Undef)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -1825,11 +1877,11 @@ func newRandomLinkedList(t *testing.T, lsys ipld.LinkSystem, size int) (ipld.Lin
 	return nextLnk, out
 }
 
-func publishRandomIndexAndAdv(t *testing.T, pub dagsync.Publisher, lsys ipld.LinkSystem, fakeSig bool, metadata []byte) (cid.Cid, []multihash.Multihash, peer.ID, crypto.PrivKey) {
-	return publishRandomIndexAndAdvWithEntriesChunkCount(t, pub, lsys, fakeSig, testEntriesChunkCount, metadata)
+func publishRandomIndexAndAdv(t *testing.T, pub dagsync.Publisher, lsys ipld.LinkSystem, fakeSig bool, metadata []byte, prevAdCid cid.Cid) (cid.Cid, []multihash.Multihash, peer.ID, crypto.PrivKey) {
+	return publishRandomIndexAndAdvWithEntriesChunkCount(t, pub, lsys, fakeSig, testEntriesChunkCount, metadata, prevAdCid)
 }
 
-func publishRandomIndexAndAdvWithEntriesChunkCount(t *testing.T, pub dagsync.Publisher, lsys ipld.LinkSystem, fakeSig bool, eChunkCount int, metadata []byte) (cid.Cid, []multihash.Multihash, peer.ID, crypto.PrivKey) {
+func publishRandomIndexAndAdvWithEntriesChunkCount(t *testing.T, pub dagsync.Publisher, lsys ipld.LinkSystem, fakeSig bool, eChunkCount int, metadata []byte, prevAdCid cid.Cid) (cid.Cid, []multihash.Multihash, peer.ID, crypto.PrivKey) {
 
 	priv, pubKey, err := p2ptest.RandTestKeyPair(crypto.Ed25519, 256)
 	require.NoError(t, err)
@@ -1848,6 +1900,9 @@ func publishRandomIndexAndAdvWithEntriesChunkCount(t *testing.T, pub dagsync.Pub
 		Addresses: addrs,
 		ContextID: ctxID,
 		Metadata:  metadata,
+	}
+	if prevAdCid.Defined() {
+		adv.PreviousID = cidlink.Link{Cid: prevAdCid}
 	}
 	var mhs []multihash.Multihash
 	if eChunkCount == 0 {
@@ -1935,6 +1990,54 @@ func publishAdvWithExtendedProviders(t *testing.T,
 			return key, nil
 		}
 		return nil, fmt.Errorf("pk not found")
+	})
+	require.NoError(t, err)
+
+	node, err := adv.ToNode()
+	require.NoError(t, err)
+	advLnk, err := lsys.Store(ipld.LinkContext{}, schema.Linkproto, node)
+	require.NoError(t, err)
+	err = pub.UpdateRoot(context.Background(), advLnk.(cidlink.Link).Cid)
+	require.NoError(t, err)
+	return adv, advLnk.(cidlink.Link).Cid, mhs
+}
+
+func publishAdWithEmptyExtendedProviders(t *testing.T,
+	provider peer.ID,
+	privKey crypto.PrivKey,
+	pubKey crypto.PubKey,
+	pub dagsync.Publisher,
+	lsys ipld.LinkSystem,
+	prevAdId cid.Cid,
+	contextId string,
+	metadata []byte) (*schema.Advertisement, cid.Cid, []multihash.Multihash) {
+
+	eChunkCount := rng.Int()%15 + 1
+
+	if metadata == nil {
+		metadata = []byte("test-metadata")
+	}
+	addrs := []string{"/ip4/127.0.0.1/tcp/9999"}
+	mhsLnk, mhs := newRandomLinkedList(t, lsys, eChunkCount)
+
+	adv := &schema.Advertisement{
+		Provider:  provider.String(),
+		Addresses: addrs,
+		Entries:   mhsLnk,
+		ContextID: []byte(contextId),
+		Metadata:  metadata,
+		ExtendedProvider: &schema.ExtendedProvider{
+			Providers: []schema.Provider{},
+			Override:  false,
+		},
+	}
+
+	if prevAdId != cid.Undef {
+		adv.PreviousID = cidlink.Link{Cid: prevAdId}
+	}
+
+	err := adv.SignWithExtendedProviders(privKey, func(s string) (crypto.PrivKey, error) {
+		panic("should not be called")
 	})
 	require.NoError(t, err)
 

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -207,16 +207,8 @@ func (ing *Ingester) ingestAd(ctx context.Context, publisherID peer.ID, adCid ci
 			return adIngestError{adIngestIndexerErr, fmt.Errorf("override can not be set on extended provider without context id")}
 		}
 
-		// Fetching the existing ExtendedProvider record or creating a new one
-		existingPInfo, _ := ing.reg.ProviderInfo(providerID)
-		if existingPInfo != nil {
-			extendedProviders = existingPInfo.ExtendedProviders
-		}
-
-		if extendedProviders == nil {
-			extendedProviders = &registry.ExtendedProviders{
-				ContextualProviders: make(map[string]registry.ContextualExtendedProviders),
-			}
+		extendedProviders = &registry.ExtendedProviders{
+			ContextualProviders: make(map[string]registry.ContextualExtendedProviders),
 		}
 
 		// Creating ExtendedProviderInfo record for each of the providers.


### PR DESCRIPTION
Removed ExtendedProviders additive behaviour. Each ExtendedProviders advertisement will have to have a full set of ExtendedProviders from now on (no deltas). Additive behaviour makes updates and removals harder and is generally counterintuitive.


Context: https://filecoinproject.slack.com/archives/C02T827T9N0/p1684402768677939