### PR TITLE
Add `oden` as indexstar backend in prod due to high 404 rate

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -24,6 +24,7 @@ spec:
             - '--backends=http://dhfind.internal.prod.cid.contact/'
             - '--backends=http://dhfind-helga.internal.prod.cid.contact/'
             - '--backends=http://dhfind-porvy.internal.prod.cid.contact/'
+            - '--backends=http://oden-indexer:3000/'
             - '--dhBackends=http://dhstore.internal.prod.cid.contact/'
             - '--dhBackends=http://dhstore-helga.internal.prod.cid.contact/'
             - '--dhBackends=http://dhstore-porvy.internal.prod.cid.contact/'


### PR DESCRIPTION
Since excluding oden from the backends the rate of 404s returned by indexstar in prod is higher than 200s.

Add it back in to investigate the effect.

Reverts: https://github.com/ipni/storetheindex/pull/1958

