### PR TITLE
Investigate growing queue lag in FDB

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
@@ -40,6 +40,14 @@ spec:
         # Increase relocation and fetch keys parallelism to speed up data distribution across the cluster.
         - knob_relocation_parallelism_per_source_server=8
         - knob_fetch_keys_parallelism_bytes=5e6
+        # Defaults to 15e6
+        - knob_max_queue_commit_bytes=30e6
+        # Defaults to 1500e6
+        - knob_storage_hard_limit_bytes=3000e6
+        # Defaults to 1000e6
+        - knob_target_bytes_per_storage_server=2000e6
+        # Defaults to 750e6
+        - knob_target_bytes_per_storage_server_batch=1500e6
       podTemplate:
         spec:
           topologySpreadConstraints:
@@ -79,6 +87,14 @@ spec:
         # Increase relocation and fetch keys parallelism to speed up data distribution across the cluster.
         - knob_relocation_parallelism_per_source_server=8
         - knob_fetch_keys_parallelism_bytes=5e6
+        # Defaults to 15e6
+        - knob_max_queue_commit_bytes=30e6
+        # Defaults to 1500e6
+        - knob_storage_hard_limit_bytes=3000e6
+        # Defaults to 1000e6
+        - knob_target_bytes_per_storage_server=2000e6
+        # Defaults to 750e6
+        - knob_target_bytes_per_storage_server_batch=1500e6
       podTemplate:
         spec:
           topologySpreadConstraints:


### PR DESCRIPTION
Double max queue commit bytes and the maximum limits for in-queue bytes per storage for both regular and batch transactions.

