### PR TITLE
Increase ingest worker count in Inga

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
@@ -83,7 +83,7 @@
     "HttpSyncRetryWaitMax": "30s",
     "HttpSyncRetryWaitMin": "1s",
     "HttpSyncTimeout": "10s",
-    "IngestWorkerCount": 3,
+    "IngestWorkerCount": 10,
     "PubSubTopic": "/indexer/ingest/mainnet",
     "RateLimit": {
       "Apply": false,


### PR DESCRIPTION
* Inga has mostly caught up with the rest of indexers so the ingestion profile should get flatter
* Increasing ingest worker count should allow inga to catch up with new ads quicker (dag.house issue)
