### PR TITLE
Move helga to larger instances

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-helga/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-helga/deployment.yaml
@@ -27,11 +27,11 @@ spec:
               mountPath: /data
           resources:
             limits:
-              cpu: "7"
-              memory: 16Gi
+              cpu: "28"
+              memory: 58Gi
             requests:
-              cpu: "7"
-              memory: 16Gi
+              cpu: "28"
+              memory: 58Gi
           ports:
             - containerPort: 40081
               name: metrics
@@ -43,7 +43,7 @@ spec:
                   - key: node.kubernetes.io/instance-type
                     operator: In
                     values:
-                      - r5n.2xlarge
+                      - c6a.8xlarge
                   - key: topology.kubernetes.io/zone
                     operator: In
                     values:
@@ -52,9 +52,4 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: dhstore-data-helga
-      tolerations:
-        - key: dedicated
-          operator: Equal
-          value: r5n-2xl
-          effect: NoSchedule
 

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-helga/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-helga/kustomization.yaml
@@ -19,4 +19,4 @@ patchesStrategicMerge:
 images:
   - name: dhstore
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
-    newTag: 20230711090901-4007d7934c3c308f98fd06d9253ba50c13339689
+    newTag: 20230719142939-cabc46a1d6076ccc62eae4475ac52b798b056b8e


### PR DESCRIPTION
To avoid OOM killing of the process move it to larger instances and give it more resource.

While at it, upgrade it to the latest dhstore.
