### PR TITLE
Remove redundant users from K8S

### DIFF
--- a/deploy/manifests/dev/us-east-2/cluster/kube-system/aws-auth.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kube-system/aws-auth.yaml
@@ -69,10 +69,6 @@ data:
       username: masih
       groups:
         - system:masters
-    - userarn: arn:aws:iam::407967248065:user/marco
-      username: marco
-      groups:
-        - system:masters
     - userarn: arn:aws:iam::407967248065:user/gammazero
       username: gammazero
       groups:
@@ -83,14 +79,6 @@ data:
         - system:masters
     - userarn: arn:aws:iam::407967248065:user/kylehuntsman
       username: kylehuntsman
-      groups:
-        - system:masters
-    - userarn: arn:aws:iam::407967248065:user/steveFraser
-      username: steveFraser
-      groups:
-        - system:masters
-    - userarn: arn:aws:iam::407967248065:user/cmharden
-      username: cmharden
       groups:
         - system:masters
     - userarn: arn:aws:iam::407967248065:user/hannahhoward

--- a/deploy/manifests/prod/us-east-2/cluster/kube-system/aws-auth.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/kube-system/aws-auth.yaml
@@ -95,10 +95,6 @@ data:
       username: masih
       groups:
         - system:masters
-    - userarn: arn:aws:iam::407967248065:user/marco
-      username: marco
-      groups:
-        - system:masters
     - userarn: arn:aws:iam::407967248065:user/gammazero
       username: gammazero
       groups:
@@ -109,14 +105,6 @@ data:
         - system:masters
     - userarn: arn:aws:iam::407967248065:user/kylehuntsman
       username: kylehuntsman
-      groups:
-        - system:masters
-    - userarn: arn:aws:iam::407967248065:user/steveFraser
-      username: steveFraser
-      groups:
-        - system:masters
-    - userarn: arn:aws:iam::407967248065:user/cmharden
-      username: cmharden
       groups:
         - system:masters
     - userarn: arn:aws:iam::407967248065:user/mayank.pandey


### PR DESCRIPTION
Clean up non existing users from K8S `aws-auth` configmap on both `dev` and `prod`.

