### PR TITLE
Remove redundant user permissions

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/autoretrieve.tf
+++ b/deploy/infrastructure/dev/us-east-2/autoretrieve.tf
@@ -32,12 +32,11 @@ data "aws_iam_policy_document" "kms_autoretrieve" {
 
       identifiers = [
         "arn:aws:iam::407967248065:user/masih",
-        "arn:aws:iam::407967248065:user/marco",
         "arn:aws:iam::407967248065:user/gammazero",
         "arn:aws:iam::407967248065:user/will.scott",
         "arn:aws:iam::407967248065:user/kylehuntsman",
-        "arn:aws:iam::407967248065:user/steveFraser",
-        "arn:aws:iam::407967248065:user/cmharden",
+        "arn:aws:iam::407967248065:user/ischasny",
+        "arn:aws:iam::407967248065:user/hannahhoward",
       ]
     }
 

--- a/deploy/infrastructure/dev/us-east-2/index-provider.tf
+++ b/deploy/infrastructure/dev/us-east-2/index-provider.tf
@@ -32,12 +32,10 @@ data "aws_iam_policy_document" "kms_index_provider" {
 
       identifiers = [
         "arn:aws:iam::407967248065:user/masih",
-        "arn:aws:iam::407967248065:user/marco",
         "arn:aws:iam::407967248065:user/gammazero",
         "arn:aws:iam::407967248065:user/will.scott",
         "arn:aws:iam::407967248065:user/kylehuntsman",
-        "arn:aws:iam::407967248065:user/steveFraser",
-        "arn:aws:iam::407967248065:user/cmharden",
+        "arn:aws:iam::407967248065:user/ischasny",
       ]
     }
 

--- a/deploy/infrastructure/dev/us-east-2/kms.tf
+++ b/deploy/infrastructure/dev/us-east-2/kms.tf
@@ -32,12 +32,10 @@ data "aws_iam_policy_document" "kms_sti" {
 
       identifiers = [
         "arn:aws:iam::407967248065:user/masih",
-        "arn:aws:iam::407967248065:user/marco",
         "arn:aws:iam::407967248065:user/gammazero",
         "arn:aws:iam::407967248065:user/will.scott",
         "arn:aws:iam::407967248065:user/kylehuntsman",
-        "arn:aws:iam::407967248065:user/steveFraser",
-        "arn:aws:iam::407967248065:user/cmharden",
+        "arn:aws:iam::407967248065:user/ischasny",
       ]
     }
 
@@ -139,12 +137,10 @@ data "aws_iam_policy_document" "kms_cluster" {
 
       identifiers = [
         "arn:aws:iam::407967248065:user/masih",
-        "arn:aws:iam::407967248065:user/marco",
         "arn:aws:iam::407967248065:user/gammazero",
         "arn:aws:iam::407967248065:user/will.scott",
         "arn:aws:iam::407967248065:user/kylehuntsman",
-        "arn:aws:iam::407967248065:user/steveFraser",
-        "arn:aws:iam::407967248065:user/cmharden",
+        "arn:aws:iam::407967248065:user/ischasny",
       ]
     }
 

--- a/deploy/infrastructure/prod/us-east-2/kms.tf
+++ b/deploy/infrastructure/prod/us-east-2/kms.tf
@@ -30,12 +30,10 @@ data "aws_iam_policy_document" "kms_sti" {
 
       identifiers = [
         "arn:aws:iam::407967248065:user/masih",
-        "arn:aws:iam::407967248065:user/marco",
         "arn:aws:iam::407967248065:user/gammazero",
         "arn:aws:iam::407967248065:user/will.scott",
         "arn:aws:iam::407967248065:user/kylehuntsman",
-        "arn:aws:iam::407967248065:user/steveFraser",
-        "arn:aws:iam::407967248065:user/cmharden",
+        "arn:aws:iam::407967248065:user/ischasny",
       ]
     }
 
@@ -135,12 +133,9 @@ data "aws_iam_policy_document" "kms_cluster" {
 
       identifiers = [
         "arn:aws:iam::407967248065:user/masih",
-        "arn:aws:iam::407967248065:user/marco",
         "arn:aws:iam::407967248065:user/gammazero",
         "arn:aws:iam::407967248065:user/will.scott",
         "arn:aws:iam::407967248065:user/kylehuntsman",
-        "arn:aws:iam::407967248065:user/steveFraser",
-        "arn:aws:iam::407967248065:user/cmharden",
       ]
     }
 


### PR DESCRIPTION
Clean up old IAM user permission references. Redundant users are already deleted from the AWS account.
