### PR TITLE
Investigate high CPU spikes potentially caused by index counter

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -248,8 +248,8 @@ func daemonAction(cctx *cli.Context) error {
 		}
 
 		// Initialize ingester.
-		ingester, err = ingest.NewIngester(cfg.Ingest, p2pHost, indexerCore, reg, dstore, dsTmp,
-			ingest.WithIndexCounts(indexCounts))
+		ingester, err = ingest.NewIngester(cfg.Ingest, p2pHost, indexerCore, reg, dstore, dsTmp) //ingest.WithIndexCounts(indexCounts)
+
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Disable index counter for ingest.

Relates to #2062 

Cc @gammazero 