### PR TITLE
Increase `CPU` for `dhstore-stateless` instances

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-stateless/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-stateless/deployment.yaml
@@ -17,10 +17,10 @@ spec:
             - '--fdbApiVersion=710'
           resources:
             limits:
-              cpu: "1.5"
+              cpu: "3"
               memory: 3Gi
             requests:
-              cpu: "1.5"
+              cpu: "3"
               memory: 3Gi
           volumeMounts:
             - mountPath: /config


### PR DESCRIPTION
They are at 100% utilisation.

