### PR TITLE
Config assigner to use new indexers for FDB valuestore

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/assigner/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/assigner/config.json
@@ -8,14 +8,19 @@
     "FilterIPs": false,
     "IndexerPool": [
       {
-        "AdminURL": "http://ber-indexer:3002",
-        "FindURL": "http://ber-indexer:3000",
-        "IngestURL": "http://ber-indexer:3001"
+        "AdminURL": "http://alva-indexer:3002",
+        "FindURL": "http://alva-indexer:3000",
+        "IngestURL": "http://alva-indexer:3001"
       },
       {
-        "AdminURL": "http://cali-indexer:3002",
-        "FindURL": "http://cali-indexer:3000",
-        "IngestURL": "http://cali-indexer:3001"
+        "AdminURL": "http://bria-indexer:3002",
+        "FindURL": "http://bria-indexer:3000",
+        "IngestURL": "http://bria-indexer:3001"
+      },
+      {
+        "AdminURL": "http://cora-indexer:3002",
+        "FindURL": "http://cora-indexer:3000",
+        "IngestURL": "http://cora-indexer:3001"
       }
     ],
     "Policy": {
@@ -60,7 +65,10 @@
   "Peering": {
     "Peers": [
       "/dns4/ber-indexer/tcp/3003/p2p/12D3KooWSQpUgBZwbNuMN3ctZjMesnoH9UDhwEXroxParXQCgurN",
-      "/dns4/cali-indexer/tcp/3003/p2p/12D3KooWHGHu3jVjya9sDSAYRmAVtUnQGTwnWeqan1smfJdjzscB"
+      "/dns4/cali-indexer/tcp/3003/p2p/12D3KooWHGHu3jVjya9sDSAYRmAVtUnQGTwnWeqan1smfJdjzscB",
+      "/dns4/alva-indexer/tcp/3003/p2p/12D3KooWSrUNEvYeHKL74mFaY6oayTJBNTfBFd1u8TBsD4ZwxRMC",
+      "/dns4/bria-indexer/tcp/3003/p2p/12D3KooWBYVX8aSiS8butwauzJvg5Ka8J339PHkn3WjhLZJAdDM8",
+      "/dns4/cora-indexer/tcp/3003/p2p/12D3KooWEkZMB3XQTDYgAxhMd9jfZhfD9zHjKPTyyi6jzM5u7bgv"
     ]
   }
 }


### PR DESCRIPTION
**Not needed if a second assigner #1877 is preferred.**

This configures the existing assigner to assign to only the new indexers.

Notice that the old indexers are still set as peers to assigner. This ensures that rebublisher direct announcements are sent to them.
