### PR TITLE
Refine prod FDB config to stay below max memory

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdb-cluster/cluster.yaml
@@ -81,22 +81,22 @@ spec:
               storage: 2Ti
     storage:
       customParameters:
-        - memory=25GiB
+        - memory=26GiB
         - cache-memory=2GiB
         # Increase the default max outstanding IO operations (64), used in AIO with O_DIRECT interface.
-        - knob_max_outstanding=256
+        - knob_max_outstanding=128
         # Increase relocation and fetch keys parallelism to speed up data distribution across the cluster.
         - knob_relocation_parallelism_per_source_server=8
-        - knob_fetch_keys_parallelism_bytes=5000000
-        - knob_max_queue_commit_bytes=30000000
-        - knob_storage_hard_limit_bytes=3000000000
-        - knob_target_bytes_per_storage_server=2000000000
-        - knob_target_bytes_per_storage_server_batch=1500000000
-        - knob_rocksdb_block_size=65536
-        - knob_rocksdb_block_cache_size=4294967296
-        - knob_rocksdb_compaction_readahead_size=65536
-        - knob_rocksdb_cf_write_buffer_size=134217728
-        - knob_rocksdb_write_buffer_size=2147483648
+        - knob_fetch_keys_parallelism_bytes=4500000
+        - knob_max_queue_commit_bytes=25000000
+        - knob_storage_hard_limit_bytes=2500000000
+        - knob_target_bytes_per_storage_server=1500000000
+        - knob_target_bytes_per_storage_server_batch=1000000000
+        - knob_rocksdb_block_size=32768
+        - knob_rocksdb_block_cache_size=2147483648
+        - knob_rocksdb_compaction_readahead_size=32768
+        - knob_rocksdb_cf_write_buffer_size=67108864
+        - knob_rocksdb_write_buffer_size=1073741824
         - knob_rocksdb_background_parallelism=8
         - knob_rocksdb_read_parallelism=16
         - knob_rocksdb_checkpoint_reader_parallelism=16


### PR DESCRIPTION
Refine the prod FDB knobs such that total memory consumption remains below max.
