### PR TITLE
Deploy foundation db `dev` cluster

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps.foundationdb.org/v1beta2
+kind: FoundationDBCluster
+metadata:
+  name: fdb-dev-cluster
+spec:
+  version: 7.1.33
+  storageServersPerPod: 3
+  automationOptions:
+    replacements:
+      enabled: true
+  faultDomain:
+    key: kubernetes.io/hostname
+    valueFrom: spec.nodeName
+  databaseConfiguration:
+    storage_engine: ssd-rocksdb-v1
+  processCounts:
+    storage: 5
+    log: 3
+    stateless: 2
+  labels:
+    matchLabels:
+      foundationdb.org/fdb-cluster-name: dev
+    processClassLabels:
+      - foundationdb.org/fdb-process-class
+    processGroupIDLabels:
+      - foundationdb.org/fdb-process-group-id
+  minimumUptimeSecondsForBounce: 60
+  processes:
+    general:
+      customParameters:
+        - memory=20GiB
+        - cache-memory=12GiB
+      podTemplate:
+        spec:
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: topology.kubernetes.io/zone
+              whenUnsatisfiable: ScheduleAnyway
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: node.kubernetes.io/instance-type
+                        operator: In
+                        values:
+                          - r5a.2xlarge
+          containers:
+            - name: foundationdb
+              resources:
+                requests:
+                  cpu: 7
+                  memory: 60.5Gi
+              securityContext:
+                runAsUser: 0
+      volumeClaimTemplate:
+        spec:
+          storageClassName: gp3-iops16k-t1000
+          resources:
+            requests:
+              storage: 16Ti
+  sidecarContainer:
+    enableReadinessProbe: false
+    enableLivenessProbe: true
+  routing:
+    useDNSInClusterFile: true

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/fdb-cluster/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/fdb-cluster/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - cluster.yaml

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/fdb-manager/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/fdb-manager/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - ../../../../../base/foundationdb/namespaced-manager
+  - pod-monitor.yaml

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/fdb-manager/pod-monitor.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/fdb-manager/pod-monitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: fdb-kubernetes-operator-controller-manager
+  labels:
+    app: fdb-kubernetes-operator-controller-manager
+spec:
+  selector:
+    matchLabels:
+      app: fdb-kubernetes-operator-controller-manager
+  namespaceSelector:
+    matchNames:
+      - storetheindex
+  podMetricsEndpoints:
+    - path: /metrics
+      port: metrics

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -15,6 +15,8 @@ resources:
 - lookout
 - cassette
 - heyfil
+- fdb-manager
+- fdb-cluster
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}


### PR DESCRIPTION
Deploy a namespaced FoundationDB controller and a cluster with reasonable configs that are initially tested in a separate namespace.

