### PR TITLE
Define workgroup to run foundationdb nodes

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/eks.tf
+++ b/deploy/infrastructure/dev/us-east-2/eks.tf
@@ -79,6 +79,18 @@ module "eks" {
       instance_types = ["r5a.2xlarge"]
       subnet_ids     = [data.aws_subnet.ue2a1.id, data.aws_subnet.ue2a2.id, data.aws_subnet.ue2a3.id]
     }
+    # Used by foundation db
+    dev-ue2-r5a-2xl = {
+      min_size       = 0
+      max_size       = 15
+      desired_size   = 1
+      instance_types = ["r5a.2xlarge"]
+      subnet_ids     = [
+        data.aws_subnet.ue2a1.id, data.aws_subnet.ue2a2.id, data.aws_subnet.ue2a3.id,
+        data.aws_subnet.ue2b1.id, data.aws_subnet.ue2b2.id, data.aws_subnet.ue2b3.id,
+        data.aws_subnet.ue2c1.id, data.aws_subnet.ue2c2.id, data.aws_subnet.ue2c3.id,
+      ]
+    }
     
     # Memory optimised node groups primarily used to run indexer nodes.
     dev-ue2a-r5n-2xl = {


### PR DESCRIPTION
Use instance type `r5a.2xlarge` for now, since we use rocksdb storage engine and would run multiple storage processes per pod.

Further testing is required to see what the best config is for our setup.

