### PR TITLE
Create KMS key for Tornado team as a tenant

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/kms.tf
+++ b/deploy/infrastructure/dev/us-east-2/kms.tf
@@ -77,7 +77,7 @@ data "aws_iam_policy_document" "kust_ctrlr" {
       "kms:DescribeKey",
     ]
 
-    resources = [aws_kms_key.kms_sti.arn, aws_kms_key.kms_cluster.arn, aws_kms_key.kms_autoretrieve.arn, aws_kms_key.kms_index_provider.arn]
+    resources = [aws_kms_key.kms_sti.arn, aws_kms_key.kms_cluster.arn, aws_kms_key.kms_autoretrieve.arn, aws_kms_key.kms_index_provider.arn, aws_kms_key.kms_tornado.arn]
   }
 }
 

--- a/deploy/infrastructure/dev/us-east-2/outputs.tf
+++ b/deploy/infrastructure/dev/us-east-2/outputs.tf
@@ -10,6 +10,10 @@ output "kms_autoretrieve_alias_arn" {
   value = aws_kms_alias.kms_autoretrieve.arn
 }
 
+output "kms_tornado_alias_arn" {
+  value = aws_kms_alias.kms_tornado.arn
+}
+
 output "kms_index_provider_alias_arn" {
   value = aws_kms_alias.kms_index_provider.arn
 }

--- a/deploy/infrastructure/dev/us-east-2/tornado.tf
+++ b/deploy/infrastructure/dev/us-east-2/tornado.tf
@@ -1,0 +1,71 @@
+resource "aws_kms_alias" "kms_tornado" {
+  target_key_id = aws_kms_key.kms_tornado.key_id
+  name          = "alias${local.iam_path}tornado"
+}
+
+resource "aws_kms_key" "kms_tornado" {
+  description = "Key used to encrypt tornado tenant secrets"
+  policy      = data.aws_iam_policy_document.kms_tornado.json
+  is_enabled  = true
+
+  tags = local.tags
+}
+
+data "aws_iam_policy_document" "kms_tornado" {
+  statement {
+    sid = "Enable IAM User Permissions"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::407967248065:root"]
+    }
+
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "Allow access for Devs via sops"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        "arn:aws:iam::407967248065:user/masih",
+        "arn:aws:iam::407967248065:user/gammazero",
+        "arn:aws:iam::407967248065:user/will.scott",
+        "arn:aws:iam::407967248065:user/kylehuntsman",
+        "arn:aws:iam::407967248065:user/ischasny",
+        "arn:aws:iam::407967248065:user/hannahhoward",
+        "arn:aws:iam::407967248065:user/rodvagg",
+      ]
+    }
+
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey"
+    ]
+
+    resources = ["*"]
+  }
+
+
+  statement {
+    sid = "Allow Flux to decrypt"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        module.kustomize_controller_role.iam_role_arn
+      ]
+    }
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+    ]
+  }
+}


### PR DESCRIPTION
Create a dedicated KMS key used to manage encryption and decryption of secrets used by the Tornado team.
