### PR TITLE
Enable write to mirror on `inga`

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
@@ -68,7 +68,7 @@
     "AdvertisementDepthLimit": 33554432,
     "AdvertisementMirror": {
       "Read": true,
-      "Write": false,
+      "Write": true,
       "Compress": "gzip",
       "Storage": {
         "Type": "s3",


### PR DESCRIPTION
Enable write to mirror on inga so that ads ingested by it are not re-downloaded by other nodes.
