### PR TITLE
Reduce compaction thresholds back on `qui`

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-qiu/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-qiu/deployment.yaml
@@ -13,12 +13,11 @@ spec:
             - '--disableWAL'
             - '--blockCacheSize=2Gi'
             - '--maxConcurrentCompactions=20'
-            - '--experimentalCompactionDebtConcurrency=100Gi'
-            - '--experimentalL0CompactionConcurrency=500'
-            # experimenting with higher threshold and impact of compaction on writes. 
-            - '--l0StopWritesThreshold=1000'
-            - '--l0CompactionThreshold=1000'
-            - '--l0CompactionFileThreshold=1000'
+            - '--experimentalCompactionDebtConcurrency=1Gi'
+            - '--experimentalL0CompactionConcurrency=10'
+            - '--l0StopWritesThreshold=12'
+            - '--l0CompactionThreshold=4'
+            - '--l0CompactionFileThreshold=500'
           env:
             - name: GO_DEBUG_MAX_THREADS
               value: "20000"


### PR DESCRIPTION
After experimentation, it seems parallelism of 20 on the current node type that qiu is running on yields fast enough compaction debt catch up at the rate of ~40GiB per hour.

Reducing compaction thresholds back down to keep compaction as aggressive as before. We may need to reduce these further depending on write load. For now the limits seem to result in a stable read amplification (on helga) which uses the same thresholds as default values.

