### PR TITLE
Make rewriting the mirror when resyncing configurable

### DIFF
--- a/config/ingest.go
+++ b/config/ingest.go
@@ -55,6 +55,8 @@ type Ingest struct {
 	// MinimumKeyLengt causes any multihash, that has a digest length less than
 	// this, to be ignored.
 	MinimumKeyLength int
+	// OverwriteMirrorOnResync overwrites the advertisement when resyncing.
+	OverwriteMirrorOnResync bool
 	// PubSubTopic sets the topic name to which to subscribe for ingestion
 	// announcements.
 	PubSubTopic string

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -1169,6 +1169,13 @@ func (ing *Ingester) ingestWorkerLogic(ctx context.Context, provider peer.ID, as
 	}
 	headAdCid := assignment.adInfos[0].cid
 
+	if ing.mirror.canWrite() && !assignment.adInfos[0].resync {
+		_, err := ing.mirror.writeHead(ctx, headAdCid, assignment.publisher)
+		if err != nil {
+			log.Errorw("Cannot write publisher head", "err", err)
+		}
+	}
+
 	total := len(assignment.adInfos)
 	log.Infow("Running worker on ad stack", "headAdCid", headAdCid, "numAdsToProcess", total)
 	var count int
@@ -1221,11 +1228,6 @@ func (ing *Ingester) ingestWorkerLogic(ctx context.Context, provider peer.ID, as
 					// else car file already exists
 				} else {
 					log.Infow("Wrote CAR for skipped advertisement", "path", carInfo.Path, "size", carInfo.Size)
-					// TODO: Move this when iterating latest (head) to earliest (root).
-					_, err = ing.mirror.writeHead(ctx, ai.cid, assignment.publisher)
-					if err != nil {
-						log.Errorw("Cannot write publisher head", "err", err)
-					}
 				}
 			}
 
@@ -1301,11 +1303,6 @@ func (ing *Ingester) ingestWorkerLogic(ctx context.Context, provider peer.ID, as
 				// else car file already exists
 			} else {
 				log.Infow("Wrote CAR for advertisement", "path", carInfo.Path, "size", carInfo.Size)
-				// TODO: Move this when iterating latest (head) to earliest (root).
-				_, err = ing.mirror.writeHead(ctx, ai.cid, assignment.publisher)
-				if err != nil {
-					log.Errorw("Cannot write publisher head", "err", err)
-				}
 			}
 		}
 


### PR DESCRIPTION
When resyncing, sometimes we want to rewrite the mirror, usually we do not.

We may want to rewrite the mirror to get rid of the deleted multihash data that is not needed or to re-encode or compress differently.  Usually, we will only want to read existing CAR files from the mirror when resyncing.
