### PR TITLE
Bump up number of inga's threads

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
@@ -82,7 +82,7 @@
     "HttpSyncRetryWaitMax": "30s",
     "HttpSyncRetryWaitMin": "1s",
     "HttpSyncTimeout": "10s",
-    "IngestWorkerCount": 3,
+    "IngestWorkerCount": 8,
     "PubSubTopic": "/indexer/ingest/mainnet",
     "ResendDirectAnnounce": false,
     "StoreBatchSize": 8192,


### PR DESCRIPTION
Inga has caught up with the most of providers. There are a few big providers left (like dag.house) that inga is still crunching through. That blocks all worker-goroutines so that they can not ingest anything from the new providers that are coming in.
