### PR TITLE
Clear LastError on good sync

### DIFF
--- a/.github/workflows/ecr-publisher.yml
+++ b/.github/workflows/ecr-publisher.yml
@@ -14,7 +14,6 @@ on:
       - 'doc/**'
     branches:
       - main
-      - update-last-error
 
 jobs:
   publisher:

--- a/.github/workflows/ecr-publisher.yml
+++ b/.github/workflows/ecr-publisher.yml
@@ -14,6 +14,7 @@ on:
       - 'doc/**'
     branches:
       - main
+      - update-last-error
 
 jobs:
   publisher:

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/ipld/go-ipld-prime v0.20.0
 	github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd
 	github.com/ipni/go-indexer-core v0.8.0
-	github.com/ipni/go-libipni v0.2.5-0.20230628005641-f3760efb1b43
+	github.com/ipni/go-libipni v0.2.5-0.20230628123033-bbe3e4d11abc
 	github.com/libp2p/go-libp2p v0.28.1
 	github.com/libp2p/go-msgio v0.3.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/ipld/go-ipld-prime v0.20.0
 	github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd
 	github.com/ipni/go-indexer-core v0.8.0
-	github.com/ipni/go-libipni v0.2.5-0.20230628123033-bbe3e4d11abc
+	github.com/ipni/go-libipni v0.2.6
 	github.com/libp2p/go-libp2p v0.28.1
 	github.com/libp2p/go-msgio v0.3.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -599,8 +599,8 @@ github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236
 github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd/go.mod h1:9DD/GM0JNPoisgR09F62kbBi7kHa4eDIea4XshXYOVc=
 github.com/ipni/go-indexer-core v0.8.0 h1:HPFMngR47FL49mVnOZBrcxJoRODjIadlP+UYMRboNKA=
 github.com/ipni/go-indexer-core v0.8.0/go.mod h1:Y9su+no9k6y+jnQRERP/CKJewdISHzzl+n91GA+y4Ao=
-github.com/ipni/go-libipni v0.2.5-0.20230628123033-bbe3e4d11abc h1:Zr6WWi8Cd1esOicOLdQRe0051xgIOsihVbzvCGx0Nls=
-github.com/ipni/go-libipni v0.2.5-0.20230628123033-bbe3e4d11abc/go.mod h1:dhBH9HwxT6HzQPRZ8ikWv+ccqF8ucMIoGiiTSrHA4tw=
+github.com/ipni/go-libipni v0.2.6 h1:YKjdNs0dlLvGkNyNAA8gvzZifAQCaclktlG5kSfBims=
+github.com/ipni/go-libipni v0.2.6/go.mod h1:dhBH9HwxT6HzQPRZ8ikWv+ccqF8ucMIoGiiTSrHA4tw=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/i18n v0.0.0-20171121225848-987a633949d0/go.mod h1:pMCz62A0xJL6I+umB2YTlFRwWXaDFA0jy+5HzGiJjqI=

--- a/go.sum
+++ b/go.sum
@@ -599,8 +599,8 @@ github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236
 github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd/go.mod h1:9DD/GM0JNPoisgR09F62kbBi7kHa4eDIea4XshXYOVc=
 github.com/ipni/go-indexer-core v0.8.0 h1:HPFMngR47FL49mVnOZBrcxJoRODjIadlP+UYMRboNKA=
 github.com/ipni/go-indexer-core v0.8.0/go.mod h1:Y9su+no9k6y+jnQRERP/CKJewdISHzzl+n91GA+y4Ao=
-github.com/ipni/go-libipni v0.2.5-0.20230628005641-f3760efb1b43 h1:0pBGLhYCNRasn8Q7MtTJ2/z63EZh3jGzGBIpL1RhzKU=
-github.com/ipni/go-libipni v0.2.5-0.20230628005641-f3760efb1b43/go.mod h1:ej3Kw/58NEyM/NOCJTL7W62PjWwGGM1Dq/6chpUzGOM=
+github.com/ipni/go-libipni v0.2.5-0.20230628123033-bbe3e4d11abc h1:Zr6WWi8Cd1esOicOLdQRe0051xgIOsihVbzvCGx0Nls=
+github.com/ipni/go-libipni v0.2.5-0.20230628123033-bbe3e4d11abc/go.mod h1:dhBH9HwxT6HzQPRZ8ikWv+ccqF8ucMIoGiiTSrHA4tw=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/i18n v0.0.0-20171121225848-987a633949d0/go.mod h1:pMCz62A0xJL6I+umB2YTlFRwWXaDFA0jy+5HzGiJjqI=

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1012,10 +1012,13 @@ func (r *Registry) RemoveProvider(ctx context.Context, providerID peer.ID) error
 }
 
 func (r *Registry) SetLastError(providerID peer.ID, err error) {
-	now := time.Now()
+	var now time.Time
+	if err != nil {
+		now = time.Now()
+	}
 	r.actions <- func() {
 		pinfo, ok := r.providers[providerID]
-		if !ok {
+		if !ok || err == pinfo.LastError {
 			return
 		}
 		pinfoCpy := *pinfo


### PR DESCRIPTION
- Do not set LastError on skipped advertisements
- Do not set LastError if db write failure
- Use new go-libipni that does not block SyncFinished events.
