### PR TITLE
Configurable max async ad syncs concurrency

### DIFF
--- a/assigner/core/assigner.go
+++ b/assigner/core/assigner.go
@@ -435,7 +435,7 @@ func (a *Assigner) Allowed(peerID peer.ID) bool {
 // Announce sends a direct announce message to the assigner. This publisher in
 // the message will be assigned to one or more indexers.
 func (a *Assigner) Announce(ctx context.Context, nextCid cid.Cid, addrInfo peer.AddrInfo) error {
-	return a.receiver.Direct(ctx, nextCid, addrInfo.ID, addrInfo.Addrs)
+	return a.receiver.Direct(ctx, nextCid, addrInfo)
 }
 
 // Assigned returns the indexers that the given peer is assigned to.

--- a/command/loadgen/loadgen.go
+++ b/command/loadgen/loadgen.go
@@ -20,7 +20,7 @@ import (
 	"github.com/ipni/go-libipni/announce/p2psender"
 	"github.com/ipni/go-libipni/dagsync"
 	"github.com/ipni/go-libipni/dagsync/dtsync"
-	"github.com/ipni/go-libipni/dagsync/httpsync"
+	"github.com/ipni/go-libipni/dagsync/ipnisync"
 	ingestclient "github.com/ipni/go-libipni/ingest/client"
 	"github.com/ipni/go-libipni/ingest/schema"
 	"github.com/libp2p/go-libp2p"
@@ -140,7 +140,7 @@ func newProviderLoadGen(c Config, indexerHttpAddr string, addressMapping map[str
 
 	var pub dagsync.Publisher
 	if c.IsHttp {
-		pub, err = httpsync.NewPublisher(c.HttpListenAddr, lsys, signingKey)
+		pub, err = ipnisync.NewPublisher(c.HttpListenAddr, lsys, signingKey)
 	} else {
 		pub, err = dtsync.NewPublisher(host, ds, lsys, c.GossipSubTopic)
 	}

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -52,6 +52,9 @@ type Ingest struct {
 	// IngestWorkerCount sets how many ingest worker goroutines to spawn. This
 	// controls how many concurrent ingest from different providers we can handle.
 	IngestWorkerCount int
+	// MaxAsyncConcurrency sets the maximum number of concurrent asynchrouous syncs
+	// (started by announce messages). Set -1 for unlimited, 0 for default.
+	MaxAsyncConcurrency int
 	// MinimumKeyLengt causes any multihash, that has a digest length less than
 	// this, to be ignored.
 	MinimumKeyLength int
@@ -134,6 +137,7 @@ func NewIngest() Ingest {
 		HttpSyncRetryWaitMin:  Duration(1 * time.Second),
 		HttpSyncTimeout:       Duration(10 * time.Second),
 		IngestWorkerCount:     10,
+		MaxAsyncConcurrency:   32,
 		PubSubTopic:           "/indexer/ingest/mainnet",
 		SyncSegmentDepthLimit: 2_000,
 		SyncTimeout:           Duration(2 * time.Hour),
@@ -173,6 +177,9 @@ func (c *Ingest) populateUnset() {
 	}
 	if c.IngestWorkerCount == 0 {
 		c.IngestWorkerCount = def.IngestWorkerCount
+	}
+	if c.MaxAsyncConcurrency == 0 {
+		c.MaxAsyncConcurrency = def.MaxAsyncConcurrency
 	}
 	if c.PubSubTopic == "" {
 		c.PubSubTopic = def.PubSubTopic

--- a/doc/ingest.md
+++ b/doc/ingest.md
@@ -149,7 +149,7 @@ The IPLD objects of advertisements and entries are represented as files named as
 The `head` protocol is the same as above, but not wrapped in a libp2p multiprotocol.
 A client wanting to know the latest advertisement CID will ask for the file named `head` in the same directory as the advertisements/entries, and will expect back a signed response for the current head.
 
-An implementation of the core HTTP content advertisement publisher is available as [httpsync/publisher](https://pkg.go.dev/github.com/ipni/go-libipni/dagsync/httpsync#Publisher). This used to build the full provider implementation available in [index-provider](https://github.com/ipni/index-provider).
+An implementation of the core HTTP content advertisement publisher is available as [ipnisync/publisher](https://pkg.go.dev/github.com/ipni/go-libipni/dagsync/ipnisync#Publisher). This used to build the full provider implementation available in [index-provider](https://github.com/ipni/index-provider).
 
 ## Announcements
 
@@ -169,7 +169,7 @@ There are two ways that a provider may proactively alert indexer(s) of new conte
 
 Both of these methods send a [`Message`](https://pkg.go.dev/github.com/ipni/go-libipni/announce/message#Message) to the indexer to announce the availability of a new advertisement. This message contains the CID of the head and the multiaddrs (libp2p and/or HTTP) of the host where the advertisement can be fetched from.
 
-The dagsync [`dtsync/Publisher`]([dtsync/publisher](https://pkg.go.dev/github.com/ipni/go-libipni/dagsync/dtsync#Publisher)) and [`httpsync/Publisher`](https://pkg.go.dev/github.com/ipni/go-libipni/dagsync/httpsync#Publisher) generate announcements automatically using the [`Sender`](https://pkg.go.dev/github.com/ipni/go-libipni/announce#Sender) instances they are configured with. These Senders can consist of both [p2psender](https://pkg.go.dev/github.com/ipni/go-libipni/announce/p2psender) and [httpsender](https://pkg.go.dev/github.com/ipni/go-libipni/announce/httpsender) types.
+The dagsync [`dtsync/Publisher`]([dtsync/publisher](https://pkg.go.dev/github.com/ipni/go-libipni/dagsync/dtsync#Publisher)) and [`ipnisync/Publisher`](https://pkg.go.dev/github.com/ipni/go-libipni/dagsync/ipnisync#Publisher) generate announcements automatically using the [`Sender`](https://pkg.go.dev/github.com/ipni/go-libipni/announce#Sender) instances they are configured with. These Senders can consist of both [p2psender](https://pkg.go.dev/github.com/ipni/go-libipni/announce/p2psender) and [httpsender](https://pkg.go.dev/github.com/ipni/go-libipni/announce/httpsender) types.
 
 ### Gossipsub
 

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -206,7 +206,7 @@ func TestEndToEndWithReferenceProvider(t *testing.T) {
 	e.run("go", "install", "github.com/ipni/index-provider/cmd/provider@latest")
 
 	// install dhstore
-	e.run("go", "install", "github.com/ipni/dhstore/cmd/dhstore@v0.0.2")
+	e.run("go", "install", "-tags", "nofdb", "github.com/ipni/dhstore/cmd/dhstore@latest")
 
 	// install ipni-cli
 	e.run("go", "install", "github.com/ipni/ipni-cli/cmd/ipni@latest")

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/ipld/go-ipld-prime v0.20.0
 	github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd
 	github.com/ipni/go-indexer-core v0.8.0
-	github.com/ipni/go-libipni v0.3.5-0.20230815222902-f322558bba48
+	github.com/ipni/go-libipni v0.4.0
 	github.com/libp2p/go-libp2p v0.29.2
 	github.com/libp2p/go-msgio v0.3.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/ipld/go-ipld-prime v0.20.0
 	github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd
 	github.com/ipni/go-indexer-core v0.8.0
-	github.com/ipni/go-libipni v0.3.5-0.20230808205428-efcc1024593a
+	github.com/ipni/go-libipni v0.3.5-0.20230815222902-f322558bba48
 	github.com/libp2p/go-libp2p v0.29.2
 	github.com/libp2p/go-msgio v0.3.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -592,8 +592,8 @@ github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236
 github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd/go.mod h1:9DD/GM0JNPoisgR09F62kbBi7kHa4eDIea4XshXYOVc=
 github.com/ipni/go-indexer-core v0.8.0 h1:HPFMngR47FL49mVnOZBrcxJoRODjIadlP+UYMRboNKA=
 github.com/ipni/go-indexer-core v0.8.0/go.mod h1:Y9su+no9k6y+jnQRERP/CKJewdISHzzl+n91GA+y4Ao=
-github.com/ipni/go-libipni v0.3.5-0.20230808205428-efcc1024593a h1:UQa8TnABIjEDv/1aRg5xmyfC5lmi9gvMJXaQeJIdTVw=
-github.com/ipni/go-libipni v0.3.5-0.20230808205428-efcc1024593a/go.mod h1:LxH6NUmEVruK3FjV2bFWfXKougX7AIe7wVjvPqITrDI=
+github.com/ipni/go-libipni v0.3.5-0.20230815222902-f322558bba48 h1:y0gtTZHB64hzGfmzA2NEvdySBlp9Z6BFUgpbIRqZ4Bo=
+github.com/ipni/go-libipni v0.3.5-0.20230815222902-f322558bba48/go.mod h1:LxH6NUmEVruK3FjV2bFWfXKougX7AIe7wVjvPqITrDI=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/i18n v0.0.0-20171121225848-987a633949d0/go.mod h1:pMCz62A0xJL6I+umB2YTlFRwWXaDFA0jy+5HzGiJjqI=

--- a/go.sum
+++ b/go.sum
@@ -592,8 +592,8 @@ github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236
 github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd/go.mod h1:9DD/GM0JNPoisgR09F62kbBi7kHa4eDIea4XshXYOVc=
 github.com/ipni/go-indexer-core v0.8.0 h1:HPFMngR47FL49mVnOZBrcxJoRODjIadlP+UYMRboNKA=
 github.com/ipni/go-indexer-core v0.8.0/go.mod h1:Y9su+no9k6y+jnQRERP/CKJewdISHzzl+n91GA+y4Ao=
-github.com/ipni/go-libipni v0.3.5-0.20230815222902-f322558bba48 h1:y0gtTZHB64hzGfmzA2NEvdySBlp9Z6BFUgpbIRqZ4Bo=
-github.com/ipni/go-libipni v0.3.5-0.20230815222902-f322558bba48/go.mod h1:LxH6NUmEVruK3FjV2bFWfXKougX7AIe7wVjvPqITrDI=
+github.com/ipni/go-libipni v0.4.0 h1:zZ8OU2N0D4iYt0E9jInbDapeh9bG10b5sBgqvScflNw=
+github.com/ipni/go-libipni v0.4.0/go.mod h1:LxH6NUmEVruK3FjV2bFWfXKougX7AIe7wVjvPqITrDI=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/i18n v0.0.0-20171121225848-987a633949d0/go.mod h1:pMCz62A0xJL6I+umB2YTlFRwWXaDFA0jy+5HzGiJjqI=

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -211,7 +211,7 @@ func NewIngester(cfg config.Ingest, h host.Host, idxr indexer.Interface, reg *re
 		return nil, err
 	}
 
-	// Instantiate retryable HTTP client used by dagsync httpsync.
+	// Instantiate retryable HTTP client used by dagsync/ipnisync.
 	rclient := &retryablehttp.Client{
 		HTTPClient: &http.Client{
 			Timeout: time.Duration(cfg.HttpSyncTimeout),


### PR DESCRIPTION
## Context
Use new go-libipni that has package `ipnisync` that replaces `httpsync`.

## Proposed Changes
- Dependency changed
- Minor API change
- New config item `Ingest.MaxAsyncConcurrency`

## Tests
Test withing go-libipni

## Revert Strategy
Change is safe to revert.
