### PR TITLE
Fix type in prod stateless dhstore deployment

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-stateless/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-stateless/deployment.yaml
@@ -28,4 +28,4 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: fdb-dev-cluster-config
+            name: fdb-prod-cluster-config


### PR DESCRIPTION
Wrong configmap name for FDB cluster file.
