### PR TITLE
Deploy new indexer and telemetry

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -18,4 +18,4 @@ resources:
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}
-  newTag: 20230904172543-1b502bd79ffbfd1fcc70cc80b35c5902508f1b4f # {"$imagepolicy": "storetheindex:storetheindex:tag"}
+  newTag: 20230914223225-7a52c806f9dc4a92fe3106fc22ef594ca084cc13 # {"$imagepolicy": "storetheindex:storetheindex:tag"}

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/telemetry/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/telemetry/deployment.yaml
@@ -12,6 +12,7 @@ spec:
       containers:
         - name: telemetry
           args:
+            - '-indexerURL=http://ago-indexer:3002'
             - '-providersURL=http://indexstar:8080/'
             - '-maxDepth=5000'
             - '-updateIn=2m'

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/telemetry/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/telemetry/kustomization.yaml
@@ -13,5 +13,5 @@ patchesStrategicMerge:
 images:
   - name: telemetry
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/telemetry
-    newTag: 20230904201658-8c50c79e5764e732949c2f22cfb0142f420f7d35
+    newTag: 20230914223558-e48eb977d04b4ac77aed05433fe6cdc2e56e609a
 


### PR DESCRIPTION
Experimental indexer and telemetry service. Telemetry pulls provider ingestion rate data from indexer's admin server.