### PR TITLE
Separate FDB data distributors on prod

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
@@ -18,6 +18,7 @@ spec:
     log: 2
     coordinator: 3
     stateless: -1
+    data_distributor: 2
   labels:
     matchLabels:
       foundationdb.org/fdb-cluster-name: fdb-prod-cluster


### PR DESCRIPTION
Run dedicated data distributors on prod for FDB cluster in order to investigate OOM error on storage servers.

