### PR TITLE
Return Not Found message with 404

### DIFF
--- a/server/find/http/handler_test.go
+++ b/server/find/http/handler_test.go
@@ -231,14 +231,14 @@ func TestServer_StreamingResponse(t *testing.T) {
 			name:               "unknown metadata",
 			reqURI:             "/metadata/fish",
 			wantContentType:    "text/plain; charset=utf-8",
-			wantResponseBody:   "\n",
+			wantResponseBody:   "Not Found\n",
 			wantResponseStatus: http.StatusNotFound,
 		},
 		{
 			name:               "unknwon any",
 			reqURI:             "/lobster",
 			wantContentType:    "text/plain; charset=utf-8",
-			wantResponseBody:   "\n",
+			wantResponseBody:   "Not Found\n",
 			wantResponseStatus: http.StatusNotFound,
 		},
 	}

--- a/server/find/http/server.go
+++ b/server/find/http/server.go
@@ -109,7 +109,7 @@ func New(listen string, indexer indexer.Interface, registry *registry.Registry, 
 			}
 			http.ServeContent(w, r, "index.html", compileTime, bytes.NewReader(buf.Bytes()))
 		default:
-			http.Error(w, "", http.StatusNotFound)
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 		}
 	})
 	mux.HandleFunc("/cid/", s.findCid)


### PR DESCRIPTION
When an incorrect URL is given to the find API, a blank response body is given with the 404 error code. When used with a user interface like a browser or curl, this is confusing until the error code in the response is inspected. Returning the "Not Found" message eliminates the confusion.

Not much to review here, but the request for review is to double-check that this will not cause any problem for some automation expecting to receive an empty response body for Not Found.