### PR TITLE
Bump `alva` DHStore batch size by 4X

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/alva/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/alva/config.json
@@ -58,7 +58,7 @@
     "ShutdownTimeout": "15m",
     "ValueStoreDir": "",
     "ValueStoreType": "none",
-    "DHBatchSize": 4096,
+    "DHBatchSize": 16384,
     "DHStoreURL": "http://dhstore-stateless:40080",
     "DHStoreHttpClientTimeout": "30s"
   },


### PR DESCRIPTION
Increase write batch size on `alva` to experiment with ingest throughput on `dev`.
