### PR TITLE
Investigate effect of cancelling `WANT`s in `cassette` more aggressively

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/cassette/config.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/cassette/config.yaml
@@ -39,3 +39,4 @@ bitswap:
   fallbackOnWantBlock: true
   recipientsRefreshInterval: 10s
   sendChannelBuffer: 100
+  broadcastCancelAfter: 2s


### PR DESCRIPTION
Using default cancel interval of 5s stalls after 10 minutes. Reduce cancellation interval to 2 seconds in prod in order to investigate impact of providers stalling.

Relates to:
 - https://github.com/ipni/cassette/pull/30

