### PR TITLE
New telemetry endpoints to get ingestion rate metrics

### DIFF
--- a/.github/workflows/ecr-publisher.yml
+++ b/.github/workflows/ecr-publisher.yml
@@ -15,7 +15,6 @@ on:
       - 'doc/**'
     branches:
       - main
-      - telemetry-endpoints
 
 jobs:
   publisher:

--- a/.github/workflows/ecr-publisher.yml
+++ b/.github/workflows/ecr-publisher.yml
@@ -1,4 +1,3 @@
-
 # Publishes storetheindex container images to the private AWS ECR.
 # The images published to ECR are used in Kubernetes clusters to server cid.contact.
 name: ECR

--- a/.github/workflows/ecr-publisher.yml
+++ b/.github/workflows/ecr-publisher.yml
@@ -1,3 +1,4 @@
+
 # Publishes storetheindex container images to the private AWS ECR.
 # The images published to ECR are used in Kubernetes clusters to server cid.contact.
 name: ECR
@@ -14,6 +15,7 @@ on:
       - 'doc/**'
     branches:
       - main
+      - telemetry-endpoints
 
 jobs:
   publisher:

--- a/command/admin.go
+++ b/command/admin.go
@@ -438,5 +438,5 @@ func telemetryAction(cctx *cli.Context) error {
 func printIngestRate(pid peer.ID, irate rate.Rate) {
 	fmt.Println("Provider", pid, "ingest rate:")
 	sec := irate.Elapsed.Seconds()
-	fmt.Printf("    %d mh, %d ads, %f seconds: %f mh/s\n", irate.Count, irate.Samples, sec, float64(irate.Count)/sec)
+	fmt.Printf("  %d multihashes from %d ads in %f seconds: %d mh/s\n", irate.Count, irate.Samples, sec, int64(float64(irate.Count)/sec))
 }

--- a/command/admin.go
+++ b/command/admin.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/ipni/storetheindex/admin/client"
+	"github.com/ipni/storetheindex/rate"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/urfave/cli/v2"
@@ -26,6 +27,7 @@ var AdminCmd = &cli.Command{
 		statusCmd,
 		syncCmd,
 		unassignCmd,
+		telemetryCmd,
 	},
 }
 
@@ -176,6 +178,22 @@ var unassignFlags = []cli.Flag{
 		Usage:    "Peer ID of publisher un-assign",
 		Aliases:  []string{"p"},
 		Required: true,
+	},
+	indexerHostFlag,
+}
+
+var telemetryCmd = &cli.Command{
+	Name:   "telemetry",
+	Usage:  "Show provider telemetry info",
+	Flags:  telemetryFlags,
+	Action: telemetryAction,
+}
+
+var telemetryFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:    "provider",
+		Usage:   "Provider ID to show latest telemetry info for",
+		Aliases: []string{"p"},
 	},
 	indexerHostFlag,
 }
