### PR TITLE
Deploy `fdbmeter` to collect FoundationDB prometheus metrics

### DIFF
--- a/deploy/manifests/base/foundationdb/fdbmeter/deployment.yaml
+++ b/deploy/manifests/base/foundationdb/fdbmeter/deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: fdbmeter
+  name: fdbmeter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fdbmeter
+  template:
+    metadata:
+      labels:
+        app: fdbmeter
+    spec:
+      containers:
+        - name: fdbmeter
+          image: fdbmeter
+          ports:
+            - containerPort: 40080
+              name: http

--- a/deploy/manifests/base/foundationdb/fdbmeter/kustomization.yaml
+++ b/deploy/manifests/base/foundationdb/fdbmeter/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+
+images:
+  - name: fdbmeter
+    newName: ghcr.io/masih/fdbmeter
+    newTag: v0.0.3

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/fdbmeter/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/fdbmeter/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fdbmeter
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: fdbmeter
+          args:
+            - '--fdbClusterFile=/config/cluster-file'
+            - '--statusRefreshInterval=1m'
+            - '--commonAttributes=cluster=fdb-dev'
+          imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: 500m
+              memory: 256Mi
+            requests:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - mountPath: /config
+              name: config
+      volumes:
+        - name: config
+          configMap:
+            name: fdb-dev-cluster-config

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/fdbmeter/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/fdbmeter/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - ../../../../../base/foundationdb/fdbmeter
+  - pod-monitor.yaml
+
+patchesStrategicMerge:
+  - deployment.yaml

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/fdbmeter/pod-monitor.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/fdbmeter/pod-monitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: fdbmeter
+  labels:
+    app: fdbmeter
+spec:
+  selector:
+    matchLabels:
+      app: fdbmeter
+  namespaceSelector:
+    matchNames:
+      - storetheindex
+  podMetricsEndpoints:
+    - path: /metrics
+      port: http

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
 - fdb-manager
 - fdb-cluster
 - dhstore-stateless
+- fdbmeter
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdbmeter/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdbmeter/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fdbmeter
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: fdbmeter
+          args:
+            - '--fdbClusterFile=/config/cluster-file'
+            - '--statusRefreshInterval=1m'
+            - '--commonAttributes=cluster=fdb-prod'
+          imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: 500m
+              memory: 256Mi
+            requests:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - mountPath: /config
+              name: config
+      volumes:
+        - name: config
+          configMap:
+            name: fdb-prod-cluster-config

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdbmeter/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdbmeter/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - ../../../../../base/foundationdb/fdbmeter
+  - pod-monitor.yaml
+
+patchesStrategicMerge:
+  - deployment.yaml

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdbmeter/pod-monitor.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdbmeter/pod-monitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: fdbmeter
+  labels:
+    app: fdbmeter
+spec:
+  selector:
+    matchLabels:
+      app: fdbmeter
+  namespaceSelector:
+    matchNames:
+      - storetheindex
+  podMetricsEndpoints:
+    - path: /metrics
+      port: http

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
 - dhstore-stateless
 - fdb-cluster
 - dhfind-stateless
+- fdbmeter
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}


### PR DESCRIPTION
Deploy `fdbmeter` to collect FoundationDB prometheus metrics on `dev` and `prod`.
