### PR TITLE
Bump DHStore batch size by 4X on remaining `dev` nodes

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/bria/config.json
@@ -58,7 +58,7 @@
     "ShutdownTimeout": "15m",
     "ValueStoreDir": "",
     "ValueStoreType": "none",
-    "DHBatchSize": 4096,
+    "DHBatchSize": 16384,
     "DHStoreURL": "http://dhstore-stateless:40080",
     "DHStoreHttpClientTimeout": "30s"
   },

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/cora/config.json
@@ -58,7 +58,7 @@
     "ShutdownTimeout": "15m",
     "ValueStoreDir": "",
     "ValueStoreType": "none",
-    "DHBatchSize": 4096,
+    "DHBatchSize": 16384,
     "DHStoreURL": "http://dhstore-stateless:40080",
     "DHStoreHttpClientTimeout": "30s"
   },


### PR DESCRIPTION
Tests on `alva` show significant increase in ingest throughput. Bump batch size on remaining nodes.

