### PR TITLE
Expand `dev` work group subnets for `r6a-xl` instance types

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/eks.tf
+++ b/deploy/infrastructure/dev/us-east-2/eks.tf
@@ -30,12 +30,19 @@ module "eks" {
       instance_types = ["r6a.xlarge"]
       subnet_ids     = [data.aws_subnet.ue2a2.id]
     }
+    dev-ue2b-r6a-xl = {
+      min_size       = 0
+      max_size       = 5
+      desired_size   = 1
+      instance_types = ["r6a.xlarge"]
+      subnet_ids     = [data.aws_subnet.ue2b1.id,data.aws_subnet.ue2b2.id,data.aws_subnet.ue2b3.id]
+    }
     dev-ue2c-r6a-xl = {
       min_size       = 0
       max_size       = 5
       desired_size   = 1
       instance_types = ["r6a.xlarge"]
-      subnet_ids     = [data.aws_subnet.ue2c2.id]
+      subnet_ids     = [data.aws_subnet.ue2c1.id,data.aws_subnet.ue2c2.id,data.aws_subnet.ue2c3.id]
     }
 
     # General purpose node groups, one per subnet.
@@ -70,7 +77,7 @@ module "eks" {
       max_size       = 7
       desired_size   = 1
       instance_types = ["r5a.2xlarge"]
-      subnet_ids     = [data.aws_subnet.ue2a1.id]
+      subnet_ids     = [data.aws_subnet.ue2a1.id, data.aws_subnet.ue2a2.id, data.aws_subnet.ue2a3.id]
     }
     
     # Memory optimised node groups primarily used to run indexer nodes.

--- a/deploy/manifests/dev/us-east-2/cluster/kube-system/aws-auth.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kube-system/aws-auth.yaml
@@ -32,6 +32,11 @@ data:
     - groups:
       - system:bootstrappers
       - system:nodes
+      rolearn: arn:aws:iam::407967248065:role/dev-ue2b-r6a-xl-eks-node-group
+      username: system:node:{{EC2PrivateDNSName}}
+    - groups:
+      - system:bootstrappers
+      - system:nodes
       rolearn: arn:aws:iam::407967248065:role/dev-ue2c-r6a-xl-eks-node-group
       username: system:node:{{EC2PrivateDNSName}}
     - groups:


### PR DESCRIPTION
Expand the subnets for r6a-xl subnets so that more IPs are available for
 nodes to be scheduled.

Create a new work group in AZ c.
