### PR TITLE
Revert "Revert "Deploy latest to inga""

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/kustomization.yaml
@@ -27,3 +27,8 @@ configMapGenerator:
 
 patchesStrategicMerge:
   - deployment.yaml
+
+images:
+  - name: storetheindex
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
+    newTag: 0.7.5


### PR DESCRIPTION
Reverts ipni/storetheindex#2057

The problem with getting providers has nothing to do with any difference between previous and latest version, so redeploying latest.