### PR TITLE
Move inga to the same instance type as other indexer nodes in prod

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/deployment.yaml
@@ -27,7 +27,7 @@ spec:
                   - key: node.kubernetes.io/instance-type
                     operator: In
                     values:
-                      - r6a.xlarge
+                      - c6a.8xlarge
                   - key: topology.kubernetes.io/zone
                     operator: In
                     values:


### PR DESCRIPTION
Inga is failing to schedule in prod. Moving it to the same instance type as other indexer nodes have. 