### PR TITLE
Point `inga` to dhstore-helga while dhstore-qiu is recovering

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-qiu/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-qiu/deployment.yaml
@@ -12,10 +12,16 @@ spec:
             - '--storePath=/data'
             - '--disableWAL'
             - '--blockCacheSize=2Gi'
-            # Set max concurrent compactions to the number of CPUs
-            - '--maxConcurrentCompactions=28'
-            # Bump from the default 12
-            - '--l0StopWritesThreshold=20'
+            - '--maxConcurrentCompactions=20'
+            - '--experimentalCompactionDebtConcurrency=100Gi'
+            - '--experimentalL0CompactionConcurrency=500'
+            # experimenting with higher threshold and impact of compaction on writes. 
+            - '--l0StopWritesThreshold=1000'
+            - '--l0CompactionThreshold=1000'
+            - '--l0CompactionFileThreshold=1000'
+          env:
+            - name: GO_DEBUG_MAX_THREADS
+              value: "20000"
           volumeMounts:
             - name: data
               mountPath: /data

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-qiu/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-qiu/kustomization.yaml
@@ -19,4 +19,4 @@ patchesStrategicMerge:
 images:
   - name: dhstore
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
-    newTag: 20230711090901-4007d7934c3c308f98fd06d9253ba50c13339689
+    newTag: 20230719142939-cabc46a1d6076ccc62eae4475ac52b798b056b8e

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
@@ -60,10 +60,10 @@
     "ValueStoreType": "none",
     "DisableWAL": true,
     "DHBatchSize": 16384,
-    "DHStoreURL": "http://dhstore-qiu:40080",
+    "DHStoreURL": "http://dhstore-helga.internal.prod.cid.contact",
     "DHStoreClusterURLs": [
       "http://dhstore.internal.prod.cid.contact",
-      "http://dhstore-helga.internal.prod.cid.contact",
+      "http://dhstore-qiu:40080",
       "http://dhstore-porvy.internal.prod.cid.contact"
     ],
     "DHStoreHttpClientTimeout": "60s"


### PR DESCRIPTION
Swap inga's dhstore with one that has free space with no compaction debt
while qiu is recovering.

Set compaction threshold on qui for experimentation and update the the
latest image that understands the new flags.
