### PR TITLE
Bump version to release index counter config

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.7.5"
+  "version": "v0.7.6"
 }


### PR DESCRIPTION
Bump version to release a change that disables index counters by default and makes it configurable. This removes contention on ingest and CPU spike no nodes until there is a more optimal implementation of index counting functionality.

