### PR TITLE
Tune RocksDB storage engine in prod FDB cluster

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
@@ -87,14 +87,14 @@ spec:
         # Increase relocation and fetch keys parallelism to speed up data distribution across the cluster.
         - knob_relocation_parallelism_per_source_server=8
         - knob_fetch_keys_parallelism_bytes=5e6
-        # Defaults to 15e6
-        - knob_max_queue_commit_bytes=30e6
-        # Defaults to 1500e6
-        - knob_storage_hard_limit_bytes=3000e6
-        # Defaults to 1000e6
-        - knob_target_bytes_per_storage_server=2000e6
-        # Defaults to 750e6
-        - knob_target_bytes_per_storage_server_batch=1500e6
+        - knob_rocksdb_block_size=65536
+        - knob_rocksdb_block_cache_size=4294967296
+        - knob_rocksdb_compaction_readahead_size=65536
+        - knob_rocksdb_cf_write_buffer_size=134217728
+        - knob_rocksdb_write_buffer_size=2147483648
+        - knob_rocksdb_background_parallelism=8
+        - knob_rocksdb_read_parallelism=16
+        - knob_rocksdb_checkpoint_reader_parallelism=16
       podTemplate:
         spec:
           topologySpreadConstraints:


### PR DESCRIPTION
Bump the default block and block cache. Increase read and compaction parallelism. Remove FDB storage limits to revert back to normal as the RocksDB settings seems to be the prohibiting factor.
