### PR TITLE
Update to latest version of go-libipni

### DIFF
--- a/assigner/command/daemon.go
+++ b/assigner/command/daemon.go
@@ -104,6 +104,7 @@ func daemonAction(cctx *cli.Context) error {
 		if err != nil {
 			return err
 		}
+		defer p2pHost.Close()
 
 		bootstrapper, err := startBootstrapper(cfg.Bootstrap, p2pHost)
 		if err != nil {

--- a/command/daemon.go
+++ b/command/daemon.go
@@ -231,6 +231,7 @@ func daemonAction(cctx *cli.Context) error {
 		if err != nil {
 			return err
 		}
+		defer p2pHost.Close()
 
 		// Do not resend direct announce messages if using an assigner service.
 		if cfg.Discovery.UseAssigner {

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/ipld/go-ipld-prime v0.20.0
 	github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd
 	github.com/ipni/go-indexer-core v0.8.0
-	github.com/ipni/go-libipni v0.3.1
+	github.com/ipni/go-libipni v0.3.2
 	github.com/libp2p/go-libp2p v0.29.0
 	github.com/libp2p/go-msgio v0.3.0
 	github.com/mitchellh/go-homedir v1.1.0
@@ -116,7 +116,7 @@ require (
 	github.com/ipfs/bbloom v0.0.4 // indirect
 	github.com/ipfs/go-block-format v0.1.2 // indirect
 	github.com/ipfs/go-blockservice v0.5.1 // indirect
-	github.com/ipfs/go-graphsync v0.14.6 // indirect
+	github.com/ipfs/go-graphsync v0.14.7 // indirect
 	github.com/ipfs/go-ipfs-blockstore v1.3.0 // indirect
 	github.com/ipfs/go-ipfs-chunker v0.0.5 // indirect
 	github.com/ipfs/go-ipfs-ds-help v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -489,8 +489,8 @@ github.com/ipfs/go-ds-leveldb v0.4.1/go.mod h1:jpbku/YqBSsBc1qgME8BkWS4AxzF2cEu1
 github.com/ipfs/go-ds-leveldb v0.4.2/go.mod h1:jpbku/YqBSsBc1qgME8BkWS4AxzF2cEu1Ii2r79Hh9s=
 github.com/ipfs/go-ds-leveldb v0.5.0 h1:s++MEBbD3ZKc9/8/njrn4flZLnCuY9I79v94gBUNumo=
 github.com/ipfs/go-ds-leveldb v0.5.0/go.mod h1:d3XG9RUDzQ6V4SHi8+Xgj9j1XuEk1z82lquxrVbml/Q=
-github.com/ipfs/go-graphsync v0.14.6 h1:NPxvuUy4Z08Mg8dwpBzwgbv/PGLIufSJ1sle6iAX8yo=
-github.com/ipfs/go-graphsync v0.14.6/go.mod h1:yT0AfjFgicOoWdAlUJ96tQ5AkuGI4r1taIQX/aHbBQo=
+github.com/ipfs/go-graphsync v0.14.7 h1:V90NORSdCpUHAgqQhApU/bmPSLOnwtSHM2v7R90k9Do=
+github.com/ipfs/go-graphsync v0.14.7/go.mod h1:yT0AfjFgicOoWdAlUJ96tQ5AkuGI4r1taIQX/aHbBQo=
 github.com/ipfs/go-ipfs-blockstore v0.0.1/go.mod h1:d3WClOmRQKFnJ0Jz/jj/zmksX0ma1gROTlovZKBmN08=
 github.com/ipfs/go-ipfs-blockstore v0.1.0/go.mod h1:5aD0AvHPi7mZc6Ci1WCAhiBQu2IsfTduLl+422H6Rqw=
 github.com/ipfs/go-ipfs-blockstore v0.1.4/go.mod h1:Jxm3XMVjh6R17WvxFEiyKBLUGr86HgIYJW/D/MwqeYQ=
@@ -592,8 +592,8 @@ github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236
 github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd/go.mod h1:9DD/GM0JNPoisgR09F62kbBi7kHa4eDIea4XshXYOVc=
 github.com/ipni/go-indexer-core v0.8.0 h1:HPFMngR47FL49mVnOZBrcxJoRODjIadlP+UYMRboNKA=
 github.com/ipni/go-indexer-core v0.8.0/go.mod h1:Y9su+no9k6y+jnQRERP/CKJewdISHzzl+n91GA+y4Ao=
-github.com/ipni/go-libipni v0.3.1 h1:zCq9UXrvVL4NAxyumPGHboUAGraNfmkDC16BAoQGrww=
-github.com/ipni/go-libipni v0.3.1/go.mod h1:2zyo+mgV+E1T0n6eGmef7+uEt0awOpIhqONfz9ZPtNo=
+github.com/ipni/go-libipni v0.3.2 h1:pzCoWQIefTkIZ0ob2BXCkIxnGoIKIMJOudvt/UgyMJk=
+github.com/ipni/go-libipni v0.3.2/go.mod h1:9APtwq1JhcpyEjVsbi8f87nkUtxQcQXokU/HNY7B9g0=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/i18n v0.0.0-20171121225848-987a633949d0/go.mod h1:pMCz62A0xJL6I+umB2YTlFRwWXaDFA0jy+5HzGiJjqI=

--- a/server/admin/server_test.go
+++ b/server/admin/server_test.go
@@ -303,6 +303,9 @@ func initIngest(t *testing.T, indx indexer.Interface, reg *registry.Registry) *i
 	dsTmp := dssync.MutexWrap(datastore.NewMapDatastore())
 	host, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		host.Close()
+	})
 
 	ing, err := ingest.NewIngester(cfg, host, indx, reg, ds, dsTmp)
 	require.NoError(t, err)

--- a/server/ingest/handler_test.go
+++ b/server/ingest/handler_test.go
@@ -77,6 +77,7 @@ func TestHandleRegisterProvider(t *testing.T) {
 
 	host, err := libp2p.New()
 	require.NoError(t, err)
+	defer host.Close()
 
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
 	dsTmp := dssync.MutexWrap(datastore.NewMapDatastore())

--- a/server/ingest/protocol_test.go
+++ b/server/ingest/protocol_test.go
@@ -140,6 +140,7 @@ func initIngest(t *testing.T, indx indexer.Interface, reg *registry.Registry) *i
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		ing.Close()
+		host.Close()
 	})
 	return ing
 }


### PR DESCRIPTION
## Context
Need to update go-libipni because it contains a fix for a graphsync deadlock

## Proposed Changes
- Includes fix for graphsync deadlock
- Tests close libp2p hosts

## Tests
No new tests needed

## Revert Strategy
Change is safe to revert.
