### PR TITLE
Fix telemetry memory use by removing concurrent distance tracking

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/telemetry/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/telemetry/deployment.yaml
@@ -13,14 +13,14 @@ spec:
         - name: telemetry
           args:
             - '-providersURL=http://indexstar:8080/'
-            - '-maxDepth=200'
+            - '-maxDepth=10000'
             - '-updateIn=2m'
             - '-listenAddr=0.0.0.0:40080'
             - '-metricsAddr=0.0.0.0:40081'
           resources:
             limits:
               cpu: "1"
-              memory: 6Gi
+              memory: 5Gi
             requests:
               cpu: "1"
-              memory: 6Gi
+              memory: 5Gi

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/telemetry/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/telemetry/kustomization.yaml
@@ -13,5 +13,5 @@ patchesStrategicMerge:
 images:
   - name: telemetry
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/telemetry
-    newTag: 20230728043540-5b26513f01e282ee4eac5efd1e93b4f58dc41641
+    newTag: 20230728164452-85e2fe951b59409804b2e1581ec85f76ee552e10
 


### PR DESCRIPTION
- Expand depth limit to 10000
- Use less memory CPU
