### PR TITLE
Increase FDB storage processes per pod to 5

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: fdb-dev-cluster
 spec:
   version: 7.1.33
-  storageServersPerPod: 3
+  storageServersPerPod: 5
   automationOptions:
     replacements:
       enabled: true


### PR DESCRIPTION
Disk IOPS offered by EBS volume is not being fully utilised. Increase the number of storage processes per pod to see the impact on write throughput.
