### PR TITLE
Increase fetch key and relocation parallelism on `prod` FDB

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
@@ -37,6 +37,9 @@ spec:
         - cache-memory=32GiB
         # Increase the default max outstanding IO operations (64), used in AIO with O_DIRECT interface.
         - knob_max_outstanding=256
+        # Increase relocation and fetch keys parallelism to speed up data distribution across the cluster.
+        - knob_relocation_parallelism_per_source_server=8
+        - knob_fetch_keys_parallelism_bytes=5e6
       podTemplate:
         spec:
           topologySpreadConstraints:
@@ -73,6 +76,9 @@ spec:
         - cache-memory=12GiB
         # Increase the default max outstanding IO operations (64), used in AIO with O_DIRECT interface.
         - knob_max_outstanding=256
+        # Increase relocation and fetch keys parallelism to speed up data distribution across the cluster.
+        - knob_relocation_parallelism_per_source_server=8
+        - knob_fetch_keys_parallelism_bytes=5e6
       podTemplate:
         spec:
           topologySpreadConstraints:


### PR DESCRIPTION
In order to investigate increasing data in move, since there is spare
 IOPS on disk increase the parallelism and fetch key parallelism bytes.

