### PR TITLE
Build and push images from `dh-key-sharding` for testing

### DIFF
--- a/.github/workflows/ecr-publisher.yml
+++ b/.github/workflows/ecr-publisher.yml
@@ -15,6 +15,8 @@ on:
     branches:
       - main
       - hack-process-deletes-only
+      # Testing https://github.com/ipni/storetheindex/pull/1759 in dev
+      - dh-key-sharding
 
 jobs:
   publisher:


### PR DESCRIPTION
Make a deployable container from `dh-key-sharding` branch for testing the sharding mechanims in dev.

See: https://github.com/ipni/storetheindex/pull/1759

