### PR TITLE
Deploy the latest version of cassette in prod

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/cassette/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/cassette/kustomization.yaml
@@ -34,4 +34,4 @@ replicas:
 images:
   - name: cassette
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/cassette
-    newTag: 20230427143618-4cac2bcb0a24ad458629d91be75fb2437223c625
+    newTag: 20230531122710-b5b419bed2a7e2cbbc2c1d5ebc0d5b936374eb67


### PR DESCRIPTION
This version has the latest boxo dependency which is the same version as Kubo `0.20.0`.

