### PR TITLE
Deploy new image to old dhstore instances

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago2/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago2/kustomization.yaml
@@ -18,4 +18,4 @@ patchesStrategicMerge:
 images:
   - name: dhstore
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
-    newTag: 20230725203839-16357fe9f5951e0e0ca9c18044b017cdd392de93
+    newTag: 20230909214400-94242b80af06db60426a12e261128267eae4c6c4

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore/kustomization.yaml
@@ -15,4 +15,4 @@ patchesStrategicMerge:
 images:
   - name: dhstore
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
-    newTag: 20230725203839-16357fe9f5951e0e0ca9c18044b017cdd392de93
+    newTag: 20230909214400-94242b80af06db60426a12e261128267eae4c6c4


### PR DESCRIPTION
New image has separate encrypted and non-encrypted paths