### PR TITLE
Bump up dhstore-helga CPU

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-helga/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-helga/deployment.yaml
@@ -26,10 +26,10 @@ spec:
               mountPath: /data
           resources:
             limits:
-              cpu: "3"
+              cpu: "4"
               memory: 16Gi
             requests:
-              cpu: "3"
+              cpu: "4"
               memory: 16Gi
           ports:
             - containerPort: 40081

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-helga/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-helga/deployment.yaml
@@ -26,10 +26,10 @@ spec:
               mountPath: /data
           resources:
             limits:
-              cpu: "4"
+              cpu: "7"
               memory: 16Gi
             requests:
-              cpu: "4"
+              cpu: "7"
               memory: 16Gi
           ports:
             - containerPort: 40081

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-helga/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-helga/deployment.yaml
@@ -26,10 +26,10 @@ spec:
               mountPath: /data
           resources:
             limits:
-              cpu: "2"
+              cpu: "3"
               memory: 16Gi
             requests:
-              cpu: "2"
+              cpu: "3"
               memory: 16Gi
           ports:
             - containerPort: 40081


### PR DESCRIPTION
Bump up dhstore-helga CPU as it seems to be the largest contributor to high read latencies

![image](https://github.com/ipni/storetheindex/assets/31857042/adbb9261-cf3f-4540-ae0f-259d2f18a26e)

![image](https://github.com/ipni/storetheindex/assets/31857042/623e9f5e-2cbd-468c-9fe6-964a3b8044cc)
