### PR TITLE
Deploy stateless dhstore manifests

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-stateless/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-stateless/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dhstore
+spec:
+  template:
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+      containers:
+        - name: dhstore
+          args:
+            - '--storeType=fdb'
+            - '--fdbClusterFile=/config/cluster-file'
+            - '--fdbApiVersion=710'
+          volumeMounts:
+            - mountPath: /config
+              name: config
+      volumes:
+        - name: config
+          configMap:
+            name: fdb-dev-cluster-config

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-stateless/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-stateless/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+nameSuffix: -stateless
+
+commonLabels:
+  name: dhstore-stateless
+
+resources:
+  - github.com/ipni/dhstore/deploy/kubernetes?ref=9939a3a8804356e6f5f18198dcfa8d75786f6223
+  - pod-monitor.yaml
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+replicas:
+  - name: dhstore
+    count: 3
+
+images:
+  - name: dhstore
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
+    newTag: 20230526214130-9939a3a8804356e6f5f18198dcfa8d75786f6223

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-stateless/pod-monitor.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-stateless/pod-monitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: dhstore-stateless
+  labels:
+    app: dhstore
+    name: dhstore-stateless
+spec:
+  selector:
+    matchLabels:
+      app: dhstore
+      name: dhstore-stateless
+  namespaceSelector:
+    matchNames:
+      - storetheindex
+  podMetricsEndpoints:
+    - path: /metrics
+      port: metrics

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
 - heyfil
 - fdb-manager
 - fdb-cluster
+- dhstore-stateless
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}


### PR DESCRIPTION
Define stateless dhstore manifests hooked up to `fdb-dev` FoundationDB cluster.
