### PR TITLE
Drop support for batch find API

### DIFF
--- a/command/loadgen.go
+++ b/command/loadgen.go
@@ -114,7 +114,7 @@ var loadGenVerifyFlags = []cli.Flag{
 }
 
 func loadGenVerifyAction(cctx *cli.Context) error {
-	client, err := client.New(cctx.String("indexerFind"))
+	cl, err := client.New(cctx.String("indexerFind"))
 	if err != nil {
 		return err
 	}
@@ -149,7 +149,7 @@ func loadGenVerifyAction(cctx *cli.Context) error {
 
 	start := time.Now()
 
-	resp, err := client.FindBatch(context.Background(), allMhs)
+	resp, err := client.FindBatch(context.Background(), cl, allMhs)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/ipld/go-ipld-prime v0.21.0
 	github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd
 	github.com/ipni/go-indexer-core v0.8.0
-	github.com/ipni/go-libipni v0.5.2-0.20230919022320-338738e5c8c8
+	github.com/ipni/go-libipni v0.5.2
 	github.com/libp2p/go-libp2p v0.31.0
 	github.com/libp2p/go-msgio v0.3.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/ipld/go-ipld-prime v0.21.0
 	github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd
 	github.com/ipni/go-indexer-core v0.8.0
-	github.com/ipni/go-libipni v0.5.1
+	github.com/ipni/go-libipni v0.5.2-0.20230919022320-338738e5c8c8
 	github.com/libp2p/go-libp2p v0.31.0
 	github.com/libp2p/go-msgio v0.3.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -592,8 +592,8 @@ github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236
 github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd/go.mod h1:9DD/GM0JNPoisgR09F62kbBi7kHa4eDIea4XshXYOVc=
 github.com/ipni/go-indexer-core v0.8.0 h1:HPFMngR47FL49mVnOZBrcxJoRODjIadlP+UYMRboNKA=
 github.com/ipni/go-indexer-core v0.8.0/go.mod h1:Y9su+no9k6y+jnQRERP/CKJewdISHzzl+n91GA+y4Ao=
-github.com/ipni/go-libipni v0.5.1 h1:HumuJtKmV8RoDpBakLgxCSl5QPiD2ljTZl/NOyXO6nM=
-github.com/ipni/go-libipni v0.5.1/go.mod h1:UnrhEqjVI2Z2HXlaieOBONJmtW557nZkYpB4IIsMD+s=
+github.com/ipni/go-libipni v0.5.2-0.20230919022320-338738e5c8c8 h1:OYbG5b2/Cnv6Ro2sx554Dn2ygmAHbCxkIaRYGcw4q68=
+github.com/ipni/go-libipni v0.5.2-0.20230919022320-338738e5c8c8/go.mod h1:UnrhEqjVI2Z2HXlaieOBONJmtW557nZkYpB4IIsMD+s=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/i18n v0.0.0-20171121225848-987a633949d0/go.mod h1:pMCz62A0xJL6I+umB2YTlFRwWXaDFA0jy+5HzGiJjqI=

--- a/go.sum
+++ b/go.sum
@@ -592,8 +592,8 @@ github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236
 github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd/go.mod h1:9DD/GM0JNPoisgR09F62kbBi7kHa4eDIea4XshXYOVc=
 github.com/ipni/go-indexer-core v0.8.0 h1:HPFMngR47FL49mVnOZBrcxJoRODjIadlP+UYMRboNKA=
 github.com/ipni/go-indexer-core v0.8.0/go.mod h1:Y9su+no9k6y+jnQRERP/CKJewdISHzzl+n91GA+y4Ao=
-github.com/ipni/go-libipni v0.5.2-0.20230919022320-338738e5c8c8 h1:OYbG5b2/Cnv6Ro2sx554Dn2ygmAHbCxkIaRYGcw4q68=
-github.com/ipni/go-libipni v0.5.2-0.20230919022320-338738e5c8c8/go.mod h1:UnrhEqjVI2Z2HXlaieOBONJmtW557nZkYpB4IIsMD+s=
+github.com/ipni/go-libipni v0.5.2 h1:9vaYOnR4dskd8p88NOboqI6yVqBwYPNCQ/zOaRSr59I=
+github.com/ipni/go-libipni v0.5.2/go.mod h1:UnrhEqjVI2Z2HXlaieOBONJmtW557nZkYpB4IIsMD+s=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/i18n v0.0.0-20171121225848-987a633949d0/go.mod h1:pMCz62A0xJL6I+umB2YTlFRwWXaDFA0jy+5HzGiJjqI=

--- a/server/find/extended_providers_test.go
+++ b/server/find/extended_providers_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func providersShouldBeUnaffectedByExtendedProvidersOfEachOtherTest(ctx context.Context, t *testing.T, c client.Interface, ind indexer.Interface, reg *registry.Registry) {
+func providersShouldBeUnaffectedByExtendedProvidersOfEachOtherTest(ctx context.Context, t *testing.T, f client.Finder, ind indexer.Interface, reg *registry.Registry) {
 	provider1Id, _, _ := test.RandomIdentity()
 	ctxId1 := []byte("test-context-id-1")
 	metadata1 := []byte("test-metadata-1")
@@ -39,7 +39,7 @@ func providersShouldBeUnaffectedByExtendedProvidersOfEachOtherTest(ctx context.C
 	addrs2 := maddrs[2:3]
 	prov2, mhs2 := createProviderAndPopulateIndexer(t, ctx, ind, reg, ctxId2, metadata2, provider2Id, addrs2, nil)
 
-	resp, err := c.FindBatch(ctx, mhs2[:10])
+	resp, err := client.FindBatch(ctx, f, mhs2[:10])
 	require.NoError(t, err)
 	err = checkResponse(resp, mhs2[:10], []model.ProviderResult{
 		{
@@ -54,7 +54,7 @@ func providersShouldBeUnaffectedByExtendedProvidersOfEachOtherTest(ctx context.C
 	require.NoError(t, err)
 }
 
-func extendedProviderShouldHaveOwnMetadataTest(ctx context.Context, t *testing.T, c client.Interface, ind indexer.Interface, reg *registry.Registry) {
+func extendedProviderShouldHaveOwnMetadataTest(ctx context.Context, t *testing.T, f client.Finder, ind indexer.Interface, reg *registry.Registry) {
 	provider1Id, _, _ := test.RandomIdentity()
 	ctxId1 := []byte("test-context-id-1")
 	metadata1 := []byte("test-metadata-1")
@@ -90,7 +90,7 @@ func extendedProviderShouldHaveOwnMetadataTest(ctx context.Context, t *testing.T
 		},
 	})
 
-	resp, err := c.FindBatch(ctx, mhs1)
+	resp, err := client.FindBatch(ctx, f, mhs1)
 	require.NoError(t, err)
 	err = checkResponse(resp, mhs1, []model.ProviderResult{
 		{
@@ -121,7 +121,7 @@ func extendedProviderShouldHaveOwnMetadataTest(ctx context.Context, t *testing.T
 	require.NoError(t, err)
 }
 
-func extendedProviderShouldInheritMetadataOfMainProviderTest(ctx context.Context, t *testing.T, c client.Interface, ind indexer.Interface, reg *registry.Registry) {
+func extendedProviderShouldInheritMetadataOfMainProviderTest(ctx context.Context, t *testing.T, f client.Finder, ind indexer.Interface, reg *registry.Registry) {
 	provider1Id, _, _ := test.RandomIdentity()
 	ctxId1 := []byte("test-context-id-1")
 	metadata1 := []byte("test-metadata-1")
@@ -153,7 +153,7 @@ func extendedProviderShouldInheritMetadataOfMainProviderTest(ctx context.Context
 		},
 	})
 
-	resp, err := c.FindBatch(ctx, mhs1)
+	resp, err := client.FindBatch(ctx, f, mhs1)
 	require.NoError(t, err)
 	err = checkResponse(resp, mhs1, []model.ProviderResult{
 		{
@@ -184,7 +184,7 @@ func extendedProviderShouldInheritMetadataOfMainProviderTest(ctx context.Context
 	require.NoError(t, err)
 }
 
-func contextualExtendedProvidersShouldUnionUpWithChainLevelOnesTest(ctx context.Context, t *testing.T, c client.Interface, ind indexer.Interface, reg *registry.Registry) {
+func contextualExtendedProvidersShouldUnionUpWithChainLevelOnesTest(ctx context.Context, t *testing.T, f client.Finder, ind indexer.Interface, reg *registry.Registry) {
 	provider1Id, _, _ := test.RandomIdentity()
 	ctxId1 := []byte("test-context-id-1")
 	metadata1 := []byte("test-metadata-1")
@@ -226,7 +226,7 @@ func contextualExtendedProvidersShouldUnionUpWithChainLevelOnesTest(ctx context.
 	}
 	populateIndex(ind, mhs2, v, t)
 
-	resp, err := c.FindBatch(ctx, mhs1)
+	resp, err := client.FindBatch(ctx, f, mhs1)
 	require.NoError(t, err)
 	err = checkResponse(resp, mhs1, []model.ProviderResult{
 		{
@@ -257,7 +257,7 @@ func contextualExtendedProvidersShouldUnionUpWithChainLevelOnesTest(ctx context.
 	require.NoError(t, err)
 
 	// for contextId2 we should get only chain-level extended providers
-	resp, err = c.FindBatch(ctx, mhs2)
+	resp, err = client.FindBatch(ctx, f, mhs2)
 	require.NoError(t, err)
 	err = checkResponse(resp, mhs2, []model.ProviderResult{
 		{
@@ -280,7 +280,7 @@ func contextualExtendedProvidersShouldUnionUpWithChainLevelOnesTest(ctx context.
 	require.NoError(t, err)
 }
 
-func contextualExtendedProvidersShouldOverrideChainLevelOnesTest(ctx context.Context, t *testing.T, c client.Interface, ind indexer.Interface, reg *registry.Registry) {
+func contextualExtendedProvidersShouldOverrideChainLevelOnesTest(ctx context.Context, t *testing.T, f client.Finder, ind indexer.Interface, reg *registry.Registry) {
 	provider1Id, _, _ := test.RandomIdentity()
 	ctxId1 := []byte("test-context-id-1")
 	metadata1 := []byte("test-metadata-1")
@@ -312,7 +312,7 @@ func contextualExtendedProvidersShouldOverrideChainLevelOnesTest(ctx context.Con
 		}},
 	})
 
-	resp, err := c.FindBatch(ctx, mhs1)
+	resp, err := client.FindBatch(ctx, f, mhs1)
 	require.NoError(t, err)
 	err = checkResponse(resp, mhs1, []model.ProviderResult{
 		{
@@ -335,7 +335,7 @@ func contextualExtendedProvidersShouldOverrideChainLevelOnesTest(ctx context.Con
 	require.NoError(t, err)
 }
 
-func mainProviderChainRecordIsIncludedIfItsMetadataIsDifferentTest(ctx context.Context, t *testing.T, c client.Interface, ind indexer.Interface, reg *registry.Registry) {
+func mainProviderChainRecordIsIncludedIfItsMetadataIsDifferentTest(ctx context.Context, t *testing.T, f client.Finder, ind indexer.Interface, reg *registry.Registry) {
 	providerId, _, _ := test.RandomIdentity()
 	ctxId1 := []byte("test-context-id-1")
 	providerMetadata := []byte("provider metadata")
@@ -364,7 +364,7 @@ func mainProviderChainRecordIsIncludedIfItsMetadataIsDifferentTest(ctx context.C
 		}},
 	})
 
-	resp, err := c.FindBatch(ctx, mhs1)
+	resp, err := client.FindBatch(ctx, f, mhs1)
 	require.NoError(t, err)
 	err = checkResponse(resp, mhs1, []model.ProviderResult{
 		{
@@ -387,7 +387,7 @@ func mainProviderChainRecordIsIncludedIfItsMetadataIsDifferentTest(ctx context.C
 	require.NoError(t, err)
 }
 
-func mainProviderContextRecordIsIncludedIfItsMetadataIsDifferentTest(ctx context.Context, t *testing.T, c client.Interface, ind indexer.Interface, reg *registry.Registry) {
+func mainProviderContextRecordIsIncludedIfItsMetadataIsDifferentTest(ctx context.Context, t *testing.T, f client.Finder, ind indexer.Interface, reg *registry.Registry) {
 	providerId, _, _ := test.RandomIdentity()
 	ctxId1 := []byte("test-context-id-1")
 	providerMetadata := []byte("provider metadata")
@@ -416,7 +416,7 @@ func mainProviderContextRecordIsIncludedIfItsMetadataIsDifferentTest(ctx context
 		}},
 	})
 
-	resp, err := c.FindBatch(ctx, mhs1)
+	resp, err := client.FindBatch(ctx, f, mhs1)
 	require.NoError(t, err)
 	err = checkResponse(resp, mhs1, []model.ProviderResult{
 		{


### PR DESCRIPTION
The find client FindBatch API, available as `HTTP POST /multihash/` is no longer supported.