### PR TITLE
Update core and has dhstore as a valuestore

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -111,7 +111,7 @@ func initAction(cctx *cli.Context) error {
 	switch storeType {
 	case "":
 		// Use config default
-	case vstoreMemory, vstorePebble:
+	case vstoreDHStore, vstoreMemory, vstorePebble:
 		// These are good
 		cfg.Indexer.ValueStoreType = storeType
 	default:

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/ipld/go-ipld-adl-hamt v0.0.0-20220616142416-9004dbd839e0
 	github.com/ipld/go-ipld-prime v0.20.0
 	github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd
-	github.com/ipni/go-indexer-core v0.7.12-0.20230616083702-8375fb1b74f7
+	github.com/ipni/go-indexer-core v0.8.0
 	github.com/ipni/go-libipni v0.2.2
 	github.com/libp2p/go-libp2p v0.28.0
 	github.com/libp2p/go-msgio v0.3.0

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/ipld/go-ipld-adl-hamt v0.0.0-20220616142416-9004dbd839e0
 	github.com/ipld/go-ipld-prime v0.20.0
 	github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd
-	github.com/ipni/go-indexer-core v0.7.11
+	github.com/ipni/go-indexer-core v0.7.12-0.20230616083702-8375fb1b74f7
 	github.com/ipni/go-libipni v0.2.2
 	github.com/libp2p/go-libp2p v0.28.0
 	github.com/libp2p/go-msgio v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -597,8 +597,8 @@ github.com/ipld/go-ipld-prime v0.20.0/go.mod h1:PzqZ/ZR981eKbgdr3y2DJYeD/8bgMawd
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20230102063945-1a409dc236dd h1:gMlw/MhNr2Wtp5RwGdsW23cs+yCuj9k2ON7i9MiJlRo=
 github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd h1:qdjo1CRvAQhOMoyYjPnbdZ5rYFFmqztweQ9KAsuWpO0=
 github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd/go.mod h1:9DD/GM0JNPoisgR09F62kbBi7kHa4eDIea4XshXYOVc=
-github.com/ipni/go-indexer-core v0.7.12-0.20230616083702-8375fb1b74f7 h1:DtanXQ7PnbY3i9kkjXhFimdAfHfBT6bmwVRG+aQysfU=
-github.com/ipni/go-indexer-core v0.7.12-0.20230616083702-8375fb1b74f7/go.mod h1:Y9su+no9k6y+jnQRERP/CKJewdISHzzl+n91GA+y4Ao=
+github.com/ipni/go-indexer-core v0.8.0 h1:HPFMngR47FL49mVnOZBrcxJoRODjIadlP+UYMRboNKA=
+github.com/ipni/go-indexer-core v0.8.0/go.mod h1:Y9su+no9k6y+jnQRERP/CKJewdISHzzl+n91GA+y4Ao=
 github.com/ipni/go-libipni v0.2.2 h1:pP0UTEz0VNRfClsy4h2Rk0pDhkj6FAI1MHWSGMlBN3Q=
 github.com/ipni/go-libipni v0.2.2/go.mod h1:jJd9baZTFVfiLz9H3+qM39NLpUu88VlgdSQZ9sbYrv0=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=

--- a/go.sum
+++ b/go.sum
@@ -597,8 +597,8 @@ github.com/ipld/go-ipld-prime v0.20.0/go.mod h1:PzqZ/ZR981eKbgdr3y2DJYeD/8bgMawd
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20230102063945-1a409dc236dd h1:gMlw/MhNr2Wtp5RwGdsW23cs+yCuj9k2ON7i9MiJlRo=
 github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd h1:qdjo1CRvAQhOMoyYjPnbdZ5rYFFmqztweQ9KAsuWpO0=
 github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd/go.mod h1:9DD/GM0JNPoisgR09F62kbBi7kHa4eDIea4XshXYOVc=
-github.com/ipni/go-indexer-core v0.7.11 h1:3WVj4ttfZ1ZsNA2wsUgT1i97G2pcerAQp8Ytvy5J36s=
-github.com/ipni/go-indexer-core v0.7.11/go.mod h1:Y9su+no9k6y+jnQRERP/CKJewdISHzzl+n91GA+y4Ao=
+github.com/ipni/go-indexer-core v0.7.12-0.20230616083702-8375fb1b74f7 h1:DtanXQ7PnbY3i9kkjXhFimdAfHfBT6bmwVRG+aQysfU=
+github.com/ipni/go-indexer-core v0.7.12-0.20230616083702-8375fb1b74f7/go.mod h1:Y9su+no9k6y+jnQRERP/CKJewdISHzzl+n91GA+y4Ao=
 github.com/ipni/go-libipni v0.2.2 h1:pP0UTEz0VNRfClsy4h2Rk0pDhkj6FAI1MHWSGMlBN3Q=
 github.com/ipni/go-libipni v0.2.2/go.mod h1:jJd9baZTFVfiLz9H3+qM39NLpUu88VlgdSQZ9sbYrv0=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -1753,7 +1753,7 @@ func TestGetEntryDataFromCar(t *testing.T) {
 
 // Make new indexer engine
 func mkIndexer(t *testing.T, withCache bool) *engine.Engine {
-	return engine.New(nil, memory.New())
+	return engine.New(memory.New())
 }
 
 func mkRegistry(t *testing.T) *registry.Registry {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -917,6 +917,10 @@ func (r *Registry) Handoff(ctx context.Context, publisherID, frozenID peer.ID, f
 // ImportProviders reads providers from another indexer and registers any that
 // are not already registered. Returns the count of newly registered providers.
 func (r *Registry) ImportProviders(ctx context.Context, fromURL *url.URL) (int, error) {
+	if r.assigned != nil {
+		return 0, errors.New("feature not available when using assigner")
+	}
+
 	cl, err := findclient.New(fromURL.String())
 	if err != nil {
 		return 0, err

--- a/server/admin/server_test.go
+++ b/server/admin/server_test.go
@@ -295,7 +295,7 @@ func initRegistry(t *testing.T, trustedID string) *registry.Registry {
 }
 
 func initIndex(t *testing.T, withCache bool) indexer.Interface {
-	return engine.New(nil, memory.New())
+	return engine.New(memory.New())
 }
 
 func initIngest(t *testing.T, indx indexer.Interface, reg *registry.Registry) *ingest.Ingester {

--- a/server/find/protocol_test.go
+++ b/server/find/protocol_test.go
@@ -253,7 +253,7 @@ func TestRemoveProvider(t *testing.T) {
 
 // InitIndex initialize a new indexer engine.
 func initIndex(t *testing.T, withCache bool) indexer.Interface {
-	return engine.New(nil, memory.New())
+	return engine.New(memory.New())
 }
 
 // InitPebbleIndex initialize a new indexer engine using pebbel with cache.
@@ -261,9 +261,9 @@ func initPebbleIndex(t *testing.T, withCache bool) indexer.Interface {
 	valueStore, err := pebble.New(t.TempDir(), nil)
 	require.NoError(t, err)
 	if withCache {
-		return engine.New(radixcache.New(1000), valueStore)
+		return engine.New(valueStore, engine.WithCache(radixcache.New(1000)))
 	}
-	return engine.New(nil, valueStore)
+	return engine.New(valueStore)
 }
 
 func initRegistry(t *testing.T) *registry.Registry {

--- a/server/ingest/protocol_test.go
+++ b/server/ingest/protocol_test.go
@@ -111,7 +111,7 @@ func TestAnnounce(t *testing.T) {
 
 // initIndex initialize a new indexer engine.
 func initIndex(t *testing.T, withCache bool) indexer.Interface {
-	return engine.New(nil, memory.New())
+	return engine.New(memory.New())
 }
 
 // initRegistry initializes a new registry


### PR DESCRIPTION
## Context
The new core has dhstore as a valuestore implementation, and not as an option to the engine.

## Proposed Changes
- Use latest core with dhstore valuestore instance.
- Make value store required.
- If valuestore is "" or "none", and DHStoreURL is configured, then use dhstore as valuestore. This makes upgrade compatible with previous configs.

## Tests
- Update e2e test to have 1st indexer write to pebble and 2nd write to dhstore.

## Revert Strategy
Change is safe to revert.
