### PR TITLE
Deploy FoundationDB CRDs in dev and define manager manifests

### DIFF
--- a/deploy/manifests/base/foundationdb/crds/kustomization.yaml
+++ b/deploy/manifests/base/foundationdb/crds/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - github.com/FoundationDB/fdb-kubernetes-operator/config/crd?ref=v1.17.0

--- a/deploy/manifests/base/foundationdb/namespaced-manager/deployment.yaml
+++ b/deploy/manifests/base/foundationdb/namespaced-manager/deployment.yaml
@@ -1,0 +1,99 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: fdb-kubernetes-operator-controller-manager
+    control-plane: controller-manager
+  name: fdb-kubernetes-operator-controller-manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fdb-kubernetes-operator-controller-manager
+  template:
+    metadata:
+      labels:
+        app: fdb-kubernetes-operator-controller-manager
+        control-plane: controller-manager
+    spec:
+      containers:
+        - command:
+            - /manager
+          env:
+            # Limit the scope of controller to one namespace.
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            # Set primary libs as library path to support DNS in cluster files.
+            - name: LD_LIBRARY_PATH
+              value: /usr/bin/fdb/primary/lib
+          image: manager
+          name: manager
+          ports:
+            - containerPort: 8080
+              name: metrics
+          resources:
+            limits:
+              cpu: 500m
+              memory: 256Mi
+            requests:
+              cpu: 500m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /var/log/fdb
+              name: logs
+            - mountPath: /usr/bin/fdb
+              name: fdb-binaries
+      initContainers:
+        # Copy library version 7.1 as primary in order to support DNS names in cluster file and
+        # avoid issues when pod IPs change on redeployment.
+        - name: foundationdb-kubernetes-init-7-1-primary
+          image: foundationdb/foundationdb-kubernetes-sidecar:7.1.33-1
+          args:
+            - "--copy-library"
+            - "7.1"
+            - "--output-dir"
+            - "/var/output-files/primary"
+            - "--init-mode"
+          volumeMounts:
+            - name: fdb-binaries
+              mountPath: /var/output-files
+        # Only copy library versions 7.1 since that's the version we use. If multi-version support
+        # needed, the libraries need to be copied via dedicated init containers.
+        - name: foundationdb-kubernetes-init-7-1
+          image: foundationdb/foundationdb-kubernetes-sidecar:7.1.33-1
+          args:
+            - --copy-library
+            - "7.1"
+            - --copy-binary
+            - fdbcli
+            - --copy-binary
+            - fdbbackup
+            - --copy-binary
+            - fdbrestore
+            - --output-dir
+            - /var/output-files/7.1.33
+            - --init-mode
+          volumeMounts:
+            - mountPath: /var/output-files
+              name: fdb-binaries
+      securityContext:
+        fsGroup: 4059
+        runAsGroup: 4059
+        runAsUser: 4059
+      serviceAccountName: fdb-kubernetes-operator-controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - emptyDir: { }
+          name: tmp
+        - emptyDir: { }
+          name: logs
+        - emptyDir: { }
+          name: fdb-binaries

--- a/deploy/manifests/base/foundationdb/namespaced-manager/kustomization.yaml
+++ b/deploy/manifests/base/foundationdb/namespaced-manager/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - rbac.yaml
+
+images:
+  - name: manager
+    newName: foundationdb/fdb-kubernetes-operator
+    newTag: v1.17.0

--- a/deploy/manifests/base/foundationdb/namespaced-manager/rbac.yaml
+++ b/deploy/manifests/base/foundationdb/namespaced-manager/rbac.yaml
@@ -1,0 +1,123 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fdb-kubernetes-operator-controller-manager
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: fdb-kubernetes-operator-manager-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - events
+      - persistentvolumeclaims
+      - pods
+      - secrets
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps.foundationdb.org
+    resources:
+      - foundationdbbackups
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps.foundationdb.org
+    resources:
+      - foundationdbbackups/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apps.foundationdb.org
+    resources:
+      - foundationdbclusters
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps.foundationdb.org
+    resources:
+      - foundationdbclusters/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apps.foundationdb.org
+    resources:
+      - foundationdbrestores
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps.foundationdb.org
+    resources:
+      - foundationdbrestores/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: fdb-kubernetes-operator-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: fdb-kubernetes-operator-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: fdb-kubernetes-operator-controller-manager

--- a/deploy/manifests/dev/us-east-2/cluster/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kustomization.yaml
@@ -18,3 +18,4 @@ resources:
   - external-snapshotter
   - snapshots
   - ../../../base/k6-operator
+  - ../../../base/foundationdb/crds


### PR DESCRIPTION
Deploy FoundationDB CRDs in `dev` cluster.

Define namespaced controller manager manifests in preparation for deploying FDB cluster in `dev` for `storetheindex` namespace.

