### PR TITLE
Revert inga to 0.7.3 to investigate excessive CPU usage

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/kustomization.yaml
@@ -27,8 +27,3 @@ configMapGenerator:
 
 patchesStrategicMerge:
   - deployment.yaml
-
-images:
-  - name: storetheindex
-    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex
-    newTag: 0.7.5


### PR DESCRIPTION
Revert back to 0.7.3 as the latest to investigate excessive CPU usage on inga.
