### PR TITLE
Deploy FDB and stateless dhstore on `prod`

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-stateless/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-stateless/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dhstore
+spec:
+  template:
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+      containers:
+        - name: dhstore
+          args:
+            - '--storeType=fdb'
+            - '--fdbClusterFile=/config/cluster-file'
+            - '--fdbApiVersion=710'
+          resources:
+            limits:
+              cpu: "3"
+              memory: 3Gi
+            requests:
+              cpu: "3"
+              memory: 3Gi
+          volumeMounts:
+            - mountPath: /config
+              name: config
+      volumes:
+        - name: config
+          configMap:
+            name: fdb-dev-cluster-config

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-stateless/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-stateless/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+nameSuffix: -stateless
+
+commonLabels:
+  name: dhstore-stateless
+
+resources:
+  - github.com/ipni/dhstore/deploy/kubernetes?ref=9939a3a8804356e6f5f18198dcfa8d75786f6223
+  - pod-monitor.yaml
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+replicas:
+  - name: dhstore
+    count: 3
+
+images:
+  - name: dhstore
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
+    newTag: 20230526214130-9939a3a8804356e6f5f18198dcfa8d75786f6223

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-stateless/pod-monitor.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-stateless/pod-monitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: dhstore-stateless
+  labels:
+    app: dhstore
+    name: dhstore-stateless
+spec:
+  selector:
+    matchLabels:
+      app: dhstore
+      name: dhstore-stateless
+  namespaceSelector:
+    matchNames:
+      - storetheindex
+  podMetricsEndpoints:
+    - path: /metrics
+      port: metrics

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps.foundationdb.org/v1beta2
+kind: FoundationDBCluster
+metadata:
+  name: fdb-prod-cluster
+spec:
+  version: 7.1.33
+  storageServersPerPod: 3
+  automationOptions:
+    replacements:
+      enabled: true
+  faultDomain:
+    key: kubernetes.io/hostname
+    valueFrom: spec.nodeName
+  databaseConfiguration:
+    storage_engine: ssd-rocksdb-v1
+  processCounts:
+    storage: 5
+    log: 2
+    stateless: 2
+  labels:
+    matchLabels:
+      foundationdb.org/fdb-cluster-name: fdb-prod-cluster
+    processClassLabels:
+      - foundationdb.org/fdb-process-class
+    processGroupIDLabels:
+      - foundationdb.org/fdb-process-group-id
+  minimumUptimeSecondsForBounce: 60
+  processes:
+    general:
+      customParameters:
+        - memory=20GiB
+        - cache-memory=12GiB
+        - knob_storage_hard_limit_bytes=10GiB
+        - knob_target_bytes_per_storage_server=9GiB
+      podTemplate:
+        spec:
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: topology.kubernetes.io/zone
+              whenUnsatisfiable: ScheduleAnyway
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: node.kubernetes.io/instance-type
+                        operator: In
+                        values:
+                          # 32 CPU, 64GiB memory
+                          - c6a.8xlarge
+          containers:
+            - name: foundationdb
+              resources:
+                requests:
+                  cpu: 30
+                  memory: 60.5Gi
+              securityContext:
+                runAsUser: 0
+      volumeClaimTemplate:
+        spec:
+          storageClassName: gp3-iops16k-t1000
+          resources:
+            requests:
+              storage: 16Ti
+  sidecarContainer:
+    enableReadinessProbe: false
+    enableLivenessProbe: true
+  routing:
+    useDNSInClusterFile: true
+  replaceInstancesWhenResourcesChange:  true

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - cluster.yaml

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -18,6 +18,8 @@ resources:
 - dhfind-porvy
 - cassette
 - fdb-manager
+- dhstore-stateless
+- fdb-cluster
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}


### PR DESCRIPTION
Set up FDB cluster and dhstore on prod. Use 5 storage servers with increased rate keeper limits tuned for write-heavy workload.

