### PR TITLE
Persist LastError across restarts

### DIFF
--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -444,7 +444,7 @@ func TestFailDuringSync(t *testing.T) {
 		require.Error(t, err)
 		// Should see last error since cannot ingest ad entries.
 		pInfo, _ := te.reg.ProviderInfo(te.pubHost.ID())
-		require.Error(t, pInfo.LastError)
+		require.NotEmpty(t, pInfo.LastError)
 		t.Log("Last Error:", pInfo.LastError)
 	}()
 	// The ingester tried to sync B, but it was blocked. Now let's stop the ingester.

--- a/internal/registry/apiconv.go
+++ b/internal/registry/apiconv.go
@@ -27,8 +27,8 @@ func RegToApiProviderInfo(pi *ProviderInfo, indexCount uint64) *model.ProviderIn
 			apiPI.LastAdvertisementTime = pi.LastAdvertisementTime.Format(time.RFC3339)
 		}
 	}
-	if pi.LastError != nil {
-		apiPI.LastError = pi.LastError.Error()
+	if pi.LastError != "" {
+		apiPI.LastError = pi.LastError
 		if !pi.LastErrorTime.IsZero() {
 			apiPI.LastErrorTime = pi.LastErrorTime.Format(time.RFC3339)
 		}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1021,8 +1021,10 @@ func (r *Registry) SetLastError(providerID peer.ID, err error) {
 		if !ok {
 			return
 		}
-		errMsg := err.Error()
-		if errMsg == pinfo.LastError {
+		var errMsg string
+		if err != nil {
+			errMsg = err.Error()
+		} else if pinfo.LastError == "" {
 			return
 		}
 		pinfoCpy := *pinfo

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -93,7 +93,7 @@ type ProviderInfo struct {
 
 	// LastError is a description of the last ingestion error to occur for this
 	// provider.
-	LastError error `json:",omitempty"`
+	LastError string `json:",omitempty"`
 	// LastErrorTime is the time that LastError occurred.
 	LastErrorTime time.Time
 
@@ -1018,11 +1018,15 @@ func (r *Registry) SetLastError(providerID peer.ID, err error) {
 	}
 	r.actions <- func() {
 		pinfo, ok := r.providers[providerID]
-		if !ok || err == pinfo.LastError {
+		if !ok {
+			return
+		}
+		errMsg := err.Error()
+		if errMsg == pinfo.LastError {
 			return
 		}
 		pinfoCpy := *pinfo
-		pinfoCpy.LastError = err
+		pinfoCpy.LastError = errMsg
 		pinfoCpy.LastErrorTime = now
 		r.providers[providerID] = &pinfoCpy
 	}
@@ -1355,6 +1359,8 @@ func loadPersistedProviders(ctx context.Context, dstore datastore.Datastore, fil
 	}
 	defer results.Close()
 
+	var fixes []*ProviderInfo
+
 	for result := range results.Next() {
 		if result.Error != nil {
 			return nil, fmt.Errorf("cannot read provider data: %v", result.Error)
@@ -1373,6 +1379,7 @@ func loadPersistedProviders(ctx context.Context, dstore datastore.Datastore, fil
 			pinfo.AddrInfo.ID = peerID
 			// Add the provider to the set of registered providers so that it
 			// does not get delisted. The next update should fix the addresses.
+			fixes = append(fixes, pinfo)
 		}
 
 		if filterIPs {
@@ -1393,6 +1400,21 @@ func loadPersistedProviders(ctx context.Context, dstore datastore.Datastore, fil
 		}
 
 		providers[peerID] = pinfo
+	}
+
+	if len(fixes) != 0 {
+		for _, pinfo := range fixes {
+			value, err := json.Marshal(pinfo)
+			if err != nil {
+				log.Errorw("Cannot marshal provider info", "err", err, "provider", pinfo.AddrInfo.ID)
+				continue
+			}
+			if err = dstore.Put(ctx, pinfo.dsKey(), value); err != nil {
+				log.Errorw("Cannot store provider info", "err", err, "provider", pinfo.AddrInfo.ID)
+				continue
+			}
+		}
+		_ = dstore.Sync(ctx, datastore.NewKey(providerKeyPath))
 	}
 
 	return providers, nil


### PR DESCRIPTION
LastError was not previously persisted.

Add code to cleanup any errors in stored provider info.
