### PR TITLE
Turn down read-only dhstore machine metrics

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-helga/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-helga/deployment.yaml
@@ -26,11 +26,11 @@ spec:
               mountPath: /data
           resources:
             limits:
-              cpu: "7"
-              memory: 60Gi
+              cpu: "3"
+              memory: 32Gi
             requests:
-              cpu: "7"
-              memory: 60Gi
+              cpu: "3"
+              memory: 32Gi
           ports:
             - containerPort: 40081
               name: metrics

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/deployment.yaml
@@ -20,11 +20,11 @@ spec:
               mountPath: /data
           resources:
             limits:
-              cpu: "30"
-              memory: 58Gi
+              cpu: "3"
+              memory: 32Gi
             requests:
-              cpu: "30"
-              memory: 58Gi
+              cpu: "3"
+              memory: 32Gi
           ports:
             - containerPort: 40081
               name: metrics


### PR DESCRIPTION
* Read-only dhstore are massively underutilised on the CPU (use 20% at peak)
* Pebble takes 100% of the memory regardless of how much is given. Trying to run read-only instances with lower RAM.