### PR TITLE
Create new indexer instances

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/alva/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/alva/config.json
@@ -1,0 +1,109 @@
+{
+  "Version": 2,
+  "Identity": {
+    "PeerID": "",
+    "PrivKey": ""
+  },
+  "Addresses": {
+    "Admin": "/ip4/0.0.0.0/tcp/3002",
+    "Finder": "/ip4/0.0.0.0/tcp/3000",
+    "FinderWebpage": "https://web-ipni.cid.contact/dev",
+    "Ingest": "/ip4/0.0.0.0/tcp/3001",
+    "P2PAddr": "/ip4/0.0.0.0/tcp/3003",
+    "NoResourceManager": true
+  },
+  "Bootstrap": {
+    "Peers": [
+      "/dns4/bootstrap-0.ipfsmain.cn/tcp/34721/p2p/12D3KooWQnwEGNqcM2nAcPtRR9rAX8Hrg4k9kJLCHoTR5chJfz6d",
+      "/dns4/bootstrap-3.mainnet.filops.net/tcp/1347/p2p/12D3KooWKhgq8c7NQ9iGjbyK7v7phXvG6492HQfiDaGHLHLQjk7R",
+      "/dns4/bootstrap-4.mainnet.filops.net/tcp/1347/p2p/12D3KooWL6PsFNPhYftrJzGgF5U18hFoaVhfGk7xwzD8yVrHJ3Uc",
+      "/dns4/bootstrap-6.mainnet.filops.net/tcp/1347/p2p/12D3KooWP5MwCiqdMETF9ub1P3MbCvQCcfconnYHbWg6sUJcDRQQ",
+      "/dns4/bootstrap-7.mainnet.filops.net/tcp/1347/p2p/12D3KooWRs3aY1p3juFjPy8gPN95PEQChm2QKGUCAdcDCC4EBMKf",
+      "/dns4/bootstrap-8.mainnet.filops.net/tcp/1347/p2p/12D3KooWScFR7385LTyR4zU1bYdzSiiAb5rnNABfVahPvVSzyTkR",
+      "/dns4/node.glif.io/tcp/1235/p2p/12D3KooWBF8cpp65hp2u9LK5mh19x67ftAam84z9LsfaquTDSBpt",
+      "/dns4/bootstrap-2.mainnet.filops.net/tcp/1347/p2p/12D3KooWEWVwHGn2yR36gKLozmb4YjDJGerotAPGxmdWZx2nxMC4",
+      "/dns4/bootstrap-5.mainnet.filops.net/tcp/1347/p2p/12D3KooWLFynvDQiUpXoHroV1YxKHhPJgysQGH2k3ZGwtWzR4dFH",
+      "/dns4/bootstrap-1.starpool.in/tcp/12757/p2p/12D3KooWQZrGH1PxSNZPum99M1zNvjNFM33d1AAu5DcvdHptuU7u",
+      "/dns4/bootstrap-0.mainnet.filops.net/tcp/1347/p2p/12D3KooWCVe8MmsEMes2FzgTpt9fXtmCY7wrq91GRiaC8PHSCCBj",
+      "/dns4/bootstrap-1.mainnet.filops.net/tcp/1347/p2p/12D3KooWCwevHg1yLCvktf2nvLu7L9894mcrJR4MsBCcm4syShVc",
+      "/dns4/bootstrap-0.starpool.in/tcp/12757/p2p/12D3KooWGHpBMeZbestVEWkfdnC9u7p6uFHXL1n7m1ZBqsEmiUzz",
+      "/dns4/lotus-bootstrap.ipfsforce.com/tcp/41778/p2p/12D3KooWGhufNmZHF3sv48aQeS13ng5XVJZ9E6qy2Ms4VzqeUsHk",
+      "/dns4/bootstrap-1.ipfsmain.cn/tcp/34723/p2p/12D3KooWMKxMkD5DMpSWsW7dBddKxKT7L2GgbNuckz9otxvkvByP"
+    ],
+    "MinimumPeers": 4
+  },
+  "Datastore": {
+    "Type": "levelds",
+    "Dir": "/data/datastore"
+  },
+  "Discovery": {
+    "FilterIPs": true,
+    "Policy": {
+      "Allow": true,
+      "Except": null,
+      "Publish": true,
+      "PublishExcept": null
+    },
+    "PollInterval": "24h0m0s",
+    "PollRetryAfter": "5m0s",
+    "PollStopAfter": "168h0m0s",
+    "PollOverrides": null,
+    "UseAssigner": true
+  },
+  "Indexer": {
+    "CacheSize": -1,
+    "ConfigCheckInterval": "30s",
+    "ShutdownTimeout": "15m",
+    "ValueStoreDir": "",
+    "ValueStoreType": "none",
+    "DHBatchSize": 4096,
+    "DHStoreURL": "http://dhstore-alva.internal.dev.cid.contact",
+    "DHStoreHttpClientTimeout": "30s"
+  },
+  "Ingest": {
+    "AdvertisementDepthLimit": 33554432,
+    "AdvertisementMirror": {
+      "Read": true,
+      "Write": true,
+      "Compress": "gzip",
+      "Storage": {
+        "Type": "s3",
+        "S3": {
+          "BucketName": "dev-sti-adstore"
+        }
+      }
+    },
+    "EntriesDepthLimit": 65536,
+    "HttpSyncRetryMax": 4,
+    "HttpSyncRetryWaitMax": "30s",
+    "HttpSyncRetryWaitMin": "1s",
+    "HttpSyncTimeout": "10s",
+    "IngestWorkerCount":10,
+    "PubSubTopic": "/indexer/ingest/mainnet",
+    "RateLimit": {
+      "Apply": false,
+      "Except": null,
+      "BlocksPerSecond": 0,
+      "BurstSize": 500
+    },
+    "ResendDirectAnnounce": false,
+    "StoreBatchSize": 8192,
+    "SyncSegmentDepthLimit": 2000,
+    "SyncTimeout": "2h0m0s"
+  },
+  "Logging": {
+    "Level": "info",
+    "Loggers": {
+      "basichost": "warn",
+      "bootstrap": "warn",
+      "dt-impl": "warn",
+      "dt_graphsync": "warn",
+      "graphsync": "warn"
+    }
+  },
+  "Peering": {
+    "Peers": [
+      "/dns4/assigner/tcp/3003/p2p/12D3KooWDBjcDRQ7CKJeF9Yy3UKbriHfyETDrXKzTDB6biH3ibBd"
+    ]
+  }
+}

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/alva/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/alva/config.json
@@ -80,12 +80,6 @@
     "HttpSyncTimeout": "10s",
     "IngestWorkerCount":10,
     "PubSubTopic": "/indexer/ingest/mainnet",
