### PR TITLE
Move `inga` to instance types with more CPU

### DIFF
--- a/deploy/infrastructure/prod/us-east-2/eks.tf
+++ b/deploy/infrastructure/prod/us-east-2/eks.tf
@@ -163,6 +163,17 @@ module "eks" {
         data.aws_subnet.ue2c1.id, data.aws_subnet.ue2c2.id, data.aws_subnet.ue2c3.id
       ]
     }
+    prod-ue2-c6a-12xl = {
+      min_size       = 0
+      max_size       = 20
+      desired_size   = 1
+      instance_types = ["c6a.12xlarge"]
+      subnet_ids     = [
+        data.aws_subnet.ue2a1.id, data.aws_subnet.ue2a2.id, data.aws_subnet.ue2a3.id,
+        data.aws_subnet.ue2b1.id, data.aws_subnet.ue2b2.id, data.aws_subnet.ue2b3.id,
+        data.aws_subnet.ue2c1.id, data.aws_subnet.ue2c2.id, data.aws_subnet.ue2c3.id
+      ]
+    }
   }
 }
 

--- a/deploy/manifests/prod/us-east-2/cluster/kube-system/aws-auth.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/kube-system/aws-auth.yaml
@@ -90,6 +90,11 @@ data:
       - system:nodes
       rolearn: arn:aws:iam::407967248065:role/prod-ue2-c6a-8xl-eks-node-group
       username: system:node:{{EC2PrivateDNSName}}
+    - groups:
+      - system:bootstrappers
+      - system:nodes
+      rolearn: arn:aws:iam::407967248065:role/prod-ue2-c6a-12xl-eks-node-group
+      username: system:node:{{EC2PrivateDNSName}}
   mapUsers: |
     - userarn: arn:aws:iam::407967248065:user/masih
       username: masih

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/deployment.yaml
@@ -14,11 +14,11 @@ spec:
               mountPath: /data
           resources:
             limits:
-              cpu: "30"
-              memory: 28Gi
+              cpu: "45"
+              memory: 50Gi
             requests:
-              cpu: "30"
-              memory: 28Gi
+              cpu: "45"
+              memory: 50Gi
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -27,7 +27,7 @@ spec:
                   - key: node.kubernetes.io/instance-type
                     operator: In
                     values:
-                      - c6a.8xlarge
+                      - c6a.12xlarge
                   - key: topology.kubernetes.io/zone
                     operator: In
                     values:
@@ -36,9 +36,4 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: inga-data
-      tolerations:
-        - key: dedicated
-          operator: Equal
-          value: c6a-8xl
-          effect: NoSchedule
 


### PR DESCRIPTION
`inga` is running out of CPU all the time. move it to c6a 12XL nodes.

