### PR TITLE
Recover FDB prod cluster from too many old generations

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
@@ -19,6 +19,7 @@ spec:
     coordinator: 3
     stateless: -1
     data_distributor: 2
+    ratekeeper: 2
   labels:
     matchLabels:
       foundationdb.org/fdb-cluster-name: fdb-prod-cluster
@@ -29,6 +30,8 @@ spec:
   minimumUptimeSecondsForBounce: 60
   processes:
     general:
+      customParameters:
+      - knob-max-generations-override=200
       volumeClaimTemplate:
         spec:
           storageClassName: gp3
@@ -49,6 +52,7 @@ spec:
         - knob_target_bytes_per_storage_server=2000e6
         # Defaults to 750e6
         - knob_target_bytes_per_storage_server_batch=1500e6
+        - knob-max-generations-override=200
       podTemplate:
         spec:
           topologySpreadConstraints:
@@ -81,8 +85,8 @@ spec:
               storage: 2Ti
     storage:
       customParameters:
-        - memory=28GiB
-        - cache-memory=5GiB
+        - memory=29GiB
+        - cache-memory=2GiB
         # Increase the default max outstanding IO operations (64), used in AIO with O_DIRECT interface.
         - knob_max_outstanding=256
         # Increase relocation and fetch keys parallelism to speed up data distribution across the cluster.
@@ -96,6 +100,7 @@ spec:
         - knob_rocksdb_background_parallelism=8
         - knob_rocksdb_read_parallelism=16
         - knob_rocksdb_checkpoint_reader_parallelism=16
+        - knob-max-generations-override=200
       podTemplate:
         spec:
           topologySpreadConstraints:


### PR DESCRIPTION
Self-recovery of the FDB nodes on prod was significantly delayed such that it halted ingestion. This was caused by growing write lag on the nodes and eventually knocked out the coordinators which resulted in the cluster being unresponsive.

To fix this, specific storage nodes with large lag were excluded, and the max generations was changed from 0 to 200.

The changes also introduce dedicated ratekeeper nodes to reduce load on storage servers.
