### PR TITLE
Do not add extra newline after json records

### DIFF
--- a/server/find/server.go
+++ b/server/find/server.go
@@ -29,10 +29,7 @@ import (
 	xnet "golang.org/x/net/netutil"
 )
 
-var (
-	log     = logging.Logger("indexer/find")
-	newline = []byte("\n")
-)
+var log = logging.Logger("indexer/find")
 
 type Server struct {
 	server    *http.Server
@@ -363,10 +360,6 @@ func (s *Server) getIndexes(w http.ResponseWriter, mhs []multihash.Multihash, st
 		for _, result := range pr {
 			if err := encoder.Encode(result); err != nil {
 				log.Errorw("Failed to encode streaming response", "err", err)
-				break
-			}
-			if _, err := w.Write(newline); err != nil {
-				log.Errorw("failed to write newline while streaming results", "err", err)
 				break
 			}
 			// TODO: optimise the number of time we call flush based on some time-based or result

--- a/server/find/server_test.go
+++ b/server/find/server_test.go
@@ -196,7 +196,6 @@ func TestServer_StreamingResponse(t *testing.T) {
 			reqAccept:       "application/x-ndjson,application/xhtml+xml,application/xml;q=0.9",
 			wantContentType: "application/x-ndjson",
 			wantResponseBody: `{"ContextID":"ZmlzaA==","Metadata":"bG9ic3Rlcg==","Provider":{"ID":"12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA","Addrs":["/ip4/127.0.0.1/tcp/9999"]}}
-
 `,
 			wantResponseStatus: http.StatusOK,
 		},
@@ -214,7 +213,6 @@ func TestServer_StreamingResponse(t *testing.T) {
 			reqAccept:       "ext/html,application/xhtml+xml,application/xml;q=0.9,application/x-ndjson",
 			wantContentType: "application/x-ndjson",
 			wantResponseBody: `{"ContextID":"ZmlzaA==","Metadata":"bG9ic3Rlcg==","Provider":{"ID":"12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA","Addrs":["/ip4/127.0.0.1/tcp/9999"]}}
-
 `,
 			wantResponseStatus: http.StatusOK,
 		},


### PR DESCRIPTION
json.Encoder.Encode already adds a newline after each record: https://pkg.go.dev/encoding/json#Encoder.Encode

