### PR TITLE
Deploy HeyFil API on dev and prod with persistent storage

### DIFF
--- a/deploy/manifests/base/heyfil/deployment.yaml
+++ b/deploy/manifests/base/heyfil/deployment.yaml
@@ -23,3 +23,5 @@ spec:
           ports:
             - containerPort: 8080
               name: metrics
+            - containerPort: 8081
+              name: api

--- a/deploy/manifests/base/heyfil/kustomization.yaml
+++ b/deploy/manifests/base/heyfil/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
   - deployment.yaml
+  - service.yaml
 
 commonLabels:
   app: heyfil

--- a/deploy/manifests/base/heyfil/service.yaml
+++ b/deploy/manifests/base/heyfil/service.yaml
@@ -1,0 +1,14 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: heyfil
+spec:
+  ports:
+    - name: metrics
+      port: 8080
+      targetPort: metrics
+    - name: api
+      port: 8081
+      targetPort: api
+  selector:
+    app: heyfil

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/heyfil/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/heyfil/deployment.yaml
@@ -9,6 +9,7 @@ spec:
         - name: heyfil
           args:
             - '--httpIndexerEndpoint=https://dev.cid.contact'
+            - '--storePath=/store'
           resources:
             limits:
               cpu: "2"
@@ -16,4 +17,10 @@ spec:
             requests:
               cpu: "2"
               memory: 2Gi
-            
+          volumeMounts:
+            - name: store
+              mountPath: /store
+      volumes:
+        - name: store
+          persistentVolumeClaim:
+            claimName: heyfil

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/heyfil/ingress.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/heyfil/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: heyfil
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+spec:
+  tls:
+    - hosts:
+        - heyfil.dev.cid.contact
+      secretName: heyfil-ingress-tls
+  rules:
+    - host: heyfil.dev.cid.contact
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: heyfil
+                port:
+                  name: api

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/heyfil/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/heyfil/kustomization.yaml
@@ -6,6 +6,8 @@ namespace: storetheindex
 resources:
   - ../../../../../base/heyfil
   - monitor.yaml
+  - pvc.yaml
+  - ingress.yaml
 
 patchesStrategicMerge:
   - deployment.yaml
@@ -13,4 +15,4 @@ patchesStrategicMerge:
 images:
   - name: heyfil
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/heyfil
-    newTag: 20230614095932-b27edd5517dd460dda4ea456cd55c323046df5c4
+    newTag: 20230706124905-cf3b03385090e32fdf35fd6974dbc8e881f1cab1

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/heyfil/pvc.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/heyfil/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: heyfil
+  name: heyfil
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 200Mi
+  storageClassName: gp3

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/heyfil/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/heyfil/deployment.yaml
@@ -7,6 +7,9 @@ spec:
     spec:
       containers:
         - name: heyfil
+          args:
+            - '--httpIndexerEndpoint=https://cid.contact'
+            - '--storePath=/store'
           resources:
             limits:
               cpu: "2"
@@ -14,4 +17,10 @@ spec:
             requests:
               cpu: "2"
               memory: 2Gi
-            
+          volumeMounts:
+            - name: store
+              mountPath: /store
+      volumes:
+        - name: store
+          persistentVolumeClaim:
+            claimName: heyfil

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/heyfil/ingress.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/heyfil/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: heyfil
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+spec:
+  tls:
+    - hosts:
+        - heyfil.cid.contact
+      secretName: heyfil-ingress-tls
+  rules:
+    - host: heyfil.cid.contact
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: heyfil
+                port:
+                  name: api

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/heyfil/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/heyfil/kustomization.yaml
@@ -6,6 +6,8 @@ namespace: storetheindex
 resources:
   - ../../../../../base/heyfil
   - monitor.yaml
+  - pvc.yaml
+  - ingress.yaml
 
 patchesStrategicMerge:
   - deployment.yaml
@@ -13,4 +15,4 @@ patchesStrategicMerge:
 images:
   - name: heyfil
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/heyfil
-    newTag: 20230614095932-b27edd5517dd460dda4ea456cd55c323046df5c4
+    newTag: 20230706124905-cf3b03385090e32fdf35fd6974dbc8e881f1cab1

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/heyfil/pvc.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/heyfil/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: heyfil
+  name: heyfil
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 200Mi
+  storageClassName: gp3


### PR DESCRIPTION
Deploy the latest HeyFil service on dev and prod that introduces a REST API for querying SP information as well as local storage for quick resumption of metrics on restart.

