### PR TITLE
Deploy new nodes and point to stateless dhstore

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/alva/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/alva/config.json
@@ -57,7 +57,7 @@
     "ValueStoreDir": "",
     "ValueStoreType": "none",
     "DHBatchSize": 4096,
-    "DHStoreURL": "http://dhstore-alva.internal.dev.cid.contact",
+    "DHStoreURL": "http://dhstore-stateless:40080",
     "DHStoreHttpClientTimeout": "30s"
   },
   "Ingest": {

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/alva/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/alva/kustomization.yaml
@@ -31,4 +31,4 @@ patchesStrategicMerge:
 images:
   - name: storetheindex
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-    newTag: 20230601012901-9af58c011632b71326d4039f0c46495c8bca3ec2
+    newTag: 20230601233715-9d2f7ccbd13dd304c0a3843969b9ddb8210ae6f1

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/config.json
@@ -57,7 +57,7 @@
     "ValueStoreDir": "",
     "ValueStoreType": "none",
     "DHBatchSize": 4096,
-    "DHStoreURL": "http://dhstore-bria.internal.dev.cid.contact",
+    "DHStoreURL": "http://dhstore-stateless:40080",
     "DHStoreHttpClientTimeout": "30s"
   },
   "Ingest": {

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/deployment.yaml
@@ -31,7 +31,7 @@ spec:
                   - key: topology.kubernetes.io/zone
                     operator: In
                     values:
-                      - us-east-2a
+                      - us-east-2b
       volumes:
         - name: data
           persistentVolumeClaim:

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/kustomization.yaml
@@ -31,4 +31,4 @@ patchesStrategicMerge:
 images:
   - name: storetheindex
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-    newTag: 20230601012901-9af58c011632b71326d4039f0c46495c8bca3ec2
+    newTag: 20230601233715-9d2f7ccbd13dd304c0a3843969b9ddb8210ae6f1

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/config.json
@@ -57,7 +57,7 @@
     "ValueStoreDir": "",
     "ValueStoreType": "none",
     "DHBatchSize": 4096,
-    "DHStoreURL": "http://dhstore-cora.internal.dev.cid.contact",
+    "DHStoreURL": "http://dhstore-stateless:40080",
     "DHStoreHttpClientTimeout": "30s"
   },
   "Ingest": {

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/deployment.yaml
@@ -31,7 +31,7 @@ spec:
                   - key: topology.kubernetes.io/zone
                     operator: In
                     values:
-                      - us-east-2a
+                      - us-east-2c
       volumes:
         - name: data
           persistentVolumeClaim:

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/kustomization.yaml
@@ -31,4 +31,4 @@ patchesStrategicMerge:
 images:
   - name: storetheindex
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-    newTag: 20230601012901-9af58c011632b71326d4039f0c46495c8bca3ec2
+    newTag: 20230601233715-9d2f7ccbd13dd304c0a3843969b9ddb8210ae6f1

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/kustomization.yaml
@@ -9,3 +9,6 @@ resources:
   - ber
   - cali
   - ago
+  - alva
+  - bria
+  - cora


### PR DESCRIPTION
Deploy the new nodes on dev, spread across AZs and point them to the FDB-backed dhstore.

