### PR TITLE
Explicitly set dhstore stateless resources in `dev`

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-stateless/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-stateless/deployment.yaml
@@ -15,6 +15,13 @@ spec:
             - '--storeType=fdb'
             - '--fdbClusterFile=/config/cluster-file'
             - '--fdbApiVersion=710'
+          resources:
+            limits:
+              cpu: "1.5"
+              memory: 3Gi
+            requests:
+              cpu: "1.5"
+              memory: 3Gi
           volumeMounts:
             - mountPath: /config
               name: config


### PR DESCRIPTION
In order to have a deterministic and isolated performance analysis explicitly set the resources for `dhstore-stateless` instances. This would make it easier to reason about potential bottlenecks or their absence in the ingest pipeline, since pods would be given the same resources on every deployment and cannot outgrow the limit specified.
