### PR TITLE
Scale up dhstore stateless in prod to 5 replicas

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-stateless/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-stateless/kustomization.yaml
@@ -15,7 +15,7 @@ patchesStrategicMerge:
 
 replicas:
   - name: dhstore
-    count: 3
+    count: 5
 
 images:
   - name: dhstore


### PR DESCRIPTION
This is to cope with read and write traffic now that they are added to read path.

