### PR TITLE
Freezer monitors mulitple directories different devices

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -124,7 +124,7 @@ func daemonAction(cctx *cli.Context) error {
 	freezeDirs = append(freezeDirs, dsDir)
 
 	if cfg.Indexer.UnfreezeOnStart {
-		unfrozen, err := registry.Unfreeze(cctx.Context, freezeDirs[0], cfg.Indexer.FreezeAtPercent, dstore)
+		unfrozen, err := registry.Unfreeze(cctx.Context, freezeDirs, cfg.Indexer.FreezeAtPercent, dstore)
 		if err != nil {
 			return fmt.Errorf("cannot unfreeze registry: %w", err)
 		}
@@ -164,7 +164,7 @@ func daemonAction(cctx *cli.Context) error {
 
 	// Create registry
 	reg, err := registry.New(cctx.Context, cfg.Discovery, dstore,
-		registry.WithFreezer(freezeDirs[0], cfg.Indexer.FreezeAtPercent))
+		registry.WithFreezer(freezeDirs, cfg.Indexer.FreezeAtPercent))
 	if err != nil {
 		return fmt.Errorf("cannot create provider registry: %s", err)
 	}

--- a/internal/freeze/device_unix.go
+++ b/internal/freeze/device_unix.go
@@ -1,0 +1,25 @@
+//go:build freebsd || linux || darwin || openbsd || (aix && !cgo)
+
+package freeze
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func deviceNumber(path string) (int, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return 0, fmt.Errorf("cannot stat %q: %w", path, err)
+	}
+	sysStatAny := fi.Sys()
+	if sysStatAny == nil {
+		return -1, nil
+	}
+	sysStat, ok := sysStatAny.(*syscall.Stat_t)
+	if !ok {
+		return -1, nil
+	}
+	return int(sysStat.Dev), nil
+}

--- a/internal/freeze/device_windows.go
+++ b/internal/freeze/device_windows.go
@@ -1,0 +1,37 @@
+package disk
+
+import (
+	"fmt"
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var devNum int
+var volNums = map[string]int{}
+
+var procGetVolumePathNameW = windows.NewLazySystemDLL("kernel32.dll").NewProc("GetVolumePathNameW")
+
+func deviceNumber(path string) (int, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return 0, fmt.Errorf("cannot stat %q: %w", path, err)
+	}
+	buf := make([]uint16, 200)
+	if procGetVolumePathNameW.Call(
+		uintptr(unsafe.Pointer(windows.StringToUTF16Ptr(path))),
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(len(buf)),
+	) == 0 {
+		return -1, nil
+	}
+	vol := syscall.UTF16ToString(buf)
+	num, ok := volNums[vol]
+	if ok {
+		return num, nil
+	}
+	devNum++
+	volNums[vol] = devNum
+	return devNum, nil
+}

--- a/internal/freeze/device_windows.go
+++ b/internal/freeze/device_windows.go
@@ -3,6 +3,7 @@ package freeze
 import (
 	"fmt"
 	"os"
+	"syscall"
 	"unsafe"
 
 	"golang.org/x/sys/windows"

--- a/internal/freeze/device_windows.go
+++ b/internal/freeze/device_windows.go
@@ -1,4 +1,4 @@
-package disk
+package freeze
 
 import (
 	"fmt"

--- a/internal/freeze/device_windows.go
+++ b/internal/freeze/device_windows.go
@@ -14,16 +14,17 @@ var volNums = map[string]int{}
 var procGetVolumePathNameW = windows.NewLazySystemDLL("kernel32.dll").NewProc("GetVolumePathNameW")
 
 func deviceNumber(path string) (int, error) {
-	fi, err := os.Stat(path)
+	_, err := os.Stat(path)
 	if err != nil {
 		return 0, fmt.Errorf("cannot stat %q: %w", path, err)
 	}
 	buf := make([]uint16, 200)
-	if procGetVolumePathNameW.Call(
+	r1, _, _ := procGetVolumePathNameW.Call(
 		uintptr(unsafe.Pointer(windows.StringToUTF16Ptr(path))),
 		uintptr(unsafe.Pointer(&buf[0])),
 		uintptr(len(buf)),
-	) == 0 {
+	)
+	if r1 == 0 {
 		return -1, nil
 	}
 	vol := syscall.UTF16ToString(buf)

--- a/internal/freeze/freezer.go
+++ b/internal/freeze/freezer.go
@@ -150,15 +150,12 @@ func (f *Freezer) Usage() (*disk.UsageStats, error) {
 
 // Unfreeze explicitly triggers the indexer to exit frozen mode.
 func Unfreeze(ctx context.Context, dirPaths []string, freezeAtPercent float64, dstore datastore.Datastore) error {
-	if dstore == nil {
+	if len(dirPaths) == 0 || dstore == nil {
 		return nil
 	}
 	dirPaths, err := uniqFsDirs(dirPaths)
 	if err != nil {
-		return nil
-	}
-	if len(dirPaths) == 0 {
-		return nil
+		return err
 	}
 	frozen, err := dstore.Has(ctx, datastore.NewKey(frozenKey))
 	if err != nil {

--- a/internal/freeze/freezer.go
+++ b/internal/freeze/freezer.go
@@ -3,9 +3,7 @@ package freeze
 import (
 	"context"
 	"fmt"
-	"os"
 	"strconv"
-	"syscall"
 	"time"
 
 	"github.com/ipfs/go-datastore"
@@ -318,7 +316,7 @@ func (f *Freezer) loadFrozenState() (bool, error) {
 func uniqFsDirs(dirPaths []string) ([]string, error) {
 	var uniqDirs []string
 	seen := make(map[string]struct{})
-	devs := make(map[int32]struct{})
+	devs := make(map[int]struct{})
 	for _, dir := range dirPaths {
 		if dir == "" {
 			continue
@@ -329,13 +327,11 @@ func uniqFsDirs(dirPaths []string) ([]string, error) {
 		}
 		seen[dir] = struct{}{}
 
-		fi, err := os.Stat(dir)
+		devNo, err := deviceNumber(dir)
 		if err != nil {
-			return nil, fmt.Errorf("cannot stat %q: %w", dir, err)
+			return nil, err
 		}
-		sysStat, ok := fi.Sys().(*syscall.Stat_t)
-		if ok {
-			devNo := sysStat.Dev
+		if devNo != -1 {
 			if _, ok = devs[devNo]; ok {
 				continue
 			}

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -763,7 +763,7 @@ func (ing *Ingester) metricsUpdater() {
 			usageStats, err := ing.reg.ValueStoreUsage()
 			if err != nil {
 				log.Errorw("Error getting disk usage", "err", err)
-			} else {
+			} else if usageStats != nil {
 				usage = usageStats.Percent
 			}
 

--- a/internal/registry/option.go
+++ b/internal/registry/option.go
@@ -8,7 +8,7 @@ import (
 // regConfig contains all options for the server.
 type regConfig struct {
 	freezeAtPercent float64
-	valueStoreDir   string
+	freezeDirs      []string
 }
 
 // Option is a function that sets a value in a regConfig.
@@ -25,13 +25,13 @@ func getOpts(opts []Option) (regConfig, error) {
 	return cfg, nil
 }
 
-func WithFreezer(valueStoreDir string, freezeAtPercent float64) Option {
+func WithFreezer(freezeDirs []string, freezeAtPercent float64) Option {
 	return func(c *regConfig) error {
-		if valueStoreDir != "" && freezeAtPercent == 0 {
+		if len(freezeDirs) != 0 && freezeAtPercent == 0 {
 			return errors.New("cannot freeze at 0 percent usage")
 		}
 		c.freezeAtPercent = freezeAtPercent
-		c.valueStoreDir = valueStoreDir
+		c.freezeDirs = freezeDirs
 		return nil
 	}
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -294,7 +294,7 @@ func New(ctx context.Context, cfg config.Discovery, dstore datastore.Datastore, 
 	}
 
 	if opts.freezeAtPercent >= 0 {
-		r.freezer, err = freeze.New(opts.valueStoreDir, opts.freezeAtPercent, dstore, r.freeze)
+		r.freezer, err = freeze.New(opts.freezeDirs, opts.freezeAtPercent, dstore, r.freeze)
 		if err != nil {
 			return nil, fmt.Errorf("cannot create freezer: %s", err)
 		}
@@ -1031,12 +1031,12 @@ func (r *Registry) ValueStoreUsage() (*disk.UsageStats, error) {
 
 // Unfreeze reverts the freezer and provider information back to its unfrozen
 // state. This must only be called when the registry is not running.
-func Unfreeze(ctx context.Context, vstoreDir string, freezeAtPercent float64, dstore datastore.Datastore) (map[peer.ID]cid.Cid, error) {
+func Unfreeze(ctx context.Context, freezeDirs []string, freezeAtPercent float64, dstore datastore.Datastore) (map[peer.ID]cid.Cid, error) {
 	if dstore == nil {
 		return nil, nil
 	}
 
-	err := freeze.Unfreeze(ctx, vstoreDir, freezeAtPercent, dstore)
+	err := freeze.Unfreeze(ctx, freezeDirs, freezeAtPercent, dstore)
 	if err != nil {
 		return nil, fmt.Errorf("cannot unfreeze freezer: %w", err)
 	}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -685,7 +685,8 @@ func TestFreezeUnfreeze(t *testing.T) {
 	ctx := context.Background()
 	tempDir := t.TempDir()
 	dstore := datastore.NewMapDatastore()
-	r, err := New(ctx, cfg, dstore, WithFreezer(tempDir, 90.0))
+	freezeDirs := []string{tempDir}
+	r, err := New(ctx, cfg, dstore, WithFreezer(freezeDirs, 90.0))
 	require.NoError(t, err)
 	t.Cleanup(func() { r.Close() })
 
@@ -752,7 +753,7 @@ func TestFreezeUnfreeze(t *testing.T) {
 
 	// Stop and restart registry and check providers are still frozen.
 	r.Close()
-	r, err = New(ctx, cfg, dstore, WithFreezer(tempDir, 90.0))
+	r, err = New(ctx, cfg, dstore, WithFreezer(freezeDirs, 90.0))
 	require.NoError(t, err)
 	require.True(t, r.Frozen())
 	infos = r.AllProviderInfo()
@@ -762,7 +763,7 @@ func TestFreezeUnfreeze(t *testing.T) {
 	}
 	r.Close()
 
-	unfrozen, err := Unfreeze(ctx, tempDir, 90.0, dstore)
+	unfrozen, err := Unfreeze(ctx, freezeDirs, 90.0, dstore)
 	require.NoError(t, err)
 	require.Equal(t, len(infos), len(unfrozen))
 	for i := range infos {
@@ -771,7 +772,7 @@ func TestFreezeUnfreeze(t *testing.T) {
 		require.Equal(t, infos[i].FrozenAt, frozenAt)
 	}
 
-	r, err = New(ctx, cfg, dstore, WithFreezer(tempDir, 90.0))
+	r, err = New(ctx, cfg, dstore, WithFreezer(freezeDirs, 90.0))
 	require.NoError(t, err)
 	require.False(t, r.Frozen())
 	infos = r.AllProviderInfo()
@@ -781,7 +782,7 @@ func TestFreezeUnfreeze(t *testing.T) {
 	}
 	r.Close()
 
-	unfrozen, err = Unfreeze(ctx, tempDir, 90.0, dstore)
+	unfrozen, err = Unfreeze(ctx, freezeDirs, 90.0, dstore)
 	require.NoError(t, err)
 	require.Zero(t, len(unfrozen))
 }
@@ -797,7 +798,7 @@ func TestHandoff(t *testing.T) {
 
 	ctx := context.Background()
 	tempDir := t.TempDir()
-	r, err := New(ctx, cfg, datastore.NewMapDatastore(), WithFreezer(tempDir, 90.0))
+	r, err := New(ctx, cfg, datastore.NewMapDatastore(), WithFreezer([]string{tempDir}, 90.0))
 	require.NoError(t, err)
 	t.Cleanup(func() { r.Close() })
 

--- a/server/admin/http/handler.go
+++ b/server/admin/http/handler.go
@@ -648,7 +648,7 @@ func (h *adminHandler) status(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Error(err)
 		usage = -1.0
-	} else {
+	} else if du != nil {
 		usage = du.Percent
 	}
 


### PR DESCRIPTION
Freezer can be created with multiple directories. It will attempt to select one for each separate device, if that information is available. Each selected directory is monitored for disk usage, and freeze happens if any exceeds the usage threshold.

Fixes #1776
