### PR TITLE
Revert "Reduce worker count on `inga` to 10"

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
@@ -82,7 +82,7 @@
     "HttpSyncRetryWaitMax": "30s",
     "HttpSyncRetryWaitMin": "1s",
     "HttpSyncTimeout": "10s",
-    "IngestWorkerCount": 10,
+    "IngestWorkerCount": 100,
     "PubSubTopic": "/indexer/ingest/mainnet",
     "ResendDirectAnnounce": false,
     "StoreBatchSize": 8192,


### PR DESCRIPTION
Reverts ipni/storetheindex#2010

Now that the ingest high cpu is resolved.