### PR TITLE
Deploy a new dhstore instance on prod

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind-qiu/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind-qiu/deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dhfind
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dhfind-qiu
+  template:
+    metadata:
+      labels:
+        app: dhfind-qiu
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+      containers:
+        - name: dhfind
+          args:
+            - '--dhstoreAddr=http://dhstore-qiu:40080/'
+            - '--stiAddr=http://indexstar:8080/'
+          resources:
+            limits:
+              cpu: "1.5"
+              memory: 512Mi
+            requests:
+              cpu: "1.5"
+              memory: 512Mi

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind-qiu/ingress.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind-qiu/ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dhfind
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt"
+spec:
+  tls:
+    - hosts:
+        - dhfind-qiu.prod.cid.contact
+      secretName: dhfind-qiu-ingress-tls
+  rules:
+    - host: dhfind-qiu.prod.cid.contact
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: dhfind-qiu
+                port:
+                  number: 80

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind-qiu/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind-qiu/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+nameSuffix: -qiu
+
+commonLabels:
+  app: dhfind-qiu
+
+resources:
+  - ../../../../../base/dhfind
+  - pod-monitor.yaml
+  - ingress.yaml
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: dhfind
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhfind
+    newTag: 20230628142546-6ec4eb394679e183e8c16519cd528feffdf506bf

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind-qiu/pod-monitor.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhfind-qiu/pod-monitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: dhfind
+spec:
+  selector:
+    matchLabels:
+      app: dhfind-qiu
+  namespaceSelector:
+    matchNames:
+      - storetheindex
+  podMetricsEndpoints:
+    - path: /metrics
+      port: metrics

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-qiu/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-qiu/deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dhstore
+spec:
+  template:
+    spec:
+      containers:
+        - name: dhstore
+          args:
+            - '--storePath=/data'
+            - '--disableWAL'
+            - '--blockCacheSize=2Gi'
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            limits:
+              cpu: "28"
+              memory: 58Gi
+            requests:
+              cpu: "28"
+              memory: 58Gi
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.kubernetes.io/instance-type
+                    operator: In
+                    values:
+                      - c6a.8xlarge
+                  - key: topology.kubernetes.io/zone
+                    operator: In
+                    values:
+                      - us-east-2b
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: dhstore-data-qiu
+

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-qiu/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-qiu/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - github.com/ipni/dhstore/deploy/kubernetes?ref=65afbf7dd908b7391e60c321822db69e9939bee7
+  - pvc.yaml
+  - pod-monitor.yaml
+
+nameSuffix: -qiu
+
+commonLabels:
+  app: dhstore-qiu
+
+patchesStrategicMerge:
+  - deployment.yaml
+
+images:
+  - name: dhstore
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
+    newTag: 20230611132714-cb13f894b8ab5f535ec425bac86d0053f7a132f2

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-qiu/pod-monitor.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-qiu/pod-monitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: dhstore
+  labels:
+    app: dhstore-qiu
+spec:
+  selector:
+    matchLabels:
+      app: dhstore-qiu
+  namespaceSelector:
+    matchNames:
+      - storetheindex
+  podMetricsEndpoints:
+    - path: /metrics
+      port: metrics

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-qiu/pvc.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-qiu/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dhstore-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 4Ti
+  storageClassName: gp3

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -22,6 +22,8 @@ resources:
 - fdb-cluster
 - dhfind-stateless
 - fdbmeter
+- dhstore-qiu
+- dhfind-qiu
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}


### PR DESCRIPTION
Since `dhstore-porvy` is close to fully utilising its given storage, deploy a new dhstore instance with a matching dhfind instance.

Once the services are up, a separate PR will switch `inga` to use the new dhstore instance instead of `porvy`.
