### PR TITLE
Upgrade production FDB to 7.3.7

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
@@ -3,7 +3,7 @@ kind: FoundationDBCluster
 metadata:
   name: fdb-prod-cluster
 spec:
-  version: 7.1.33
+  version: 7.3.7
   storageServersPerPod: 2
   automationOptions:
     replacements:


### PR DESCRIPTION
Investigating rocksdb storage engine memory leak problem. Upgrade the production FDB cluster to 7.3.7.
