### PR TITLE
Use the same FDB config as `prod` on `dev`

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: fdb-dev-cluster
 spec:
   version: 7.1.33
-  storageServersPerPod: 5
+  storageServersPerPod: 2
   automationOptions:
     replacements:
       enabled: true
@@ -15,8 +15,9 @@ spec:
     storage_engine: ssd-rocksdb-v1
   processCounts:
     storage: 5
-    log: 3
-    stateless: 2
+    log: 2
+    coordinator: 3
+    stateless: -1
   labels:
     matchLabels:
       foundationdb.org/fdb-cluster-name: fdb-dev-cluster
@@ -27,9 +28,26 @@ spec:
   minimumUptimeSecondsForBounce: 60
   processes:
     general:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: gp3
+    log:
       customParameters:
-        - memory=20GiB
+        - memory=50GiB
         - cache-memory=12GiB
+        # Increase the default max outstanding IO operations (64), used in AIO with O_DIRECT interface.
+        - knob_max_outstanding=256
+        # Increase relocation and fetch keys parallelism to speed up data distribution across the cluster.
+        - knob_relocation_parallelism_per_source_server=8
+        - knob_fetch_keys_parallelism_bytes=5e6
+        # Defaults to 15e6
+        - knob_max_queue_commit_bytes=30e6
+        # Defaults to 1500e6
+        - knob_storage_hard_limit_bytes=3000e6
+        # Defaults to 1000e6
+        - knob_target_bytes_per_storage_server=2000e6
+        # Defaults to 750e6
+        - knob_target_bytes_per_storage_server_batch=1500e6
       podTemplate:
         spec:
           topologySpreadConstraints:
@@ -44,13 +62,61 @@ spec:
                       - key: node.kubernetes.io/instance-type
                         operator: In
                         values:
-                          - r5a.2xlarge
+                          # 32 CPU, 64GiB memory
+                          - c6a.8xlarge
           containers:
             - name: foundationdb
               resources:
                 requests:
-                  cpu: 7
-                  memory: 60.5Gi
+                  cpu: 30
+                  memory: 57Gi
+              securityContext:
+                runAsUser: 0
+      volumeClaimTemplate:
+        spec:
+          storageClassName: gp3-iops16k-t1000
+          resources:
+            requests:
+              storage: 2Ti
+    storage:
+      customParameters:
+        - memory=28GiB
+        - cache-memory=5GiB
+        # Increase the default max outstanding IO operations (64), used in AIO with O_DIRECT interface.
+        - knob_max_outstanding=256
+        # Increase relocation and fetch keys parallelism to speed up data distribution across the cluster.
+        - knob_relocation_parallelism_per_source_server=8
+        - knob_fetch_keys_parallelism_bytes=5e6
+        - knob_rocksdb_block_size=65536
+        - knob_rocksdb_block_cache_size=4294967296
+        - knob_rocksdb_compaction_readahead_size=65536
+        - knob_rocksdb_cf_write_buffer_size=134217728
+        - knob_rocksdb_write_buffer_size=2147483648
+        - knob_rocksdb_background_parallelism=8
+        - knob_rocksdb_read_parallelism=16
+        - knob_rocksdb_checkpoint_reader_parallelism=16
+      podTemplate:
+        spec:
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: topology.kubernetes.io/zone
+              whenUnsatisfiable: ScheduleAnyway
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: node.kubernetes.io/instance-type
+                        operator: In
+                        values:
+                          # 32 CPU, 64GiB memory
+                          - c6a.8xlarge
+          containers:
+            - name: foundationdb
+              resources:
+                requests:
+                  cpu: 30
+                  memory: 57Gi
               securityContext:
                 runAsUser: 0
       volumeClaimTemplate:
@@ -64,3 +130,4 @@ spec:
     enableLivenessProbe: true
   routing:
     useDNSInClusterFile: true
+  replaceInstancesWhenResourcesChange: true


### PR DESCRIPTION
To make testing on dev comparable with prod, configure the dev FDB cluster such that it matches the prod nodes.

