### PR TITLE
Reduce FDB log process cache to 12GiB

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
@@ -34,7 +34,7 @@ spec:
     log:
       customParameters:
         - memory=50GiB
-        - cache-memory=12.5GiB
+        - cache-memory=12GiB
         # Increase the default max outstanding IO operations (64), used in AIO with O_DIRECT interface.
         - knob_max_outstanding=256
         # Increase relocation and fetch keys parallelism to speed up data distribution across the cluster.


### PR DESCRIPTION
Investigate log processes not starting potentially due to decimal point
 in cache-memory config.
