### PR TITLE
Use new FDB indexers as providers backends.

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -16,10 +16,9 @@ spec:
             - '--providersBackends=http://inga-indexer:3000/'
             
             # New FDB-backed new indexers
-            # Excluded while load testing FoundationDB
-            # - '--providersBackends=http://arya-indexer:3000/'
-            # - '--providersBackends=http://bala-indexer:3000/'
-            # - '--providersBackends=http://cera-indexer:3000/'
+            - '--providersBackends=http://arya-indexer:3000/'
+            - '--providersBackends=http://bala-indexer:3000/'
+            - '--providersBackends=http://cera-indexer:3000/'
             
             # Remove old nodes since inga is largely caught up and other indexers may be further behind/forward.
             # This results in inconsistent responses and hard to debug issues.


### PR DESCRIPTION
This is necessary since there are 17 providers known to the fdb indexers that are not known to inga.

It is no longer necessary to remove these for FDB load testing, because the indexstar provider cache removes any significant query load.
