### PR TITLE
Disconnect old indexers

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -19,12 +19,10 @@ spec:
             - '--backends=http://dhfind.internal.prod.cid.contact/'
             - '--backends=http://dhfind-helga.internal.prod.cid.contact/'
             - '--backends=http://dhfind-porvy.internal.prod.cid.contact/'
-            - '--backends=http://dido-indexer:3000/'
-            - '--backends=http://kepa-indexer:3000/'
-            - '--backends=http://oden-indexer:3000/'
+            - '--backends=http://inga-indexer:3000/'
             - '--cascadeBackends=http://caskadht.internal.prod.cid.contact/'
             - '--cascadeBackends=http://cassette.internal.prod.cid.contact/'
-            - '--fallbackBackend=http://dido-indexer:3000/'
+            - '--fallbackBackend=http://inga-indexer:3000/'
           env:
             # Increase maximum accepted request body to 1 MiB in order to allow batch finds requests
             # by the `provider verify-ingest` CLI command. 


### PR DESCRIPTION
Also connect `inga` to indexestar so that it can serve the static page and `/providers` endpoint
