### PR TITLE
Disconnect dido and kepa from reads in prod

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -17,6 +17,7 @@ spec:
             # Use service names local to the namespace over HTTP to avoid
             # TLS handshake overhead.
             - '--backends=http://oden-indexer:3000/'
+            - '--backends=http://inga-indexer:3000/'
             - '--backends=http://dhfind.internal.prod.cid.contact/'
             - '--backends=http://dhfind-helga.internal.prod.cid.contact/'
             - '--backends=http://dhfind-porvy.internal.prod.cid.contact/'

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -16,8 +16,6 @@ spec:
             - '--translateNonStreaming'
             # Use service names local to the namespace over HTTP to avoid
             # TLS handshake overhead.
-            - '--backends=http://dido-indexer:3000/'
-            - '--backends=http://kepa-indexer:3000/'
             - '--backends=http://oden-indexer:3000/'
             - '--backends=http://dhfind.internal.prod.cid.contact/'
             - '--backends=http://dhfind-helga.internal.prod.cid.contact/'


### PR DESCRIPTION
Leaving oden connected until inga catches up with dag.house. The [provider](https://inga.prod.cid.contact/providers/QmQzqxhK82kAmKvARFZSkUVS6fo9sySaiogAnx5EnZ6ZmC) to watch. 

Also connect inga to not to break `providers` endpoint.