### PR TITLE
Include telemetry service in dev deploy manifests

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 - lookout
 - cassette
 - heyfil
+- telemetry
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}


### PR DESCRIPTION
The new telemetry service was added but not included in the kustomization that gets applied by flux CD. Add it to trigger deployment.
