### PR TITLE
Update the github certificate thumbprints

### DIFF
--- a/deploy/infrastructure/common/github_actions.tf
+++ b/deploy/infrastructure/common/github_actions.tf
@@ -6,7 +6,8 @@ resource "aws_iam_openid_connect_provider" "github" {
   ]
 
   thumbprint_list = [
-    "6938fd4d98bab03faadb97b34396831e3780aea1"
+    "6938fd4d98bab03faadb97b34396831e3780aea1",
+    "a3b59e5fe884ee1f34d98eef858e3fb662ac104a"
   ]
   url = "https://token.actions.githubusercontent.com"
 }

--- a/deploy/infrastructure/common/github_actions.tf
+++ b/deploy/infrastructure/common/github_actions.tf
@@ -7,7 +7,7 @@ resource "aws_iam_openid_connect_provider" "github" {
 
   thumbprint_list = [
     "6938fd4d98bab03faadb97b34396831e3780aea1",
-    "a3b59e5fe884ee1f34d98eef858e3fb662ac104a"
+    "1c58a3a8518e8759bf075b76b750d4f2df264fcd"
   ]
   url = "https://token.actions.githubusercontent.com"
 }


### PR DESCRIPTION
Looks like github changed certs, so we need a new fingerprint. Otherwise, ECR builds are failing with error:

"OpenIDConnect provider's HTTPS certificate doesn't match configured thumbprint"

I manually added the new fingerprint in the AWS console (IAM > identity providers > token.actions.githubusercontent.com) to see that it fixed the build problem, so now adding it here. The old fingerprint is still there in case this is a temporary situation and github changes back, or some servers still present the old certs.
