### PR TITLE
Stop cluster dhstore instances in prep to delete their data

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-a/cadi/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-a/cadi/kustomization.yaml
@@ -11,3 +11,7 @@ resources:
 
 patchesStrategicMerge:
   - pvc.yaml
+
+replicas:
+  - name: cadi-dhstore
+    count: 0

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-a/saar/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-a/saar/kustomization.yaml
@@ -11,3 +11,7 @@ resources:
 
 patchesStrategicMerge:
   - pvc.yaml
+
+replicas:
+  - name: saar-dhstore
+    count: 0

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-b/aviv/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-b/aviv/kustomization.yaml
@@ -11,3 +11,7 @@ resources:
 
 patchesStrategicMerge:
   - pvc.yaml
+
+replicas:
+  - name: aviv-dhstore
+    count: 0

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-b/dina/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-b/dina/kustomization.yaml
@@ -11,3 +11,7 @@ resources:
 
 patchesStrategicMerge:
   - pvc.yaml
+
+replicas:
+  - name: dina-dhstore
+    count: 0

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-b/vesa/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-b/vesa/kustomization.yaml
@@ -11,3 +11,7 @@ resources:
 
 patchesStrategicMerge:
   - pvc.yaml
+
+replicas:
+  - name: vesa-dhstore
+    count: 0

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-c/bala/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-c/bala/kustomization.yaml
@@ -11,3 +11,7 @@ resources:
 
 patchesStrategicMerge:
   - pvc.yaml
+
+replicas:
+  - name: bala-dhstore
+    count: 0

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-c/maja/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-c/maja/kustomization.yaml
@@ -11,3 +11,7 @@ resources:
 
 patchesStrategicMerge:
   - pvc.yaml
+
+replicas:
+  - name: maja-dhstore
+    count: 0

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-c/zora/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-cluster/instances/zone-c/zora/kustomization.yaml
@@ -11,3 +11,7 @@ resources:
 
 patchesStrategicMerge:
   - pvc.yaml
+
+replicas:
+  - name: zora-dhstore
+    count: 0


### PR DESCRIPTION
The cluster dhstore instances previously participated in a key-sharding experiment using envoy.  We want to delete that data in prep for other experiments using dedicated indexer-dhstore pairs and using FoundationDB.  Before deleting the pvcs, we need to stop the dhstore instances using those pvcs.