### PR TITLE
Increase number of CPUs on inga

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/deployment.yaml
@@ -14,10 +14,10 @@ spec:
               mountPath: /data
           resources:
             limits:
-              cpu: "3"
+              cpu: "10"
               memory: 28Gi
             requests:
-              cpu: "3"
+              cpu: "10"
               memory: 28Gi
       affinity:
         nodeAffinity:


### PR DESCRIPTION
Inga has higher concurrency factor now and has been running at 100% CPU lately that has been failing readiness probes. 