### PR TITLE
Increase PVC of `inga` to 1Ti

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/pvc_data.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/pvc_data.yaml
@@ -11,5 +11,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 160Gi
+      storage: 1Ti
   storageClassName: gp3


### PR DESCRIPTION
That node uses `dhstore` for storage. It is unclear why it's utilising so much disk for provider info. Further investigation needed. For now increase PVC volume to avoid alerts.
