### PR TITLE
Add noop indexer to assigner to avoid crash loopback

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/assigner/config.json
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/assigner/config.json
@@ -7,6 +7,11 @@
   "Assignment": {
     "FilterIPs": false,
     "IndexerPool": [
+      {
+        "AdminURL": "http://noop-indexer:3002",
+        "FindURL": "http://noop-indexer:3000",
+        "IngestURL": "http://noop-indexer:3001"
+      }
     ],
     "Policy": {
       "Allow": true,


### PR DESCRIPTION
Assigner requires at least one indexer. Until that condition is relaxed
, add a fake indexer sot that the service starts.

See:
 - https://github.com/ipni/storetheindex/issues/2168
