### PR TITLE
Reduce FDB memory demand to fit allocatable memory in `c6a.8xl`

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
@@ -53,7 +53,7 @@ spec:
               resources:
                 requests:
                   cpu: 30
-                  memory: 60.5Gi
+                  memory: 59Gi
               securityContext:
                 runAsUser: 0
       volumeClaimTemplate:


### PR DESCRIPTION
The allocatable memory left on `c6a8xl` nodes is just over 60Gi after daemonsets run.

Reduce the demand slightly so that it fits on the nodes.