@@ -379,4 +397,46 @@ func unassignAction(cctx *cli.Context) error {
 	fmt.Println()
 	fmt.Println("Restart assigner service see this change. To prevent re-assignment to this indexer, first block the peer on this indexer or configure a pre-set assignment.")
 	return nil
+}
+
+func telemetryAction(cctx *cli.Context) error {
+	cl, err := client.New(cliIndexer(cctx, "admin"))
+	if err != nil {
+		return err
+	}
+	if cctx.String("provider") == "" {
+		rateMap, err := cl.GetAllTelemetry(cctx.Context)
+		if err != nil {
+			return err
+		}
+		if len(rateMap) == 0 {
+			fmt.Println("no new rate information")
+			return nil
+		}
+		for pid, irate := range rateMap {
+			printIngestRate(peer.ID(pid), irate)
+		}
+		return nil
+	}
+
+	pid, err := peer.Decode(cctx.String("provider"))
+	if err != nil {
+		return err
+	}
+	irate, ok, err := cl.GetTelemetry(cctx.Context, pid)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		fmt.Println("no new rate information")
+		return nil
+	}
+	printIngestRate(pid, irate)
+	return nil
+}
+
+func printIngestRate(pid peer.ID, irate rate.Rate) {
+	fmt.Println("Provider", pid, "ingest rate:")
+	sec := irate.Elapsed.Seconds()
+	fmt.Printf("    %d mh, %d ads, %f seconds: %f mh/s\n", irate.Count, irate.Samples, sec, float64(irate.Count)/sec)
 }

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -231,6 +231,7 @@ func testEndToEndWithReferenceProvider(t *testing.T, publisherProto string) {
 	require.Equal(t, 1, headCount)
 
 	outRates := e.Run(indexer, "admin", "telemetry", "-i", "http://localhost:3002")
+	require.Contains(t, string(outRates), "1043 multihashes from 1 ads")
 	t.Logf("Telemetry:\n%s", outRates)
 
 	root2 := filepath.Join(e.Dir, ".storetheindex2")

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -111,7 +111,7 @@ func testEndToEndWithReferenceProvider(t *testing.T, publisherProto string) {
 	case "http":
 		e.Run(provider, "init", "--pubkind=http")
 	case "libp2p":
-		e.Run(provider, "init", "--pubkind=libp2phttp")
+		e.Run(provider, "init", "--pubkind=libp2p")
 	case "libp2phttp":
 		e.Run(provider, "init", "--pubkind=libp2phttp")
 	}
@@ -229,6 +229,9 @@ func testEndToEndWithReferenceProvider(t *testing.T, publisherProto string) {
 	}
 	require.Equal(t, 1, carCount)
 	require.Equal(t, 1, headCount)
+
+	outRates := e.Run(indexer, "admin", "telemetry", "-i", "http://localhost:3002")
+	t.Logf("Telemetry:\n%s", outRates)
 
 	root2 := filepath.Join(e.Dir, ".storetheindex2")
 	e.Env = append(e.Env, fmt.Sprintf("%s=%s", config.EnvDir, root2))

--- a/internal/metrics/server.go
+++ b/internal/metrics/server.go
@@ -14,11 +14,9 @@ import (
 
 // Global Tags
 var (
-	ErrKind, _   = tag.NewKey("errKind")
-	Found, _     = tag.NewKey("found")
-	Method, _    = tag.NewKey("method")
-	Publisher, _ = tag.NewKey("publisher")
-	Version, _   = tag.NewKey("version")
+	ErrKind, _ = tag.NewKey("errKind")
+	Found, _   = tag.NewKey("found")
+	Method, _  = tag.NewKey("method")
 )
 
 // Measures
@@ -33,9 +31,6 @@ var (
 	AdIngestSuccessCount = stats.Int64("ingest/adingestSuccess", "Number of successful ad ingest", stats.UnitDimensionless)
 	AdIngestSkippedCount = stats.Int64("ingest/adingestSkipped", "Number of ads skipped during ingest", stats.UnitDimensionless)
 	AdLoadError          = stats.Int64("ingest/adLoadError", "Number of times an ad failed to load", stats.UnitDimensionless)
-	AdsIngestedCount     = stats.Int64("ingest/adsingested", "Number of advertisements ingested per provider", stats.UnitDimensionless)
-	MhsIngestedCount     = stats.Int64("ingest/mhsingested", "Number of multihashes ingested per provider", stats.UnitDimensionless)
-	MhsIngestTime        = stats.Float64("ingest/mhsingesttime", "How long it took to sync an Ad's entries", stats.UnitMilliseconds)
 	ProviderCount        = stats.Int64("provider/count", "Number of known (registered) providers", stats.UnitDimensionless)
 	EntriesSyncLatency   = stats.Float64("ingest/entriessynclatency", "How long it took to sync an Ad's entries", stats.UnitMilliseconds)
 	PercentUsage         = stats.Float64("ingest/percentusage", "Percent usage of storage available in value store", stats.UnitDimensionless)
@@ -96,21 +91,6 @@ var (
 		Measure:     AdLoadError,
 		Aggregation: view.Count(),
 	}
-	adsIngested = &view.View{
-		Measure:     AdsIngestedCount,
-		Aggregation: view.Count(),
-		TagKeys:     []tag.Key{Publisher},
-	}
-	mhsIngestTimeView = &view.View{
-		Measure:     MhsIngestTime,
-		Aggregation: view.LastValue(),
-		TagKeys:     []tag.Key{Publisher},
-	}
-	mhsIngested = &view.View{
-		Measure:     MhsIngestedCount,
-		Aggregation: view.LastValue(),
-		TagKeys:     []tag.Key{Publisher},
-	}
 	percentUsageView = &view.View{
 		Measure:     PercentUsage,
 		Aggregation: view.LastValue(),
@@ -143,9 +123,6 @@ func Start(views []*view.View) http.Handler {
 		adIngestSkipped,
 		adIngestSuccess,
 		adLoadError,
-		adsIngested,
-		mhsIngested,
-		mhsIngestTimeView,
 		percentUsageView,
 		nonRemoveAdCountView,
 		removeAdCountView,

--- a/rate/map.go
+++ b/rate/map.go
@@ -14,7 +14,7 @@ type Rate struct {
 }
 
 // Map records the cumulative rate, since the last call to Get or GetAll,
-// for each ID. Getting the rate
+// for each ID.
 type Map struct {
 	mutex sync.Mutex
 	rates map[string]Rate
@@ -27,7 +27,7 @@ func NewMap() *Map {
 }
 
 // Update adds the new rate information to the existing information. If the
-// existing rate information is markes as observed, then it is reset before
+// existing rate information is marked as observed, then it is reset before
 // applying the new information.
 func (m *Map) Update(id string, count uint64, elapsed time.Duration) {
 	if m == nil || count == 0 || elapsed == 0 {
@@ -46,7 +46,7 @@ func (m *Map) Update(id string, count uint64, elapsed time.Duration) {
 }
 
 // Get reads the accumulated rate information for the specified ID. The
-// information is markes as observed and is reset at next write.
+// information is marked as observed and is reset at next write.
 func (m *Map) Get(id string) (Rate, bool) {
 	if m == nil {
 		return Rate{}, false
@@ -62,7 +62,7 @@ func (m *Map) Get(id string) (Rate, bool) {
 }
 
 // GetAll reads and removes all accumulated rate information. The
-// information is markes as observed and is reset at next write.
+// information is marked as observed and is reset at next write.
 func (m *Map) GetAll() map[string]Rate {
 	if m == nil {
 		return nil

--- a/rate/map.go
+++ b/rate/map.go
@@ -1,0 +1,85 @@
+package rate
+
+import (
+	"sync"
+	"time"
+)
+
+type Rate struct {
+	Count   uint64
+	Elapsed time.Duration
+	Samples int
+
+	observed bool
+}
+
+// Map records the cumulative rate, since the last call to Get or GetAll,
+// for each ID. Getting the rate
+type Map struct {
+	mutex sync.Mutex
+	rates map[string]Rate
+}
+
+func NewMap() *Map {
+	return &Map{
+		rates: map[string]Rate{},
+	}
+}
+
+// Update adds the new rate information to the existing information. If the
+// existing rate information is markes as observed, then it is reset before
+// applying the new information.
+func (m *Map) Update(id string, count uint64, elapsed time.Duration) {
+	if m == nil || count == 0 || elapsed == 0 {
+		return
+	}
+	m.mutex.Lock()
+	rate := m.rates[id]
+	if rate.observed {
+		rate = Rate{}
+	}
+	rate.Count += count
+	rate.Elapsed += elapsed
+	rate.Samples++
+	m.rates[id] = rate
+	m.mutex.Unlock()
+}
+
+// Get reads the accumulated rate information for the specified ID. The
+// information is markes as observed and is reset at next write.
+func (m *Map) Get(id string) (Rate, bool) {
+	if m == nil {
+		return Rate{}, false
+	}
+	m.mutex.Lock()
+	r, ok := m.rates[id]
+	if ok && !r.observed {
+		r.observed = true
+		m.rates[id] = r
+	}
+	m.mutex.Unlock()
+	return r, ok
+}
+
+// GetAll reads and removes all accumulated rate information. The
+// information is markes as observed and is reset at next write.
+func (m *Map) GetAll() map[string]Rate {
+	if m == nil {
+		return nil
+	}
+	m.mutex.Lock()
+	if len(m.rates) == 0 {
+		m.mutex.Unlock()
+		return nil
+	}
+	out := make(map[string]Rate, len(m.rates))
+	for id, r := range m.rates {
+		if !r.observed {
+			r.observed = true
+			m.rates[id] = r
+		}
+		out[id] = r
+	}
+	m.mutex.Unlock()
+	return out
+}

--- a/server/admin/server.go
+++ b/server/admin/server.go
@@ -86,6 +86,10 @@ func New(listen string, id peer.ID, indexer indexer.Interface, ingester *ingest.
 	mux.Handle("/metrics/", metrics.Start(append(coremetrics.DefaultViews, coremetrics.PebbleViews...)))
 	mux.Handle("/debug/pprof/", pprof.WithProfile())
 
+	// Telemetry routes
+	mux.HandleFunc("/telemetry/providers", h.listTelemetry)
+	mux.HandleFunc("/telemetry/providers/", h.getTelemetry)
+
 	// Config routes
 	mux.HandleFunc("/config/log/level", setLogLevel)
 	mux.HandleFunc("/config/log/subsystems", listLogSubSystems)


### PR DESCRIPTION
Expose new endpoints in admin server to get per-provider ingestion rate data:
- /telemetry/providers
- /telemetry/providers/

Remove per-provider prometheus metrics.

Reset rate stats after they are retrieved from the indexer.
