### PR TITLE
Build container with go1.20.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-bullseye as builder
+FROM golang:1.20-bullseye as builder
 LABEL maintainer="Andrew Gillis <andrew.gillis@protocol.ai>"
 
 # Install deps


### PR DESCRIPTION
Use more recent image, with go 1.20.x, as build container.