### PR TITLE
Remove redundant reframe routing from cloudfront

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/cloudfront.tf
+++ b/deploy/infrastructure/dev/us-east-2/cloudfront.tf
@@ -67,16 +67,6 @@ resource "aws_cloudfront_distribution" "cdn" {
     viewer_protocol_policy = "redirect-to-https"
   }
 
-  ordered_cache_behavior {
-    path_pattern = "reframe"
-    # CloudFront does not support configuring allowed methods selectively.
-    # Hence the complete method list.
-    allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "DELETE", "PATCH", "POST"]
-    cached_methods         = ["GET", "HEAD", "OPTIONS"]
-    target_origin_id       = local.indexstar_origin_id
-    cache_policy_id        = aws_cloudfront_cache_policy.reframe.id
-    viewer_protocol_policy = "redirect-to-https"
-  }
 
   ordered_cache_behavior {
     path_pattern = "ingest/*"
@@ -159,31 +149,6 @@ module "records" {
       }
     },
   ]
-}
-
-resource "aws_cloudfront_cache_policy" "reframe" {
-  name = "${local.environment_name}_reframe"
-
-  # We have to set non-zero TTL values because otherwise CloudFront won't let 
-  # the query strings settings to be configured.
-  min_ttl     = 0
-  default_ttl = 3600
-  max_ttl     = 86400
-
-  parameters_in_cache_key_and_forwarded_to_origin {
-    cookies_config {
-      cookie_behavior = "none"
-    }
-    headers_config {
-      header_behavior = "none"
-    }
-    query_strings_config {
-      query_string_behavior = "all"
-    }
-
-    enable_accept_encoding_brotli = true
-    enable_accept_encoding_gzip   = true
-  }
 }
 
 resource "aws_cloudfront_cache_policy" "lookup" {

--- a/deploy/infrastructure/prod/us-east-2/cloudfront.tf
+++ b/deploy/infrastructure/prod/us-east-2/cloudfront.tf
@@ -100,17 +100,6 @@ resource "aws_cloudfront_distribution" "cdn" {
   }
 
   ordered_cache_behavior {
-    path_pattern           = "reframe"
-    # CloudFront does not support configuring allowed methods selectively.
-    # Hence the complete method list.
-    allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "DELETE", "PATCH", "POST"]
-    cached_methods         = ["GET", "HEAD", "OPTIONS"]
-    target_origin_id       = local.indexstar_origin_id
-    cache_policy_id        = aws_cloudfront_cache_policy.reframe.id
-    viewer_protocol_policy = "redirect-to-https"
-  }
-
-  ordered_cache_behavior {
     path_pattern     = "multihash/*"
     # CloudFront does not support configuring allowed methods selectively.
     # Hence the complete method list.
@@ -180,31 +169,6 @@ resource "aws_cloudfront_distribution" "cdn" {
   viewer_certificate {
     acm_certificate_arn = module.cid_contact_cert.acm_certificate_arn
     ssl_support_method  = "sni-only"
-  }
-}
-
-resource "aws_cloudfront_cache_policy" "reframe" {
-  name = "reframe"
-
-  # We have to set non-zero TTL values because otherwise CloudFront won't let 
-  # the query strings settings to be configured.
-  min_ttl     = 0
-  default_ttl = 3600
-  max_ttl     = 86400
-
-  parameters_in_cache_key_and_forwarded_to_origin {
-    cookies_config {
-      cookie_behavior = "none"
-    }
-    headers_config {
-      header_behavior = "none"
-    }
-    query_strings_config {
-      query_string_behavior = "all"
-    }
-
-    enable_accept_encoding_brotli = true
-    enable_accept_encoding_gzip   = true
   }
 }
 


### PR DESCRIPTION
cid.contact no longer supports reframe paths. Remove caching config for it.