-    "RateLimit": {
-      "Apply": false,
-      "Except": null,
-      "BlocksPerSecond": 0,
-      "BurstSize": 500
-    },
     "ResendDirectAnnounce": false,
     "StoreBatchSize": 8192,
     "SyncSegmentDepthLimit": 2000,

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/alva/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/alva/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: indexer
+spec:
+  template:
+    spec:
+      serviceAccountName: storetheindex
+      terminationGracePeriodSeconds: 600
+      containers:
+        - name: indexer
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            limits:
+              cpu: "3"
+              memory: 28Gi
+            requests:
+              cpu: "3"
+              memory: 28Gi
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.kubernetes.io/instance-type
+                    operator: In
+                    values:
+                      - r6a.xlarge
+                  - key: topology.kubernetes.io/zone
+                    operator: In
+                    values:
+                      - us-east-2a
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: alva-data
+

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/alva/identity.key.encrypted
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/alva/identity.key.encrypted
@@ -1,0 +1,22 @@
+{
+	"data": "ENC[AES256_GCM,data:h7npG+UyrXIHwqRlkdBoGIjMNgmLv6r3FVu25Pu0ps9XQ2g6o9RrKQ4QA51D095bCFx0m9KRBXhDeu27ts8Zs6F+cxo=,iv:HJ/3LZK3CStGgvrgPncJdtwdS5v1fnv4zrvM3W6LsJ0=,tag:ikf7blqnKcOvQmSit3gY9g==,type:str]",
+	"sops": {
+		"kms": [
+			{
+				"arn": "arn:aws:kms:us-east-2:407967248065:alias/sti_flux",
+				"created_at": "2023-05-25T13:51:33Z",
+				"enc": "AQICAHi99m+hXhXmjeAqO3v9MBDcMaC2zWJIlamGyiBfOVdULAFQFyq9djNX2wjz+GRXCstXAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM1j9tJqHUdzoXs0JRAgEQgDt9NrNX+t+RcB9skeOmZSwpUbAPHnGQgFCteWn5Bf0NoO7UOWp6DFasTtDWELtbWTmA0pOJT6X0pivm1g==",
+				"aws_profile": ""
+			}
+		],
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2023-05-25T13:51:33Z",
+		"mac": "ENC[AES256_GCM,data:kNqjmhouvvrHvZimkXq1Wg1tii/ji7FOrCYdsb4+ppQfh3YNb4vcEPlH2bcw0tUbXo1xGOhsR19Ar6s8qT3v10JHs/Zk2GKSvan43sDQjb6cO7mssi+UqLbE+0TxKkiLOmqc8ZlPemdT8zMbSDLzKILPeXsvBu2luYEtZNM0v2E=,iv:PEIJsuaJovTJ68kxg83SW766ss19lr6PmNeicWy8ZuI=,tag:6h6S6C76yCxPAyYg89prDg==,type:str]",
+		"pgp": null,
+		"encrypted_regex": "^(data|stringData)$",
+		"version": "3.7.3"
+	}
+}

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/alva/ingress.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/alva/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: indexer
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt"
+spec:
+  tls:
+    - hosts:
+        - alva.dev.cid.contact
+      secretName: alva-indexer-ingress-tls
+  rules:
+    - host: alva.dev.cid.contact
+      http:
+        paths:
+          - path: /ingest
+            pathType: Prefix
+            backend:
+              service:
+                name: indexer
+                port:
+                  number: 3001
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: indexer
+                port:
+                  number: 3000

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/alva/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/alva/kustomization.yaml
@@ -1,0 +1,34 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - ../../../../../../base/storetheindex-single
+  - ingress.yaml
+  - pvc_data.yaml
+
+namePrefix: alva-
+
+commonLabels:
+  name: alva
+
+secretGenerator:
+  - name: identity
+    behavior: replace
+    files:
+      - identity.key=identity.key.encrypted # 12D3KooWSrUNEvYeHKL74mFaY6oayTJBNTfBFd1u8TBsD4ZwxRMC
+
+configMapGenerator:
+  - name: config
+    behavior: replace
+    files:
+      - config=config.json
+
+patchesStrategicMerge:
+  - deployment.yaml
+  
+images:
+  - name: storetheindex
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
+    newTag: 20230601012901-9af58c011632b71326d4039f0c46495c8bca3ec2

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/alva/pvc_data.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/alva/pvc_data.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: indexer-single
+    app.kubernetes.io/managed-by: kustomization
+    app.kubernetes.io/part-of: storetheindex
+  name: data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Ti
+  storageClassName: io2

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/alva/pvc_data.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/alva/pvc_data.yaml
@@ -11,5 +11,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1Ti
+      storage: 100Gi
   storageClassName: io2

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/alva/pvc_data.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/alva/pvc_data.yaml
@@ -12,4 +12,4 @@ spec:
   resources:
     requests:
       storage: 100Gi
