### PR TITLE
Revert "Deploy latest indexer to ago (#2153)"

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/instances/ago/kustomization.yaml
@@ -31,4 +31,4 @@ patchesStrategicMerge:
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}
-  newTag: 20230725214852-50377dbdada1d9dfb69fd455b91a6a5fa7da6507
+  newTag: 20230713175039-e46f6e6bd679c9fcd9eaf3e2663f27f33bbc8eeb


### PR DESCRIPTION
This reverts commit 47f38668349b716898d6a4949fa8f745e431f6ee.

Bootstrapping in kubo v0.21.0 seems to be broken.