### PR TITLE
Switch dhstore backend to investigating degraded ingest

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
@@ -60,9 +60,9 @@
     "ValueStoreType": "none",
     "DisableWAL": true,
     "DHBatchSize": 16384,
-    "DHStoreURL": "http://dhstore-qiu:40080",
+    "DHStoreURL": "http://dhstore-helga.internal.prod.cid.contact",
     "DHStoreClusterURLs": [
-      "http://dhstore-helga.internal.prod.cid.contact",
+      "http://dhstore-qiu:40080",
       "http://dhstore.internal.prod.cid.contact",
       "http://dhstore-porvy.internal.prod.cid.contact"
     ],


### PR DESCRIPTION
Switch inga from qiu dhstore to helga in order to determine if the slow ingest is caused by dhstore backend or not.