-  storageClassName: io2
+  storageClassName: gp3

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/config.json
@@ -1,0 +1,109 @@
+{
+  "Version": 2,
+  "Identity": {
+    "PeerID": "",
+    "PrivKey": ""
+  },
+  "Addresses": {
+    "Admin": "/ip4/0.0.0.0/tcp/3002",
+    "Finder": "/ip4/0.0.0.0/tcp/3000",
+    "FinderWebpage": "https://web-ipni.cid.contact/dev",
+    "Ingest": "/ip4/0.0.0.0/tcp/3001",
+    "P2PAddr": "/ip4/0.0.0.0/tcp/3003",
+    "NoResourceManager": true
+  },
+  "Bootstrap": {
+    "Peers": [
+      "/dns4/bootstrap-0.ipfsmain.cn/tcp/34721/p2p/12D3KooWQnwEGNqcM2nAcPtRR9rAX8Hrg4k9kJLCHoTR5chJfz6d",
+      "/dns4/bootstrap-3.mainnet.filops.net/tcp/1347/p2p/12D3KooWKhgq8c7NQ9iGjbyK7v7phXvG6492HQfiDaGHLHLQjk7R",
+      "/dns4/bootstrap-4.mainnet.filops.net/tcp/1347/p2p/12D3KooWL6PsFNPhYftrJzGgF5U18hFoaVhfGk7xwzD8yVrHJ3Uc",
+      "/dns4/bootstrap-6.mainnet.filops.net/tcp/1347/p2p/12D3KooWP5MwCiqdMETF9ub1P3MbCvQCcfconnYHbWg6sUJcDRQQ",
+      "/dns4/bootstrap-7.mainnet.filops.net/tcp/1347/p2p/12D3KooWRs3aY1p3juFjPy8gPN95PEQChm2QKGUCAdcDCC4EBMKf",
+      "/dns4/bootstrap-8.mainnet.filops.net/tcp/1347/p2p/12D3KooWScFR7385LTyR4zU1bYdzSiiAb5rnNABfVahPvVSzyTkR",
+      "/dns4/node.glif.io/tcp/1235/p2p/12D3KooWBF8cpp65hp2u9LK5mh19x67ftAam84z9LsfaquTDSBpt",
+      "/dns4/bootstrap-2.mainnet.filops.net/tcp/1347/p2p/12D3KooWEWVwHGn2yR36gKLozmb4YjDJGerotAPGxmdWZx2nxMC4",
+      "/dns4/bootstrap-5.mainnet.filops.net/tcp/1347/p2p/12D3KooWLFynvDQiUpXoHroV1YxKHhPJgysQGH2k3ZGwtWzR4dFH",
+      "/dns4/bootstrap-1.starpool.in/tcp/12757/p2p/12D3KooWQZrGH1PxSNZPum99M1zNvjNFM33d1AAu5DcvdHptuU7u",
+      "/dns4/bootstrap-0.mainnet.filops.net/tcp/1347/p2p/12D3KooWCVe8MmsEMes2FzgTpt9fXtmCY7wrq91GRiaC8PHSCCBj",
+      "/dns4/bootstrap-1.mainnet.filops.net/tcp/1347/p2p/12D3KooWCwevHg1yLCvktf2nvLu7L9894mcrJR4MsBCcm4syShVc",
+      "/dns4/bootstrap-0.starpool.in/tcp/12757/p2p/12D3KooWGHpBMeZbestVEWkfdnC9u7p6uFHXL1n7m1ZBqsEmiUzz",
+      "/dns4/lotus-bootstrap.ipfsforce.com/tcp/41778/p2p/12D3KooWGhufNmZHF3sv48aQeS13ng5XVJZ9E6qy2Ms4VzqeUsHk",
+      "/dns4/bootstrap-1.ipfsmain.cn/tcp/34723/p2p/12D3KooWMKxMkD5DMpSWsW7dBddKxKT7L2GgbNuckz9otxvkvByP"
+    ],
+    "MinimumPeers": 4
+  },
+  "Datastore": {
+    "Type": "levelds",
+    "Dir": "/data/datastore"
+  },
+  "Discovery": {
+    "FilterIPs": true,
+    "Policy": {
+      "Allow": true,
+      "Except": null,
+      "Publish": true,
+      "PublishExcept": null
+    },
+    "PollInterval": "24h0m0s",
+    "PollRetryAfter": "5m0s",
+    "PollStopAfter": "168h0m0s",
+    "PollOverrides": null,
+    "UseAssigner": true
+  },
+  "Indexer": {
+    "CacheSize": -1,
+    "ConfigCheckInterval": "30s",
+    "ShutdownTimeout": "15m",
+    "ValueStoreDir": "",
+    "ValueStoreType": "none",
+    "DHBatchSize": 4096,
+    "DHStoreURL": "http://dhstore-bria.internal.dev.cid.contact",
+    "DHStoreHttpClientTimeout": "30s"
+  },
+  "Ingest": {
+    "AdvertisementDepthLimit": 33554432,
+    "AdvertisementMirror": {
+      "Read": true,
+      "Write": true,
+      "Compress": "gzip",
+      "Storage": {
+        "Type": "s3",
+        "S3": {
+          "BucketName": "dev-sti-adstore"
+        }
+      }
+    },
+    "EntriesDepthLimit": 65536,
+    "HttpSyncRetryMax": 4,
+    "HttpSyncRetryWaitMax": "30s",
+    "HttpSyncRetryWaitMin": "1s",
+    "HttpSyncTimeout": "10s",
+    "IngestWorkerCount":10,
+    "PubSubTopic": "/indexer/ingest/mainnet",
+    "RateLimit": {
+      "Apply": false,
+      "Except": null,
+      "BlocksPerSecond": 0,
+      "BurstSize": 500
+    },
+    "ResendDirectAnnounce": false,
+    "StoreBatchSize": 8192,
+    "SyncSegmentDepthLimit": 2000,
+    "SyncTimeout": "2h0m0s"
+  },
+  "Logging": {
+    "Level": "info",
+    "Loggers": {
+      "basichost": "warn",
+      "bootstrap": "warn",
+      "dt-impl": "warn",
+      "dt_graphsync": "warn",
+      "graphsync": "warn"
+    }
+  },
+  "Peering": {
+    "Peers": [
+      "/dns4/assigner/tcp/3003/p2p/12D3KooWDBjcDRQ7CKJeF9Yy3UKbriHfyETDrXKzTDB6biH3ibBd"
+    ]
+  }
+}

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/config.json
@@ -80,12 +80,6 @@
     "HttpSyncTimeout": "10s",
     "IngestWorkerCount":10,
     "PubSubTopic": "/indexer/ingest/mainnet",
