### PR TITLE
Investigate high FDB storage lag by reducing dhstore batch to 16

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/arya/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/arya/config.json
@@ -58,7 +58,7 @@
     "ShutdownTimeout": "15m",
     "ValueStoreDir": "",
     "ValueStoreType": "none",
-    "DHBatchSize": 16384,
+    "DHBatchSize": 16,
     "DHStoreURL": "http://dhstore-stateless:40080",
     "DHStoreHttpClientTimeout": "30s"
   },

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/bala/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/bala/config.json
@@ -58,7 +58,7 @@
     "ShutdownTimeout": "15m",
     "ValueStoreDir": "",
     "ValueStoreType": "none",
-    "DHBatchSize": 16384,
+    "DHBatchSize": 16,
     "DHStoreURL": "http://dhstore-stateless:40080",
     "DHStoreHttpClientTimeout": "30s"
   },

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/cera/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/cera/config.json
@@ -58,7 +58,7 @@
     "ShutdownTimeout": "15m",
     "ValueStoreDir": "",
     "ValueStoreType": "none",
-    "DHBatchSize": 16384,
+    "DHBatchSize": 16,
     "DHStoreURL": "http://dhstore-stateless:40080",
     "DHStoreHttpClientTimeout": "30s"
   },


### PR DESCRIPTION
Reduce the batch size on writes to DH store to investigate FDB high storage server lag. This should increase the number of transactions but offer better distribution across servers.

