### PR TITLE
Gracefully skip not found content from HTTP publishers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd
 	github.com/ipld/go-storethehash v0.3.13
 	github.com/ipni/go-indexer-core v0.7.7
-	github.com/ipni/go-libipni v0.1.1-0.20230519151455-6b4cd0c25354
+	github.com/ipni/go-libipni v0.1.1
 	github.com/libp2p/go-libp2p v0.27.3
 	github.com/libp2p/go-msgio v0.3.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd
 	github.com/ipld/go-storethehash v0.3.13
 	github.com/ipni/go-indexer-core v0.7.7
-	github.com/ipni/go-libipni v0.1.0
+	github.com/ipni/go-libipni v0.1.1-0.20230519151455-6b4cd0c25354
 	github.com/libp2p/go-libp2p v0.27.3
 	github.com/libp2p/go-msgio v0.3.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -620,8 +620,8 @@ github.com/ipni/dhstore v0.0.2-0.20230324212407-ceb5f50e3bad h1:nS2Zq9bHG0eFzRjz
 github.com/ipni/dhstore v0.0.2-0.20230324212407-ceb5f50e3bad/go.mod h1:XI6XW5Eu97zY5PEK2ZRuESh8mYkxIZYRTMcknPVbbrc=
 github.com/ipni/go-indexer-core v0.7.7 h1:eHkC+HZkcFDC7uEayYkAMsRpMC8MbQ9ZQ1uQJy261dk=
 github.com/ipni/go-indexer-core v0.7.7/go.mod h1:03SY41l6ZC2gPRvDBuO8QMSpBSvd+P8NtUJEWgJxbNc=
-github.com/ipni/go-libipni v0.1.1-0.20230519151455-6b4cd0c25354 h1:y7yX0ji0E0TIqm5NC/frpZ6guVcoIqyHXim1AUs59U0=
-github.com/ipni/go-libipni v0.1.1-0.20230519151455-6b4cd0c25354/go.mod h1:iTYDXVB8tiQKe8gn3dN/+XF/XsgsiiR6xPAvU5waFnY=
+github.com/ipni/go-libipni v0.1.1 h1:keoNoYM1xXQeHVnpjjzRY12jSl9IwDasxDaswa9N4Tw=
+github.com/ipni/go-libipni v0.1.1/go.mod h1:iTYDXVB8tiQKe8gn3dN/+XF/XsgsiiR6xPAvU5waFnY=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=

--- a/go.sum
+++ b/go.sum
@@ -620,8 +620,8 @@ github.com/ipni/dhstore v0.0.2-0.20230324212407-ceb5f50e3bad h1:nS2Zq9bHG0eFzRjz
 github.com/ipni/dhstore v0.0.2-0.20230324212407-ceb5f50e3bad/go.mod h1:XI6XW5Eu97zY5PEK2ZRuESh8mYkxIZYRTMcknPVbbrc=
 github.com/ipni/go-indexer-core v0.7.7 h1:eHkC+HZkcFDC7uEayYkAMsRpMC8MbQ9ZQ1uQJy261dk=
 github.com/ipni/go-indexer-core v0.7.7/go.mod h1:03SY41l6ZC2gPRvDBuO8QMSpBSvd+P8NtUJEWgJxbNc=
-github.com/ipni/go-libipni v0.1.0 h1:w4kLZv51AGezsoRsQEIZGw8SyyfMkBGWLmBdN+gE8AI=
-github.com/ipni/go-libipni v0.1.0/go.mod h1:iTYDXVB8tiQKe8gn3dN/+XF/XsgsiiR6xPAvU5waFnY=
+github.com/ipni/go-libipni v0.1.1-0.20230519151455-6b4cd0c25354 h1:y7yX0ji0E0TIqm5NC/frpZ6guVcoIqyHXim1AUs59U0=
+github.com/ipni/go-libipni v0.1.1-0.20230519151455-6b4cd0c25354/go.mod h1:iTYDXVB8tiQKe8gn3dN/+XF/XsgsiiR6xPAvU5waFnY=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=

--- a/internal/ingest/linksystem.go
+++ b/internal/ingest/linksystem.go
@@ -368,6 +368,7 @@ func (ing *Ingester) ingestAd(ctx context.Context, publisherID peer.ID, adCid ci
 		msg := err.Error()
 		switch {
 		case
+			errors.Is(err, ipld.ErrNotExists{}),
 			strings.Contains(msg, "content not found"),
 			strings.Contains(msg, "graphsync request failed to complete: skip"):
 			return adIngestError{adIngestContentNotFound, wrappedErr}
@@ -452,7 +453,7 @@ func (ing *Ingester) ingestHamtFromPublisher(ctx context.Context, ad schema.Adve
 				dagsync.ScopedSegmentDepthLimit(-1))
 			if err != nil {
 				wrappedErr := fmt.Errorf("failed to sync remaining HAMT: %w", err)
-				if strings.Contains(err.Error(), "content not found") {
+				if errors.Is(err, ipld.ErrNotExists{}) || strings.Contains(err.Error(), "content not found") {
 					return 0, adIngestError{adIngestContentNotFound, wrappedErr}
 				}
 				return 0, adIngestError{adIngestSyncEntriesErr, wrappedErr}
@@ -566,7 +567,7 @@ func (ing *Ingester) ingestEntriesFromPublisher(ctx context.Context, ad schema.A
 				return mhCount, err
 			}
 			wrappedErr := fmt.Errorf("failed to sync entries: %w", err)
-			if strings.Contains(err.Error(), "content not found") {
+			if errors.Is(err, ipld.ErrNotExists{}) || strings.Contains(err.Error(), "content not found") {
 				return mhCount, adIngestError{adIngestContentNotFound, wrappedErr}
 			}
 			return mhCount, adIngestError{adIngestSyncEntriesErr, wrappedErr}


### PR DESCRIPTION
Bubble up the fix in HTTP syncer so that 404s from HTTP publisher are surfaced appropriately. Improve error checking logic to break out early if the error is of kind `ipld.ErrNotExists`.

Relates to:
 - https://github.com/ipni/go-libipni/pull/39

Fixes #1771

