### PR TITLE
Resume dhstore stateless on prod and upgrade to FDB client library 7.3.7

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-stateless/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-stateless/deployment.yaml
@@ -15,7 +15,7 @@ spec:
             - '--providersURL=http://indexstar:8080/'
             - '--storeType=fdb'
             - '--fdbClusterFile=/config/cluster-file'
-            - '--fdbApiVersion=710'
+            - '--fdbApiVersion=730'
           resources:
             limits:
               cpu: "3"

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-stateless/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-stateless/kustomization.yaml
@@ -15,9 +15,9 @@ patchesStrategicMerge:
 
 replicas:
   - name: dhstore
-    count: 0
+    count: 2
 
 images:
   - name: dhstore
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
-    newTag: 20230711090901-4007d7934c3c308f98fd06d9253ba50c13339689
+    newTag: 20230718102059-38bdb04f3b6d4796eaa54c5c58a73bc3e1fa76e4

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdbmeter/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/fdbmeter/kustomization.yaml
@@ -9,3 +9,7 @@ resources:
 
 patchesStrategicMerge:
   - deployment.yaml
+
+images:
+  - name: ghcr.io/masih/fdbmeter
+    newTag: sha-b83c2fdecd3cdefb847298b6deced3b999403a90


### PR DESCRIPTION
FDB cluster in prod is back up and running. Resume write traffic. Upgrade fdbmeter and dhstore to use the latest compatible FDB client libraries.

