### PR TITLE
Investigating high CPU usage: Reduce worker count on inga to 5

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
@@ -82,7 +82,7 @@
     "HttpSyncRetryWaitMax": "30s",
     "HttpSyncRetryWaitMin": "1s",
     "HttpSyncTimeout": "10s",
-    "IngestWorkerCount": 100,
+    "IngestWorkerCount": 5,
     "PubSubTopic": "/indexer/ingest/mainnet",
     "ResendDirectAnnounce": false,
     "StoreBatchSize": 8192,


### PR DESCRIPTION
`inga` on prod is suffering from high CPU usage to the extent where it is unresponsive. Reduce worker count to 5 to investigate.
