### PR TITLE
Fix FDB cluster name in manifest

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
@@ -19,7 +19,7 @@ spec:
     stateless: 2
   labels:
     matchLabels:
-      foundationdb.org/fdb-cluster-name: dev
+      foundationdb.org/fdb-cluster-name: fdb-dev-cluster
     processClassLabels:
       - foundationdb.org/fdb-process-class
     processGroupIDLabels:


### PR DESCRIPTION
Otherwise, coordinator selection fails by the controller.