-    "RateLimit": {
-      "Apply": false,
-      "Except": null,
-      "BlocksPerSecond": 0,
-      "BurstSize": 500
-    },
     "ResendDirectAnnounce": false,
     "StoreBatchSize": 8192,
     "SyncSegmentDepthLimit": 2000,

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: indexer
+spec:
+  template:
+    spec:
+      serviceAccountName: storetheindex
+      terminationGracePeriodSeconds: 600
+      containers:
+        - name: indexer
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            limits:
+              cpu: "3"
+              memory: 28Gi
+            requests:
+              cpu: "3"
+              memory: 28Gi
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.kubernetes.io/instance-type
+                    operator: In
+                    values:
+                      - r6a.xlarge
+                  - key: topology.kubernetes.io/zone
+                    operator: In
+                    values:
+                      - us-east-2a
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: bria-data
+

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/identity.key.encrypted
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/identity.key.encrypted
@@ -1,0 +1,22 @@
+{
+	"data": "ENC[AES256_GCM,data:I40f84qlprpnYBuyCysWbijhCSqDwloEol5uYRnzERxTdyblfQrPZAiwYN+MncLfK4sGkaMj0U+IGNsa19JzvzAaroA=,iv:9QHrdYqnT244C416nLMejRKaXGBepjyvsajjPHzDTuY=,tag:jPrDlInMDsgHYaLzkCdkMA==,type:str]",
+	"sops": {
+		"kms": [
+			{
+				"arn": "arn:aws:kms:us-east-2:407967248065:alias/sti_flux",
+				"created_at": "2023-05-25T13:49:34Z",
+				"enc": "AQICAHi99m+hXhXmjeAqO3v9MBDcMaC2zWJIlamGyiBfOVdULAGB+0ZVVNaOJna8KSNca4ucAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMNzUGl0JIy5MXlymcAgEQgDt1QT/NJOhSL4ZMBIshirapLwu0ONgyocEGKN2UJUkoUyPUkYeRoCM/+PRZ+es8ssbuXicloZwsOZY85g==",
+				"aws_profile": ""
+			}
+		],
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2023-05-25T13:49:35Z",
+		"mac": "ENC[AES256_GCM,data:0uD5DwYdEwpfDWXq4t2gUATERcuIzJ3zJ0wX1LkHpdMfYq7tqNJr9vyw1g7eu8oU9Mmz3tti4sLidhjtoz2cxq+IwX4yGhO9fC0qYawpTqcb7g1CFLnZgBDAUiYQOdQVOI0wTn332QVATJAEOwnM8AQ5/H9rittyBCHFVq1fFJU=,iv:fBsii88gKp1llk5y76YWIoU0VTZUkFPeIS2BSPKwITY=,tag:R7L14Qkemv/86E6uGKcQdg==,type:str]",
+		"pgp": null,
+		"encrypted_regex": "^(data|stringData)$",
+		"version": "3.7.3"
+	}
+}

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/ingress.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: indexer
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt"
+spec:
+  tls:
+    - hosts:
+        - bria.dev.cid.contact
+      secretName: bria-indexer-ingress-tls
+  rules:
+    - host: bria.dev.cid.contact
+      http:
+        paths:
+          - path: /ingest
+            pathType: Prefix
+            backend:
+              service:
+                name: indexer
+                port:
+                  number: 3001
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: indexer
+                port:
+                  number: 3000

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/kustomization.yaml
@@ -1,0 +1,34 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - ../../../../../../base/storetheindex-single
+  - ingress.yaml
+  - pvc_data.yaml
+
+namePrefix: bria-
+
+commonLabels:
+  name: bria
+
+secretGenerator:
+  - name: identity
+    behavior: replace
+    files:
+      - identity.key=identity.key.encrypted # 12D3KooWBYVX8aSiS8butwauzJvg5Ka8J339PHkn3WjhLZJAdDM8
+
+configMapGenerator:
+  - name: config
+    behavior: replace
+    files:
+      - config=config.json
+
+patchesStrategicMerge:
+  - deployment.yaml
+  
+images:
+  - name: storetheindex
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
+    newTag: 20230601012901-9af58c011632b71326d4039f0c46495c8bca3ec2

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/pvc_data.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/pvc_data.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: indexer-single
+    app.kubernetes.io/managed-by: kustomization
+    app.kubernetes.io/part-of: storetheindex
+  name: data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Ti
+  storageClassName: io2

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/pvc_data.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/pvc_data.yaml
@@ -11,5 +11,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1Ti
+      storage: 100Gi
   storageClassName: io2

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/pvc_data.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/pvc_data.yaml
@@ -12,4 +12,4 @@ spec:
   resources:
     requests:
       storage: 100Gi
