### PR TITLE
Increase `cassette` memory limit to 10Gi on prod

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/cassette/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/cassette/deployment.yaml
@@ -24,10 +24,10 @@ spec:
           resources:
             limits:
               cpu: "3"
-              memory: 8Gi
+              memory: 10Gi
             requests:
               cpu: "3"
-              memory: 8Gi
+              memory: 10Gi
       volumes:
         - name: identity
           secret:


### PR DESCRIPTION
It's at 95% utilisation.
