### PR TITLE
Exclude `inga` and add FDB-backed indexers as provider backends

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -13,9 +13,15 @@ spec:
         - name: indexstar
           args:
             - '--translateNonStreaming'
-            # Use service names local to the namespace over HTTP to avoid
-            # TLS handshake overhead.
-            - '--providersBackends=http://inga-indexer:3000/'
+            # Exclude inga because it is suffering from high CPU usage that then results 
+            # in large influx of 404s due to provider info lookup failing via dhfind instances.
+            # - '--providersBackends=http://inga-indexer:3000/'
+            
+            # New FDB-backed new indexers 
+            - '--providersBackends=http://arya-indexer:3000/'
+            - '--providersBackends=http://bala-indexer:3000/'
+            - '--providersBackends=http://cera-indexer:3000/'
+            
             # Keeping old indexers connected as providers backends for redundancy
             - '--providersBackends=http://oden-indexer:3000/'
             - '--providersBackends=http://kepa-indexer:3000/'


### PR DESCRIPTION
`inga` is suffering from high CPU usage, despite reduction of worker count by 10X and increase of CPU resource by ~3X.

This level of CPU consumption seems unreasonable and causes latency

fluctuation in lookups. Further, it causes high rate of 404s due to provider lookups via dhfind instances failing. Therefore it is now excluded as a provider backend.

Include new FDB backed instances as provider backed since they now have 100% coverage of providers.
