### PR TITLE
Revert "Disconnect old indexers"

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -19,10 +19,12 @@ spec:
             - '--backends=http://dhfind.internal.prod.cid.contact/'
             - '--backends=http://dhfind-helga.internal.prod.cid.contact/'
             - '--backends=http://dhfind-porvy.internal.prod.cid.contact/'
-            - '--backends=http://inga-indexer:3000/'
+            - '--backends=http://dido-indexer:3000/'
+            - '--backends=http://kepa-indexer:3000/'
+            - '--backends=http://oden-indexer:3000/'
             - '--cascadeBackends=http://caskadht.internal.prod.cid.contact/'
             - '--cascadeBackends=http://cassette.internal.prod.cid.contact/'
-            - '--fallbackBackend=http://inga-indexer:3000/'
+            - '--fallbackBackend=http://dido-indexer:3000/'
           env:
             # Increase maximum accepted request body to 1 MiB in order to allow batch finds requests
             # by the `provider verify-ingest` CLI command. 


### PR DESCRIPTION
Reverts ipni/storetheindex#1837

This is to investigate extended providers not appearing as expected on results fetched from double hashed stores. 
Cc @ischasny 