### PR TITLE
Give prod dhstore more RAM

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/deployment.yaml
@@ -21,10 +21,10 @@ spec:
           resources:
             limits:
               cpu: "5"
-              memory: 16Gi
+              memory: 32Gi
             requests:
               cpu: "5"
-              memory: 16Gi
+              memory: 32Gi
           ports:
             - containerPort: 40081
               name: metrics


### PR DESCRIPTION
Increasing CPU have improved the latencies however they are still behind the other instances