-  storageClassName: io2
+  storageClassName: gp3

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/config.json
@@ -1,0 +1,109 @@
+{
+  "Version": 2,
+  "Identity": {
+    "PeerID": "",
+    "PrivKey": ""
+  },
+  "Addresses": {
+    "Admin": "/ip4/0.0.0.0/tcp/3002",
+    "Finder": "/ip4/0.0.0.0/tcp/3000",
+    "FinderWebpage": "https://web-ipni.cid.contact/dev",
+    "Ingest": "/ip4/0.0.0.0/tcp/3001",
+    "P2PAddr": "/ip4/0.0.0.0/tcp/3003",
+    "NoResourceManager": true
+  },
+  "Bootstrap": {
+    "Peers": [
+      "/dns4/bootstrap-0.ipfsmain.cn/tcp/34721/p2p/12D3KooWQnwEGNqcM2nAcPtRR9rAX8Hrg4k9kJLCHoTR5chJfz6d",
+      "/dns4/bootstrap-3.mainnet.filops.net/tcp/1347/p2p/12D3KooWKhgq8c7NQ9iGjbyK7v7phXvG6492HQfiDaGHLHLQjk7R",
+      "/dns4/bootstrap-4.mainnet.filops.net/tcp/1347/p2p/12D3KooWL6PsFNPhYftrJzGgF5U18hFoaVhfGk7xwzD8yVrHJ3Uc",
+      "/dns4/bootstrap-6.mainnet.filops.net/tcp/1347/p2p/12D3KooWP5MwCiqdMETF9ub1P3MbCvQCcfconnYHbWg6sUJcDRQQ",
+      "/dns4/bootstrap-7.mainnet.filops.net/tcp/1347/p2p/12D3KooWRs3aY1p3juFjPy8gPN95PEQChm2QKGUCAdcDCC4EBMKf",
+      "/dns4/bootstrap-8.mainnet.filops.net/tcp/1347/p2p/12D3KooWScFR7385LTyR4zU1bYdzSiiAb5rnNABfVahPvVSzyTkR",
+      "/dns4/node.glif.io/tcp/1235/p2p/12D3KooWBF8cpp65hp2u9LK5mh19x67ftAam84z9LsfaquTDSBpt",
+      "/dns4/bootstrap-2.mainnet.filops.net/tcp/1347/p2p/12D3KooWEWVwHGn2yR36gKLozmb4YjDJGerotAPGxmdWZx2nxMC4",
+      "/dns4/bootstrap-5.mainnet.filops.net/tcp/1347/p2p/12D3KooWLFynvDQiUpXoHroV1YxKHhPJgysQGH2k3ZGwtWzR4dFH",
+      "/dns4/bootstrap-1.starpool.in/tcp/12757/p2p/12D3KooWQZrGH1PxSNZPum99M1zNvjNFM33d1AAu5DcvdHptuU7u",
+      "/dns4/bootstrap-0.mainnet.filops.net/tcp/1347/p2p/12D3KooWCVe8MmsEMes2FzgTpt9fXtmCY7wrq91GRiaC8PHSCCBj",
+      "/dns4/bootstrap-1.mainnet.filops.net/tcp/1347/p2p/12D3KooWCwevHg1yLCvktf2nvLu7L9894mcrJR4MsBCcm4syShVc",
+      "/dns4/bootstrap-0.starpool.in/tcp/12757/p2p/12D3KooWGHpBMeZbestVEWkfdnC9u7p6uFHXL1n7m1ZBqsEmiUzz",
+      "/dns4/lotus-bootstrap.ipfsforce.com/tcp/41778/p2p/12D3KooWGhufNmZHF3sv48aQeS13ng5XVJZ9E6qy2Ms4VzqeUsHk",
+      "/dns4/bootstrap-1.ipfsmain.cn/tcp/34723/p2p/12D3KooWMKxMkD5DMpSWsW7dBddKxKT7L2GgbNuckz9otxvkvByP"
+    ],
+    "MinimumPeers": 4
+  },
+  "Datastore": {
+    "Type": "levelds",
+    "Dir": "/data/datastore"
+  },
+  "Discovery": {
+    "FilterIPs": true,
+    "Policy": {
+      "Allow": true,
+      "Except": null,
+      "Publish": true,
+      "PublishExcept": null
+    },
+    "PollInterval": "24h0m0s",
+    "PollRetryAfter": "5m0s",
+    "PollStopAfter": "168h0m0s",
+    "PollOverrides": null,
+    "UseAssigner": true
+  },
+  "Indexer": {
+    "CacheSize": -1,
+    "ConfigCheckInterval": "30s",
+    "ShutdownTimeout": "15m",
+    "ValueStoreDir": "",
+    "ValueStoreType": "none",
+    "DHBatchSize": 4096,
+    "DHStoreURL": "http://dhstore-cora.internal.dev.cid.contact",
+    "DHStoreHttpClientTimeout": "30s"
+  },
+  "Ingest": {
+    "AdvertisementDepthLimit": 33554432,
+    "AdvertisementMirror": {
+      "Read": true,
+      "Write": true,
+      "Compress": "gzip",
+      "Storage": {
+        "Type": "s3",
+        "S3": {
+          "BucketName": "dev-sti-adstore"
+        }
+      }
+    },
+    "EntriesDepthLimit": 65536,
+    "HttpSyncRetryMax": 4,
+    "HttpSyncRetryWaitMax": "30s",
+    "HttpSyncRetryWaitMin": "1s",
+    "HttpSyncTimeout": "10s",
+    "IngestWorkerCount":10,
+    "PubSubTopic": "/indexer/ingest/mainnet",
+    "RateLimit": {
+      "Apply": false,
+      "Except": null,
+      "BlocksPerSecond": 0,
+      "BurstSize": 500
+    },
+    "ResendDirectAnnounce": false,
+    "StoreBatchSize": 8192,
+    "SyncSegmentDepthLimit": 2000,
+    "SyncTimeout": "2h0m0s"
+  },
+  "Logging": {
+    "Level": "info",
+    "Loggers": {
+      "basichost": "warn",
+      "bootstrap": "warn",
+      "dt-impl": "warn",
+      "dt_graphsync": "warn",
+      "graphsync": "warn"
+    }
+  },
+  "Peering": {
+    "Peers": [
+      "/dns4/assigner/tcp/3003/p2p/12D3KooWDBjcDRQ7CKJeF9Yy3UKbriHfyETDrXKzTDB6biH3ibBd"
+    ]
+  }
+}

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/config.json
@@ -80,12 +80,6 @@
     "HttpSyncTimeout": "10s",
     "IngestWorkerCount":10,
     "PubSubTopic": "/indexer/ingest/mainnet",
