### PR TITLE
Reduce termination grace period for indexers to 3 minutes

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/deployment.yaml
@@ -6,7 +6,11 @@ spec:
   template:
     spec:
       serviceAccountName: storetheindex
-      terminationGracePeriodSeconds: 600
+      # Wait at most 3 minutes for storetheindex process to exit.
+      # This value used to be 10 minutes which we hit every time the shutdown took longer than 3 minutes.
+      # The most likely cause for this is lingering GraphSync syncs which do not clear after 10 minutes of wait,
+      # hence no point to wait that long.
+      terminationGracePeriodSeconds: 180
       containers:
         - name: indexer
           volumeMounts:


### PR DESCRIPTION
This value used to be 10 minutes which we hit every time the shutdown took longer than 3 minutes. The most likely cause for this is lingering GraphSync syncs which do not clear after 10 minutes of wait, hence no point to wait that long.
