### PR TITLE
Disable replace in prod fdb and undeploy dhstore stateless

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-stateless/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-stateless/kustomization.yaml
@@ -15,7 +15,7 @@ patchesStrategicMerge:
 
 replicas:
   - name: dhstore
-    count: 2
+    count: 0
 
 images:
   - name: dhstore

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
@@ -7,7 +7,7 @@ spec:
   storageServersPerPod: 2
   automationOptions:
     replacements:
-      enabled: true
+      enabled: false
   faultDomain:
     key: kubernetes.io/hostname
     valueFrom: spec.nodeName


### PR DESCRIPTION
While prod FDB is coming up, disable writes to it and disable replace instances.
