### PR TITLE
Override `app` label in dhstore stateless to restrict service selectors

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-stateless/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-stateless/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 nameSuffix: -stateless
 
 commonLabels:
-  name: dhstore-stateless
+  app: dhstore-stateless
 
 resources:
   - github.com/ipni/dhstore/deploy/kubernetes?ref=9939a3a8804356e6f5f18198dcfa8d75786f6223

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-stateless/pod-monitor.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-stateless/pod-monitor.yaml
@@ -3,13 +3,11 @@ kind: PodMonitor
 metadata:
   name: dhstore-stateless
   labels:
-    app: dhstore
-    name: dhstore-stateless
+    app: dhstore-stateless
 spec:
   selector:
     matchLabels:
-      app: dhstore
-      name: dhstore-stateless
+      app: dhstore-stateless
   namespaceSelector:
     matchNames:
       - storetheindex

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-stateless/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-stateless/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 nameSuffix: -stateless
 
 commonLabels:
-  name: dhstore-stateless
+  app: dhstore-stateless
 
 resources:
   - github.com/ipni/dhstore/deploy/kubernetes?ref=9939a3a8804356e6f5f18198dcfa8d75786f6223

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-stateless/pod-monitor.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-stateless/pod-monitor.yaml
@@ -3,13 +3,11 @@ kind: PodMonitor
 metadata:
   name: dhstore-stateless
   labels:
-    app: dhstore
-    name: dhstore-stateless
+    app: dhstore-stateless
 spec:
   selector:
     matchLabels:
-      app: dhstore
-      name: dhstore-stateless
+      app: dhstore-stateless
   namespaceSelector:
     matchNames:
       - storetheindex


### PR DESCRIPTION
Do not reuse `app=dhstore` label in stateless instances to avoid other services selecting stateless instances and routing traffic to them.
