### PR TITLE
Remove unspecified addresses from announcements and ads

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/ipld/go-ipld-prime v0.20.0
 	github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd
 	github.com/ipni/go-indexer-core v0.8.0
-	github.com/ipni/go-libipni v0.3.2
+	github.com/ipni/go-libipni v0.3.3
 	github.com/libp2p/go-libp2p v0.29.0
 	github.com/libp2p/go-msgio v0.3.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -592,8 +592,8 @@ github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236
 github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd/go.mod h1:9DD/GM0JNPoisgR09F62kbBi7kHa4eDIea4XshXYOVc=
 github.com/ipni/go-indexer-core v0.8.0 h1:HPFMngR47FL49mVnOZBrcxJoRODjIadlP+UYMRboNKA=
 github.com/ipni/go-indexer-core v0.8.0/go.mod h1:Y9su+no9k6y+jnQRERP/CKJewdISHzzl+n91GA+y4Ao=
-github.com/ipni/go-libipni v0.3.2 h1:pzCoWQIefTkIZ0ob2BXCkIxnGoIKIMJOudvt/UgyMJk=
-github.com/ipni/go-libipni v0.3.2/go.mod h1:9APtwq1JhcpyEjVsbi8f87nkUtxQcQXokU/HNY7B9g0=
+github.com/ipni/go-libipni v0.3.3 h1:Of8y97uPMmuN+oWS7EfQRmpawg/u7XYYcIcUCu2EgVE=
+github.com/ipni/go-libipni v0.3.3/go.mod h1:9APtwq1JhcpyEjVsbi8f87nkUtxQcQXokU/HNY7B9g0=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/i18n v0.0.0-20171121225848-987a633949d0/go.mod h1:pMCz62A0xJL6I+umB2YTlFRwWXaDFA0jy+5HzGiJjqI=

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -675,8 +675,8 @@ func (r *Registry) Update(ctx context.Context, provider, publisher peer.AddrInfo
 	}
 
 	if r.filterIPs {
-		provider.Addrs = mautil.FilterPrivateIPs(provider.Addrs)
-		publisher.Addrs = mautil.FilterPrivateIPs(publisher.Addrs)
+		provider.Addrs = mautil.FilterPublic(provider.Addrs)
+		publisher.Addrs = mautil.FilterPublic(publisher.Addrs)
 	}
 
 	var newPublisher bool
@@ -1385,9 +1385,9 @@ func loadPersistedProviders(ctx context.Context, dstore datastore.Datastore, fil
 		}
 
 		if filterIPs {
-			pinfo.AddrInfo.Addrs = mautil.FilterPrivateIPs(pinfo.AddrInfo.Addrs)
+			pinfo.AddrInfo.Addrs = mautil.FilterPublic(pinfo.AddrInfo.Addrs)
 			if pinfo.Publisher.Validate() == nil && pinfo.PublisherAddr != nil {
-				pubAddrs := mautil.FilterPrivateIPs([]multiaddr.Multiaddr{pinfo.PublisherAddr})
+				pubAddrs := mautil.FilterPublic([]multiaddr.Multiaddr{pinfo.PublisherAddr})
 				if len(pubAddrs) == 0 {
 					pinfo.PublisherAddr = nil
 				} else {


### PR DESCRIPTION
## Context
Unspecified addresses, [::] and "0.0.0.0", need to be removed from the publisher addresses in announcement messages and from the provider addresses in advertisements.

This is currently causing sync failures when trying to access these addresses to get advertisements from, now that at least one provider is including such addresses in its announce messages.  Also, these addresses are unusable by retrieval clients that may receive these in index query responses.

## Proposed Changes
Update to a later version of go-libipni that has this address filtering fix.

## Tests
Tests are included in `go-libipni/mautil`

## Revert Strategy
Change is safe to revert.
