### PR TITLE
Increase max outstanding IO operations to 256

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
@@ -35,6 +35,8 @@ spec:
       customParameters:
         - memory=50GiB
         - cache-memory=32GiB
+        # Increase the default max outstanding IO operations (64), used in AIO with O_DIRECT interface.
+        - knob_max_outstanding=256
       podTemplate:
         spec:
           topologySpreadConstraints:
@@ -69,6 +71,8 @@ spec:
       customParameters:
         - memory=20GiB
         - cache-memory=12GiB
+        # Increase the default max outstanding IO operations (64), used in AIO with O_DIRECT interface.
+        - knob_max_outstanding=256
       podTemplate:
         spec:
           topologySpreadConstraints:


### PR DESCRIPTION
FoundationDB used AIO with O_Direct interface to interact with disk. The maximum number of outstanding IO operations default to 64. If this value is too low then the ratekeeper limits the accepted write rate which results in a growing lag between memory and disk in log and storage servers.

Bump the max outstanding kob to 256 in order to observe the effect on lag.
