### PR TITLE
Increase sensitivity to read amplification relative to compaction

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-helga/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-helga/deployment.yaml
@@ -22,6 +22,12 @@ spec:
             - '--storePath=/data'
             - '--disableWAL'
             - '--blockCacheSize=2Gi'
+            - '--maxConcurrentCompactions=20'
+            - '--experimentalCompactionDebtConcurrency=1Gi'
+            - '--experimentalL0CompactionConcurrency=10'
+            - '--l0StopWritesThreshold=8'
+            - '--l0CompactionThreshold=3'
+            - '--l0CompactionFileThreshold=300'
           volumeMounts:
             - name: data
               mountPath: /data

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-qiu/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-qiu/deployment.yaml
@@ -15,9 +15,9 @@ spec:
             - '--maxConcurrentCompactions=20'
             - '--experimentalCompactionDebtConcurrency=1Gi'
             - '--experimentalL0CompactionConcurrency=10'
-            - '--l0StopWritesThreshold=12'
-            - '--l0CompactionThreshold=4'
-            - '--l0CompactionFileThreshold=500'
+            - '--l0StopWritesThreshold=8'
+            - '--l0CompactionThreshold=3'
+            - '--l0CompactionFileThreshold=300'
           env:
             - name: GO_DEBUG_MAX_THREADS
               value: "20000"


### PR DESCRIPTION
Reduce the threshold at which compaction is triggered and stop writes
more aggressively if compaction is not keeping up.

Set the config for both `helga` and `qiu`.

These changes need to be experimented with to see impact on ingest rate
first.

**Do not merge until the current compaction debt and provider lag is
caught up.**
