### PR TITLE
Create a new dhstore node in dev since dhstore-ago2 is out of space

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago3/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago3/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dhstore
+spec:
+  selector:
+    matchLabels:
+      app: dhstore-ago3
+  template:
+    metadata:
+      labels:
+        app: dhstore-ago3
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+      containers:
+        - name: dhstore
+          args:
+            - '--providersURL=http://ago-indexer:3000/'
+            - '--storePath=/data'
+            - '--disableWAL'
+            - '--blockCacheSize=2Gi'
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            limits:
+              cpu: "7"
+              memory: 60Gi
+            requests:
+              cpu: "7"
+              memory: 60Gi
+          ports:
+            - containerPort: 40081
+              name: metrics
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.kubernetes.io/instance-type
+                    operator: In
+                    values:
+                      - r5n.2xlarge
+                  - key: topology.kubernetes.io/zone
+                    operator: In
+                    values:
+                      - us-east-2c    
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: dhstore-data-ago3
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: r5n-2xl
+          effect: NoSchedule
+

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago3/internal-service.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago3/internal-service.yaml
@@ -1,0 +1,26 @@
+# DHStore internal service, accessible only within K8S cluster VPC via:
+#  - http://dhstore-ago3.internal.dev.cid.contact
+#
+# See: https://github.com/ipni/dhstore
+kind: Service
+apiVersion: v1
+metadata:
+  name: dhstore-internal
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internal
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+    external-dns.alpha.kubernetes.io/access: private
+    external-dns.alpha.kubernetes.io/hostname: dhstore-ago3.internal.dev.cid.contact
+  labels:
+    app: dhstore-ago3
+spec:
+  externalTrafficPolicy: Cluster
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+  selector:
+    app: dhstore-ago3
+  type: LoadBalancer

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago3/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago3/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: storetheindex
+
+resources:
+  - github.com/ipni/dhstore/deploy/kubernetes?ref=58dfcad7aae9c172c68237dad25494625d8ac160
+  - pvc.yaml
+  - internal-service.yaml
+  - pod-monitor.yaml
+
+nameSuffix: -ago3
+
+patchesStrategicMerge:
+  - deployment.yaml
+  - service.yaml
+
+images:
+  - name: dhstore
+    newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
+    newTag: 20230725203839-16357fe9f5951e0e0ca9c18044b017cdd392de93

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago3/pod-monitor.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago3/pod-monitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: dhstore
+  labels:
+    app: dhstore-ago3
+spec:
+  selector:
+    matchLabels:
+      app: dhstore-ago3
+  namespaceSelector:
+    matchNames:
+      - storetheindex
+  podMetricsEndpoints:
+    - path: /metrics
+      port: metrics

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago3/pvc.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago3/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dhstore-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 16Ti
+  storageClassName: gp3-iops5k-t300

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago3/service.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago3/service.yaml
@@ -1,0 +1,9 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: dhstore
+  labels:
+    app: dhstore-ago3
+spec:
+  selector:
+    app: dhstore-ago3

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - indexstar
 - dhstore
 - dhstore-ago2
+- dhstore-ago3
 - caskadht
 - snapshots
 - lookout


### PR DESCRIPTION
After it is created and running, a following PR will switch ago-indexer and indexstar to use it.
