### PR TITLE
Deploy the latest indexstar to prod

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -16,10 +16,17 @@ spec:
             - '--translateNonStreaming'
             # Use service names local to the namespace over HTTP to avoid
             # TLS handshake overhead.
-            - '--backends=http://inga-indexer:3000/'
+            - '--providersBackends=http://inga-indexer:3000/'
+            # Keeping old indexers connected as providers backends for redundancy
+            - '--providersBackends=http://oden-indexer:3000/'
+            - '--providersBackends=http://kepa-indexer:3000/'
+            - '--providersBackends=http://dido-indexer:3000/'
             - '--backends=http://dhfind.internal.prod.cid.contact/'
             - '--backends=http://dhfind-helga.internal.prod.cid.contact/'
             - '--backends=http://dhfind-porvy.internal.prod.cid.contact/'
+            - '--dhBackends=http://dhstore.internal.prod.cid.contact/'
+            - '--dhBackends=http://dhstore-helga.internal.prod.cid.contact/'
+            - '--dhBackends=http://dhstore-porvy.internal.prod.cid.contact/'
             - '--cascadeBackends=http://caskadht.internal.prod.cid.contact/'
             - '--cascadeBackends=http://cassette.internal.prod.cid.contact/'
             - '--fallbackBackend=http://dido-indexer:3000/'

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
@@ -18,4 +18,4 @@ replicas:
 images:
   - name: indexstar
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/indexstar/indexstar
-    newTag: 20230522125314-98f3dabfa61e0f42ec4d20b439fa118b7536935d
+    newTag: 20230613141317-5952e8ecfb34c27e6e98d00e3e220144c95b8ca7


### PR DESCRIPTION
* Deploy the latest indexstar to prod
* The latest indexstar supports separate backend types for provider, regular and double hashed lookups