### PR TITLE
Reduce worker count on `inga` to 10

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
@@ -82,7 +82,7 @@
     "HttpSyncRetryWaitMax": "30s",
     "HttpSyncRetryWaitMin": "1s",
     "HttpSyncTimeout": "10s",
-    "IngestWorkerCount": 100,
+    "IngestWorkerCount": 10,
     "PubSubTopic": "/indexer/ingest/mainnet",
     "ResendDirectAnnounce": false,
     "StoreBatchSize": 8192,


### PR DESCRIPTION
After having given 45 CPUs it is still maxing out. Reduce worker count.
