### PR TITLE
Deploy FDB controller manager in `prod`

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-manager/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-manager/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - ../../../../../base/foundationdb/namespaced-manager
+  - pod-monitor.yaml

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-manager/pod-monitor.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-manager/pod-monitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: fdb-kubernetes-operator-controller-manager
+  labels:
+    app: fdb-kubernetes-operator-controller-manager
+spec:
+  selector:
+    matchLabels:
+      app: fdb-kubernetes-operator-controller-manager
+  namespaceSelector:
+    matchNames:
+      - storetheindex
+  podMetricsEndpoints:
+    - path: /metrics
+      port: metrics

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
 - dhfind-helga
 - dhfind-porvy
 - cassette
+- fdb-manager
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}


### PR DESCRIPTION
Deploy FDB controller manager in `prod` in prep for cluster deployment.

