### PR TITLE
Increase workers on inga to 50 now that CPU usage has settled

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
@@ -82,7 +82,7 @@
     "HttpSyncRetryWaitMax": "30s",
     "HttpSyncRetryWaitMin": "1s",
     "HttpSyncTimeout": "10s",
-    "IngestWorkerCount": 5,
+    "IngestWorkerCount": 50,
     "PubSubTopic": "/indexer/ingest/mainnet",
     "ResendDirectAnnounce": false,
     "StoreBatchSize": 8192,


### PR DESCRIPTION
`inga` is back up and operational after working through the CPU flareup.

Increase worker count from 5 to 50 in order to investigate the impact of ingest on CPU spikes. Note that the node is currently running 0.7.3.

Cc @gammazero  for visibility.
