### PR TITLE
feat: suspend autoretrieve namespace CD

### DIFF
--- a/deploy/manifests/dev/us-east-2/cluster/autoretrieve/flux-cd.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/autoretrieve/flux-cd.yaml
@@ -15,6 +15,7 @@ kind: Kustomization
 metadata:
   name: autoretrieve
 spec:
+  suspend: true
   serviceAccountName: flux
   decryption:
     provider: sops


### PR DESCRIPTION
Suspend the continuous delivery in the autoretrieve namespace to prevent changes to the autoretrieve namespaced manifests from making changes to the current running tornado applications.