### PR TITLE
Fix assigner service announce endpoint

### DIFF
--- a/assigner/server/server.go
+++ b/assigner/server/server.go
@@ -45,9 +45,12 @@ func New(listen string, assigner *core.Assigner, options ...Option) (*Server, er
 	}
 
 	// Direct announce.
-	mux.HandleFunc("/ingest/announce", s.announce)
+	mux.HandleFunc("/announce", s.announce)
 	// Health check.
 	mux.HandleFunc("/health", s.health)
+
+	// Depricated
+	mux.HandleFunc("/ingest/announce", s.announce)
 
 	return s, nil
 }
@@ -66,7 +69,7 @@ func (s *Server) Close() error {
 	return s.server.Shutdown(context.Background())
 }
 
-// PUT /ingest/announce
+// PUT /announce
 func (s *Server) announce(w http.ResponseWriter, r *http.Request) {
 	if !methodOK(w, r, http.MethodPut) {
 		return

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd
 	github.com/ipld/go-storethehash v0.3.13
 	github.com/ipni/go-indexer-core v0.7.7
-	github.com/ipni/go-libipni v0.0.9
+	github.com/ipni/go-libipni v0.1.0
 	github.com/libp2p/go-libp2p v0.27.3
 	github.com/libp2p/go-msgio v0.3.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -620,8 +620,8 @@ github.com/ipni/dhstore v0.0.2-0.20230324212407-ceb5f50e3bad h1:nS2Zq9bHG0eFzRjz
 github.com/ipni/dhstore v0.0.2-0.20230324212407-ceb5f50e3bad/go.mod h1:XI6XW5Eu97zY5PEK2ZRuESh8mYkxIZYRTMcknPVbbrc=
 github.com/ipni/go-indexer-core v0.7.7 h1:eHkC+HZkcFDC7uEayYkAMsRpMC8MbQ9ZQ1uQJy261dk=
 github.com/ipni/go-indexer-core v0.7.7/go.mod h1:03SY41l6ZC2gPRvDBuO8QMSpBSvd+P8NtUJEWgJxbNc=
-github.com/ipni/go-libipni v0.0.9 h1:u0R5dXUR+jNdbY5G0vtIf3/+z7G9Tv1QM6lq3ZVsdZA=
-github.com/ipni/go-libipni v0.0.9/go.mod h1:paYP9U4N3/vOzGCuN9kU972vtvw9JUcQjOKyiCFGwRk=
+github.com/ipni/go-libipni v0.1.0 h1:w4kLZv51AGezsoRsQEIZGw8SyyfMkBGWLmBdN+gE8AI=
+github.com/ipni/go-libipni v0.1.0/go.mod h1:iTYDXVB8tiQKe8gn3dN/+XF/XsgsiiR6xPAvU5waFnY=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=


### PR DESCRIPTION
Need assigner to use newer `/announce` HTTP endpoint to be compatible with go-libipni HTTP sender.

Fixes https://github.com/ipni/go-libipni/issues/36