### PR TITLE
Change dev assigner service hostname

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/assigner/service-external.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/assigner/service-external.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-type: nlb
     service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
-    external-dns.alpha.kubernetes.io/hostname: assigner.dev.cid.contact
+    external-dns.alpha.kubernetes.io/hostname: assigner-peer.dev.cid.contact
 spec:
   ports:
     - name: libp2p

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/assigner/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/assigner/config.json
@@ -71,7 +71,7 @@
   },
   "Peering": {
     "Peers": [
-      "/dns4/assigner.dev.cid.contact/tcp/3003/p2p/12D3KooWDBjcDRQ7CKJeF9Yy3UKbriHfyETDrXKzTDB6biH3ibBd",
+      "/dns4/assigner-peer.dev.cid.contact/tcp/3003/p2p/12D3KooWDBjcDRQ7CKJeF9Yy3UKbriHfyETDrXKzTDB6biH3ibBd",
       "/dns4/dido-indexer/tcp/3003/p2p/12D3KooWBHY2dGH8ngC6LjCiMC7JuRQf3DEb3Nk8neuntAGirb89",
       "/dns4/kepa-indexer/tcp/3003/p2p/12D3KooWJMn6BzkMixb2w8hR83Jpvugbqw3pBXwHqmbiFxh7nHz3",
       "/dns4/oden-indexer/tcp/3003/p2p/12D3KooWGxW4Bqhc3aVjkDiUU7B3FmNC72v2D9eq1LB6aVHRHNTH"


### PR DESCRIPTION
Libp2p server is not exposed because the subdomain [assigner.dev](http://assigner.dev/).cid.contact is already in use by ingress for taking in direct announces via HTTP PUT.

The assigner has two different services (HTTP ingest and libp2p). They are handled with two different instances. One uses nginx which handles http, the other uses nlb directly to service. Those two create their own load balancer in aws. Therefore cannot use the same name server record.

This PR gives a new subdomain for the libp2p assigner service, i.e. change the annotation.