### PR TITLE
Increase storage memory limit to 28GiB

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
@@ -80,7 +80,7 @@ spec:
               storage: 2Ti
     storage:
       customParameters:
-        - memory=20GiB
+        - memory=28GiB
         - cache-memory=5GiB
         # Increase the default max outstanding IO operations (64), used in AIO with O_DIRECT interface.
         - knob_max_outstanding=256


### PR DESCRIPTION
In order to utilise all the memory available, increase memory limit to
 28GiB since the pod only runs 2 storage server processes.

