### PR TITLE
Increase max r6a.xlarge instances to 5 in prod

### DIFF
--- a/deploy/infrastructure/prod/us-east-2/eks.tf
+++ b/deploy/infrastructure/prod/us-east-2/eks.tf
@@ -60,7 +60,7 @@ module "eks" {
     # Node group for running double hashed indexer nodes
     prod-ue2c-r6a-xl = {
       min_size       = 0
-      max_size       = 3
+      max_size       = 5
       desired_size   = 1
       instance_types = ["r6a.xlarge"]
       subnet_ids     = [data.aws_subnet.ue2c2.id, data.aws_subnet.ue2c3.id]


### PR DESCRIPTION
We ran out of this instance type with three new FDB indexers in place.
