### PR TITLE
Deploy latest to cassette with option to not cache 404s

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/cassette/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/cassette/kustomization.yaml
@@ -30,4 +30,4 @@ configMapGenerator:
 images:
   - name: cassette
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/cassette
-    newTag: 20230613135826-0b883bbb58e89b390afa2e5dab26f48efc17cbf3
+    newTag: 20230613173013-4da1fda20a33cb42ebf6ab0cbef98dcdf2418e10

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/cassette/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/cassette/kustomization.yaml
@@ -34,4 +34,4 @@ replicas:
 images:
   - name: cassette
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/cassette
-    newTag: 20230613135826-0b883bbb58e89b390afa2e5dab26f48efc17cbf3
+    newTag: 20230613173013-4da1fda20a33cb42ebf6ab0cbef98dcdf2418e10


### PR DESCRIPTION
Success rate since adding the caching is reduced by 30%. Investigate what causes this by disabling 404 caching.
