### PR TITLE
Deploy dhstore and indexstar

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago3/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago3/kustomization.yaml
@@ -18,4 +18,4 @@ patchesStrategicMerge:
 images:
   - name: dhstore
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
-    newTag: 20230726183918-f7fa512bb1daee3f87bceb0084c591b0e67a005b
+    newTag: 20230909214400-94242b80af06db60426a12e261128267eae4c6c4

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
@@ -18,4 +18,4 @@ replicas:
 images:
   - name: indexstar
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/indexstar/indexstar
-    newTag: 20230727062040-c8ca931594389de625e7378ba0f3565695576894
+    newTag: 20230909220037-1eeef46bdd8a8bd801a27f102428b5f870e081e0


### PR DESCRIPTION
New indexstar and dhstore have separate encrypted and non-encrypted lookup paths.
