### PR TITLE
Deploy new assigner for FDB-backed indexers

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/assigner-fdb-backed/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/assigner-fdb-backed/config.json
@@ -8,14 +8,19 @@
     "FilterIPs": false,
     "IndexerPool": [
       {
-        "AdminURL": "http://ber-indexer:3002",
-        "FindURL": "http://ber-indexer:3000",
-        "IngestURL": "http://ber-indexer:3001"
+        "AdminURL": "http://alva-indexer:3002",
+        "FindURL": "http://alva-indexer:3000",
+        "IngestURL": "http://alva-indexer:3001"
       },
       {
-        "AdminURL": "http://cali-indexer:3002",
-        "FindURL": "http://cali-indexer:3000",
-        "IngestURL": "http://cali-indexer:3001"
+        "AdminURL": "http://bria-indexer:3002",
+        "FindURL": "http://bria-indexer:3000",
+        "IngestURL": "http://bria-indexer:3001"
+      },
+      {
+        "AdminURL": "http://cora-indexer:3002",
+        "FindURL": "http://cora-indexer:3000",
+        "IngestURL": "http://cora-indexer:3001"
       }
     ],
     "Policy": {
@@ -59,9 +64,9 @@
   },
   "Peering": {
     "Peers": [
-      "/dns4/assigner-fdb-backed/tcp/3003/p2p/12D3KooWGp2P8Ca3xVeKf2b41rWB4687Ude8kkDSrFWQ6oBnTNCv",
-      "/dns4/ber-indexer/tcp/3003/p2p/12D3KooWSQpUgBZwbNuMN3ctZjMesnoH9UDhwEXroxParXQCgurN",
-      "/dns4/cali-indexer/tcp/3003/p2p/12D3KooWHGHu3jVjya9sDSAYRmAVtUnQGTwnWeqan1smfJdjzscB"
+      "/dns4/alva-indexer/tcp/3003/p2p/12D3KooWSrUNEvYeHKL74mFaY6oayTJBNTfBFd1u8TBsD4ZwxRMC",
+      "/dns4/bria-indexer/tcp/3003/p2p/12D3KooWBYVX8aSiS8butwauzJvg5Ka8J339PHkn3WjhLZJAdDM8",
+      "/dns4/cora-indexer/tcp/3003/p2p/12D3KooWEkZMB3XQTDYgAxhMd9jfZhfD9zHjKPTyyi6jzM5u7bgv"
     ]
   }
 }

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/assigner-fdb-backed/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/assigner-fdb-backed/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: assigner
+spec:
+  template:
+    spec:
+      containers:
+        - name: assigner
+          ports:
+            - containerPort: 3003
+              name: libp2p
+          resources:
+            limits:
+              cpu: "3"
+              memory: 2Gi
+            requests:
+              cpu: "3"
+              memory: 2Gi
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            - name: identity
+              mountPath: /identity
+      volumes:
+        - name: config
+          configMap:
+            name: config
+        - name: identity
+          secret:
+            secretName: identity

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/assigner-fdb-backed/identity.key.encrypted
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/assigner-fdb-backed/identity.key.encrypted
@@ -1,0 +1,22 @@
+{
+	"data": "ENC[AES256_GCM,data:8NNDohVJw63YMyvMRBcXeGwyNf81FJ+THWU/DQc2wPedJoo1K0E8EjFFodU0tUHMh3WyCPlizT2SUeY1mfsnyyLhBC8=,iv:byyjqgn+BdtKuF0Wd5nPf5k2mzms0kqceDynA78eZn8=,tag:VIIiZMMkmiu10MUSv55psQ==,type:str]",
+	"sops": {
+		"kms": [
+			{
+				"arn": "arn:aws:kms:us-east-2:407967248065:alias/sti_flux",
+				"created_at": "2023-05-18T14:51:02Z",
+				"enc": "AQICAHi99m+hXhXmjeAqO3v9MBDcMaC2zWJIlamGyiBfOVdULAEdd7BQIEmxnHs7Kb/sy1XvAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM/ohgFZqzV+8DXyWWAgEQgDsnr/eRuPUTeHS9pQ1FU5KnkoGQgwpkVcP29A+JwHOU6V1JxdxmlSiZT9RjroaD7FWy7iAXlz0jyi/xDw==",
+				"aws_profile": ""
+			}
+		],
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2023-05-18T14:51:03Z",
+		"mac": "ENC[AES256_GCM,data:LF65/FtQLb/kZTd330c9rTZzuiXjauUVCZEdtvBwo5eizxg7OxGqqcmdrbjD+/CcbZe8JPLOPAXHvyHG+fTDR5aZc2ya+cY7WEk4YlV2YYNqUXGqwHmL0wGcRTLYqrxVSBea5lUJq6HD1VOGEkQOCjR3OcX9X9oH/vYNoAZKGGI=,iv:Wy7YFCQ7OVHs4rjduZYW0ZYqMuNaZwj8RuOkafIzz/4=,tag:vS4h6uwJLl0940/CCMfFRg==,type:str]",
+		"pgp": null,
+		"encrypted_regex": "^(data|stringData)$",
+		"version": "3.7.3"
+	}
+}

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/assigner-fdb-backed/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/assigner-fdb-backed/kustomization.yaml
@@ -1,0 +1,32 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+nameSuffix: -fdb-backed
+commonLabels:
+  app: assigner-fdb-backed
+
+resources:
+  - ../../../../../base/assigner
+
+patchesStrategicMerge:
+  - deployment.yaml
+  - service.yaml
+
+secretGenerator:
+  - name: identity
+    behavior: create
+    files:
+      - identity.key=identity.key.encrypted # 12D3KooWGp2P8Ca3xVeKf2b41rWB4687Ude8kkDSrFWQ6oBnTNCv
+
+configMapGenerator:
+  - name: config
+    behavior: create
+    files:
+      - config=config.json
+
+images:
+- name: storetheindex
+  newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
+  newTag: 20230518132024-2ea1218070d49e938fef062597eb739e89c3957a

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/assigner-fdb-backed/service.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/assigner-fdb-backed/service.yaml
@@ -1,0 +1,9 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: assigner
+spec:
+  ports:
+    - name: libp2p
+      port: 3003
+      targetPort: libp2p

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/alva/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/alva/config.json
@@ -99,7 +99,7 @@
   },
   "Peering": {
     "Peers": [
-      "/dns4/assigner/tcp/3003/p2p/12D3KooWDBjcDRQ7CKJeF9Yy3UKbriHfyETDrXKzTDB6biH3ibBd"
+      "/dns4/assigner-fdb-backed/tcp/3003/p2p/12D3KooWGp2P8Ca3xVeKf2b41rWB4687Ude8kkDSrFWQ6oBnTNCv"
     ]
   }
 }

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/config.json
@@ -99,7 +99,7 @@
   },
   "Peering": {
     "Peers": [
-      "/dns4/assigner/tcp/3003/p2p/12D3KooWDBjcDRQ7CKJeF9Yy3UKbriHfyETDrXKzTDB6biH3ibBd"
+      "/dns4/assigner-fdb-backed/tcp/3003/p2p/12D3KooWGp2P8Ca3xVeKf2b41rWB4687Ude8kkDSrFWQ6oBnTNCv"
     ]
   }
 }

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/config.json
@@ -99,7 +99,7 @@
   },
   "Peering": {
     "Peers": [
-      "/dns4/assigner/tcp/3003/p2p/12D3KooWDBjcDRQ7CKJeF9Yy3UKbriHfyETDrXKzTDB6biH3ibBd"
+      "/dns4/assigner-fdb-backed/tcp/3003/p2p/12D3KooWGp2P8Ca3xVeKf2b41rWB4687Ude8kkDSrFWQ6oBnTNCv"
     ]
   }
 }

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
 - fdb-manager
 - fdb-cluster
 - dhstore-stateless
+- assigner-fdb-backed
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}


### PR DESCRIPTION
Deploy a new assigner for the FoundationDB backed indexer nodes, that is daisy-chained to the front-facing assigner to propagate announcements through.

