### PR TITLE
Exclude FDB indexers from serving as providers backends

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -16,9 +16,9 @@ spec:
             - '--providersBackends=http://inga-indexer:3000/'
             
             # New FDB-backed new indexers
-            - '--providersBackends=http://arya-indexer:3000/'
-            - '--providersBackends=http://bala-indexer:3000/'
-            - '--providersBackends=http://cera-indexer:3000/'
+            #- '--providersBackends=http://arya-indexer:3000/'
+            #- '--providersBackends=http://bala-indexer:3000/'
+            #- '--providersBackends=http://cera-indexer:3000/'
             
             # Remove old nodes since inga is largely caught up and other indexers may be further behind/forward.
             # This results in inconsistent responses and hard to debug issues.


### PR DESCRIPTION
Indexstar star is picking up providers from these indexers, which all have errors writing to the offline FDB storage. This is causing false reporting for provider errors from the providers/ endpoint. This PR updates indexstar to not get provider updates from these indexers.
