### PR TITLE
Move `cera` to compute optimised instance type

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/cera/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/cera/deployment.yaml
@@ -14,11 +14,11 @@ spec:
               mountPath: /data
           resources:
             limits:
-              cpu: "7"
-              memory: 60Gi
+              cpu: "30"
+              memory: 58Gi
             requests:
-              cpu: "7"
-              memory: 60Gi
+              cpu: "30"
+              memory: 58Gi
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -27,7 +27,7 @@ spec:
                   - key: node.kubernetes.io/instance-type
                     operator: In
                     values:
-                      - r6a.2xlarge
+                      - c6a.8xlarge
                   - key: topology.kubernetes.io/zone
                     operator: In
                     values:


### PR DESCRIPTION
`cera` on prod consistently runs out of given CPU. Give it more CPU to see if it still runs out.


<!-- If no, outline the steps required to revert this change. -->
