### PR TITLE
Expand subnets for `dev-ue2a-r6a-xl` node group

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/eks.tf
+++ b/deploy/infrastructure/dev/us-east-2/eks.tf
@@ -28,7 +28,7 @@ module "eks" {
       max_size       = 5
       desired_size   = 1
       instance_types = ["r6a.xlarge"]
-      subnet_ids     = [data.aws_subnet.ue2a2.id]
+      subnet_ids     = [data.aws_subnet.ue2a1.id, data.aws_subnet.ue2a2.id, data.aws_subnet.ue2a3.id]
     }
     dev-ue2b-r6a-xl = {
       min_size       = 0


### PR DESCRIPTION
Expand subnets for `dev-ue2a-r6a-xl` as we were running out of IPs and
nodes were not getting scheduled.
