### PR TITLE
Deploy new dhstore-ago2 and replace dhfind-ago2

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhfind-ago2/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhfind-ago2/kustomization.yaml
@@ -18,3 +18,7 @@ images:
   - name: dhfind
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhfind
     newTag: 20230628142546-6ec4eb394679e183e8c16519cd528feffdf506bf
+
+replicas:
+  - name: dhfind
+    count: 0

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago2/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago2/deployment.yaml
@@ -18,6 +18,7 @@ spec:
       containers:
         - name: dhstore
           args:
+            - '--providersURL=http://ago-indexer:3000/'
             - '--storePath=/data'
             - '--disableWAL'
             - '--blockCacheSize=2Gi'

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago2/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago2/kustomization.yaml
@@ -18,4 +18,4 @@ patchesStrategicMerge:
 images:
   - name: dhstore
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
-    newTag: 20230611132714-cb13f894b8ab5f535ec425bac86d0053f7a132f2
+    newTag: 20230629194957-ba81f67dc426c1c71bdefd20d0a03a4860a431c5

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -17,7 +17,7 @@ spec:
             # TLS handshake overhead.
             - '--providersBackends=http://ago-indexer:3000/'
             - '--backends=http://dhfind.internal.dev.cid.contact/'
-            - '--backends=http://dhfind-ago2.internal.dev.cid.contact/'
+            - '--backends=http://dhstore-ago2.internal.dev.cid.contact/'
             - '--dhBackends=http://dhstore.internal.dev.cid.contact/'
             - '--dhBackends=http://dhstore-ago2.internal.dev.cid.contact/'
             - '--cascadeBackends=http://caskadht.internal.dev.cid.contact/'


### PR DESCRIPTION
New dhstore has both dhstore and dhfind functionality.

- Deploy the new dhstore.
- Configure new dhstore with providersURL that points to ago-indexer.
- In indexstar, replace dhfind-ago2 with dhstore-ago2.
