### PR TITLE
Reduce dhstore stateless instances to 2

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-stateless/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-stateless/kustomization.yaml
@@ -15,7 +15,7 @@ patchesStrategicMerge:
 
 replicas:
   - name: dhstore
-    count: 3
+    count: 2
 
 images:
   - name: dhstore

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-stateless/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-stateless/kustomization.yaml
@@ -15,7 +15,7 @@ patchesStrategicMerge:
 
 replicas:
   - name: dhstore
-    count: 5
+    count: 2
 
 images:
   - name: dhstore


### PR DESCRIPTION
They are under utilised. Reduce the replica count to 2 on dev and prod.

