### PR TITLE
Fix panic due to unassigned bootstrap config functions

### DIFF
--- a/assigner/command/daemon.go
+++ b/assigner/command/daemon.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -17,6 +18,7 @@ import (
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/urfave/cli/v2"
 )
@@ -233,6 +235,10 @@ func startBootstrapper(cfg sticfg.Bootstrap, p2pHost host.Host) (io.Closer, erro
 
 	bootCfg := bootstrap.BootstrapConfigWithPeers(addrs)
 	bootCfg.MinPeerThreshold = cfg.MinimumPeers
+
+	// Kubo does not allow these to be nil, so set empty functions.
+	bootCfg.LoadBackupBootstrapPeers = func(_ context.Context) []peer.AddrInfo { return nil }
+	bootCfg.SaveBackupBootstrapPeers = func(_ context.Context, _ []peer.AddrInfo) {}
 
 	return bootstrap.Bootstrap(p2pHost.ID(), p2pHost, nil, bootCfg)
 }


### PR DESCRIPTION
Need this because of https://github.com/ipfs/kubo/issues/10030.

Can be removed when https://github.com/ipfs/kubo/pull/10029 is available.