-    "RateLimit": {
-      "Apply": false,
-      "Except": null,
-      "BlocksPerSecond": 0,
-      "BurstSize": 500
-    },
     "ResendDirectAnnounce": false,
     "StoreBatchSize": 8192,
     "SyncSegmentDepthLimit": 2000,

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: indexer
+spec:
+  template:
+    spec:
+      serviceAccountName: storetheindex
+      terminationGracePeriodSeconds: 600
+      containers:
+        - name: indexer
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            limits:
+              cpu: "3"
+              memory: 28Gi
+            requests:
+              cpu: "3"
+              memory: 28Gi
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.kubernetes.io/instance-type
+                    operator: In
+                    values:
+                      - r6a.xlarge
+                  - key: topology.kubernetes.io/zone
+                    operator: In
+                    values:
+                      - us-east-2a
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: cora-data
+

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/identity.key.encrypted
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/identity.key.encrypted
@@ -1,0 +1,22 @@
+{
+	"data": "ENC[AES256_GCM,data:Au1nTqoPoblaa+MH8yRUjYLUHJTzT+uw7cg96zupXV5AvyQQcDjbLe7PUTRv2y31xGL4165CwNm8HshibnVNZVekB2k=,iv:rQFtyGOTl9CGb9hXxXz/7WT7yV4EV4hpyVnTkTc7G60=,tag:be590QY97iGFSmf4RVn/HA==,type:str]",
+	"sops": {
+		"kms": [
+			{
+				"arn": "arn:aws:kms:us-east-2:407967248065:alias/sti_flux",
+				"created_at": "2023-05-25T13:50:25Z",
+				"enc": "AQICAHi99m+hXhXmjeAqO3v9MBDcMaC2zWJIlamGyiBfOVdULAFE5778LE+BNvi89FXVbl0tAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMNIjygCUynJdFOPXrAgEQgDvqsY3UMGNtSmfwjB6BOEHAurlnlHJ/jpV98bKh1epQc7Q3DAsWtphT2PG7XcjoFRiebjsoySHjy2j6jA==",
+				"aws_profile": ""
+			}
+		],
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2023-05-25T13:50:25Z",
+		"mac": "ENC[AES256_GCM,data:0o33MBeQXERW+22DS1hjuHAQBoWHyFOlhv/2/kgYG8c3NQEdEPIdSwNg8patdJ+HMxOwAHasoumXGkY+Al9fYgUZbJlOe7Cf+FVMQC3QOIQEcIbTdX5VUHCrukTCXPeae4NHIi4h7o1s0kmbrQ2uvbIJopA6wriKNJyTlCCa2v0=,iv:Z9U2NKAa9ehyU7Pj5/ZIZbtwhV+MfNjWcOVV6dRBGIw=,tag:E3LET9Tot0rXnNb4kAplog==,type:str]",
+		"pgp": null,
+		"encrypted_regex": "^(data|stringData)$",
+		"version": "3.7.3"
+	}
+}

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/ingress.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: indexer
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt"
+spec:
+  tls:
+    - hosts:
+        - cora.dev.cid.contact
+      secretName: cora-indexer-ingress-tls
+  rules:
+    - host: cora.dev.cid.contact
+      http:
+        paths:
+          - path: /ingest
+            pathType: Prefix
+            backend:
+              service:
+                name: indexer
+                port:
+                  number: 3001
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: indexer
+                port:
+                  number: 3000

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/kustomization.yaml
@@ -1,0 +1,34 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - ../../../../../../base/storetheindex-single
+  - ingress.yaml
+  - pvc_data.yaml
+
+namePrefix: cora-
+
+commonLabels:
+  name: cora
+
+secretGenerator:
+  - name: identity
+    behavior: replace
+    files:
+      - identity.key=identity.key.encrypted # 12D3KooWEkZMB3XQTDYgAxhMd9jfZhfD9zHjKPTyyi6jzM5u7bgv
+
+configMapGenerator:
+  - name: config
+    behavior: replace
+    files:
+      - config=config.json
+
+patchesStrategicMerge:
+  - deployment.yaml
+  
+images:
+  - name: storetheindex
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
+    newTag: 20230601012901-9af58c011632b71326d4039f0c46495c8bca3ec2

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/pvc_data.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/pvc_data.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: indexer-single
+    app.kubernetes.io/managed-by: kustomization
+    app.kubernetes.io/part-of: storetheindex
+  name: data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Ti
+  storageClassName: io2

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/pvc_data.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/pvc_data.yaml
@@ -11,5 +11,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1Ti
+      storage: 100Gi
   storageClassName: io2

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/pvc_data.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/pvc_data.yaml
@@ -12,4 +12,4 @@ spec:
   resources:
     requests:
       storage: 100Gi
-  storageClassName: io2
+  storageClassName: gp3

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/kustomization.yaml
@@ -9,6 +9,3 @@ resources:
   - ber
   - cali
   - ago
-  - alva
-  - bria
-  - cora

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/kustomization.yaml
@@ -9,3 +9,6 @@ resources:
   - ber
   - cali
   - ago
+  - alva
+  - bria
+  - cora


### PR DESCRIPTION
New indexer nodes `alva`, `bria`, and `cora`. Each has 100Gi pvc size and are a mirror reader and writer.