### PR TITLE
Add old indexers as provider backend while investigating `inga` issues

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -23,9 +23,9 @@ spec:
             
             # Remove old nodes since inga is largely caught up and other indexers may be further behind/forward.
             # This results in inconsistent responses and hard to debugt issues.
-            # - '--providersBackends=http://oden-indexer:3000/'
-            # - '--providersBackends=http://kepa-indexer:3000/'
-            # - '--providersBackends=http://dido-indexer:3000/'
+            - '--providersBackends=http://oden-indexer:3000/'
+            - '--providersBackends=http://kepa-indexer:3000/'
+            - '--providersBackends=http://dido-indexer:3000/'
             - '--backends=http://dhfind.internal.prod.cid.contact/'
             - '--backends=http://dhfind-helga.internal.prod.cid.contact/'
             - '--backends=http://dhfind-porvy.internal.prod.cid.contact/'


### PR DESCRIPTION
`inga` was the only provider backend and it down. As a result no providers are being found and therefore no lookups.

Restore old ndoes while investigating.
