### PR TITLE
Remove FDB ratekeeper memory limits

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
@@ -30,8 +30,6 @@ spec:
       customParameters:
         - memory=20GiB
         - cache-memory=12GiB
-        - knob_storage_hard_limit_bytes=10GiB
-        - knob_target_bytes_per_storage_server=9GiB
       podTemplate:
         spec:
           topologySpreadConstraints:


### PR DESCRIPTION
Altering knobs here requires tuning of other knobs to make sure storage server MVCC memory is not limiting performance.

For now remove them.

