### PR TITLE
Deploy caching in cassette

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/cassette/config.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/cassette/config.yaml
@@ -39,3 +39,6 @@ bitswap:
   fallbackOnWantBlock: true
   recipientsRefreshInterval: 10s
   sendChannelBuffer: 100
+cache:
+  expiry: 12h
+  size: 10000

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/cassette/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/cassette/kustomization.yaml
@@ -30,4 +30,4 @@ configMapGenerator:
 images:
   - name: cassette
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/cassette
-    newTag: 20230611103608-58dc6312994689faa1c4fbf9d673d0b716d0394f
+    newTag: 20230613135826-0b883bbb58e89b390afa2e5dab26f48efc17cbf3

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/cassette/config.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/cassette/config.yaml
@@ -40,3 +40,6 @@ bitswap:
   recipientsRefreshInterval: 10s
   sendChannelBuffer: 100
   broadcastCancelAfter: 2s
+cache:
+  expiry: 24h
+  size: 1000000

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/cassette/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/cassette/deployment.yaml
@@ -24,10 +24,10 @@ spec:
           resources:
             limits:
               cpu: "3"
-              memory: 5Gi
+              memory: 8Gi
             requests:
               cpu: "3"
-              memory: 5Gi
+              memory: 8Gi
       volumes:
         - name: identity
           secret:

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/cassette/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/cassette/kustomization.yaml
@@ -34,4 +34,4 @@ replicas:
 images:
   - name: cassette
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/cassette
-    newTag: 20230611103608-58dc6312994689faa1c4fbf9d673d0b716d0394f
+    newTag: 20230613135826-0b883bbb58e89b390afa2e5dab26f48efc17cbf3


### PR DESCRIPTION
Set cache expiry to 24 hours with cache size of 1M. The caching memory footprint is unclear just now. Further experimentation is needed to right-size the instance relative to cache size.

Use a reduced cache expiry and size for `dev` environment.

See:
 - https://github.com/ipni/cassette/pull/38
