### PR TITLE
Increase worker counts to 100 on prod indexer nodes

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/arya/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/arya/config.json
@@ -80,7 +80,7 @@
     "HttpSyncRetryWaitMax": "30s",
     "HttpSyncRetryWaitMin": "1s",
     "HttpSyncTimeout": "10s",
-    "IngestWorkerCount":24,
+    "IngestWorkerCount": 100,
     "PubSubTopic": "/indexer/ingest/mainnet",
     "ResendDirectAnnounce": false,
     "StoreBatchSize": 8192,

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/bala/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/bala/config.json
@@ -80,7 +80,7 @@
     "HttpSyncRetryWaitMax": "30s",
     "HttpSyncRetryWaitMin": "1s",
     "HttpSyncTimeout": "10s",
-    "IngestWorkerCount":24,
+    "IngestWorkerCount": 100,
     "PubSubTopic": "/indexer/ingest/mainnet",
     "ResendDirectAnnounce": false,
     "StoreBatchSize": 8192,

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/cera/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/cera/config.json
@@ -80,7 +80,7 @@
     "HttpSyncRetryWaitMax": "30s",
     "HttpSyncRetryWaitMin": "1s",
     "HttpSyncTimeout": "10s",
-    "IngestWorkerCount":24,
+    "IngestWorkerCount": 100,
     "PubSubTopic": "/indexer/ingest/mainnet",
     "ResendDirectAnnounce": false,
     "StoreBatchSize": 8192,

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
@@ -82,7 +82,7 @@
     "HttpSyncRetryWaitMax": "30s",
     "HttpSyncRetryWaitMin": "1s",
     "HttpSyncTimeout": "10s",
-    "IngestWorkerCount": 30,
+    "IngestWorkerCount": 100,
     "PubSubTopic": "/indexer/ingest/mainnet",
     "ResendDirectAnnounce": false,
     "StoreBatchSize": 8192,


### PR DESCRIPTION
After a while nodes enter a dormant state and stop ingesting ads. Upon increasing the worker count they seem to resume ingestion. This hints at a potential bottleneck in worker mechanism where extended sync timeouts keep the workers busy? Further investigation is needed to confirm this.

For now increase worker count on all indexer nodes in prod to avoid reduction in ingest rate.

