### PR TITLE
Deploy `r6a.2xl` worker node group on `prod` cluster

### DIFF
--- a/deploy/infrastructure/prod/us-east-2/eks.tf
+++ b/deploy/infrastructure/prod/us-east-2/eks.tf
@@ -131,6 +131,27 @@ module "eks" {
         }
       }
     }
+    prod-ue2a-r6a-2xl = {
+      min_size       = 0
+      max_size       = 10
+      desired_size   = 0
+      instance_types = ["r6a.2xlarge"]
+      subnet_ids     = [data.aws_subnet.ue2a1.id,data.aws_subnet.ue2a2.id, data.aws_subnet.ue2a3.id]
+    }
+    prod-ue2b-r6a-2xl = {
+      min_size       = 0
+      max_size       = 10
+      desired_size   = 0
+      instance_types = ["r6a.2xlarge"]
+      subnet_ids     = [data.aws_subnet.ue2b1.id,data.aws_subnet.ue2b2.id, data.aws_subnet.ue2b3.id]
+    }
+    prod-ue2c-r6a-2xl = {
+      min_size       = 0
+      max_size       = 10
+      desired_size   = 0
+      instance_types = ["r6a.2xlarge"]
+      subnet_ids     = [data.aws_subnet.ue2c1.id,data.aws_subnet.ue2c2.id, data.aws_subnet.ue2c3.id]
+    }
   }
 }
 

--- a/deploy/manifests/prod/us-east-2/cluster/kube-system/aws-auth.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/kube-system/aws-auth.yaml
@@ -70,6 +70,21 @@ data:
       - system:nodes
       rolearn: arn:aws:iam::407967248065:role/prod-ue2c-r6a-xl-eks-node-group
       username: system:node:{{EC2PrivateDNSName}}
+    - groups:
+      - system:bootstrappers
+      - system:nodes
+      rolearn: arn:aws:iam::407967248065:role/prod-ue2a-r6a-2xl-eks-node-group
+      username: system:node:{{EC2PrivateDNSName}}
+    - groups:
+      - system:bootstrappers
+      - system:nodes
+      rolearn: arn:aws:iam::407967248065:role/prod-ue2a-r6b-2xl-eks-node-group
+      username: system:node:{{EC2PrivateDNSName}}
+    - groups:
+      - system:bootstrappers
+      - system:nodes
+      rolearn: arn:aws:iam::407967248065:role/prod-ue2a-r6c-2xl-eks-node-group
+      username: system:node:{{EC2PrivateDNSName}}
   mapUsers: |
     - userarn: arn:aws:iam::407967248065:user/masih
       username: masih


### PR DESCRIPTION
These are the instance types that will be used by the new indexers pointed to FDB backed dhstores.

Relates to:
 - https://github.com/ipni/storetheindex/pull/1906
