### PR TITLE
Deploy latest to `cassette`

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/cassette/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/cassette/kustomization.yaml
@@ -30,4 +30,4 @@ configMapGenerator:
 images:
   - name: cassette
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/cassette
-    newTag: 20230611102024-408d38b0b68f7c67fb63d84eba1e73192a1b1b15
+    newTag: 20230611103608-58dc6312994689faa1c4fbf9d673d0b716d0394f

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/cassette/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/cassette/kustomization.yaml
@@ -34,4 +34,4 @@ replicas:
 images:
   - name: cassette
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/cassette
-    newTag: 20230611102024-408d38b0b68f7c67fb63d84eba1e73192a1b1b15
+    newTag: 20230611103608-58dc6312994689faa1c4fbf9d673d0b716d0394f


### PR DESCRIPTION
Deploy latest to cassette which removes the receiver buffer size.
