### PR TITLE
Expand prod dhstore pvc for maximum headroom

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/pvc-gp3.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/pvc-gp3.yaml
@@ -7,7 +7,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 15Ti
+      storage: 16Ti
   dataSource:
     name: dhstore-20230427
     kind: VolumeSnapshot


### PR DESCRIPTION
Increase dhstore PVC to 16Ti so that if we need to switch to it, it has max head room.

