### PR TITLE
Do not show internal errors in provider information

### DIFF
--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -1202,7 +1202,11 @@ func (ing *Ingester) ingestWorkerLogic(ctx context.Context, provider peer.ID, as
 		}
 
 		if err != nil {
-			ing.reg.SetLastError(provider, fmt.Errorf("error while ingesting ad %s: %s", ai.cid, err))
+			errText := err.Error()
+			if errors.Is(err, errInternal) {
+				errText = errInternal.Error()
+			}
+			ing.reg.SetLastError(provider, fmt.Errorf("error while ingesting ad %s: %s", ai.cid, errText))
 			log.Errorw("Error while ingesting ad. Bailing early, not ingesting later ads.", "adCid", ai.cid, "err", err, "adsLeftToProcess", i+1)
 			// Tell anyone waiting that the sync finished for this head because
 			// of error.  TODO(mm) would be better to propagate the error.


### PR DESCRIPTION
## Context
Do not show the details of an internal error in the provider information LastError field.

Fixes #2135

## Proposed Changes
Before this PR a LastError would have this value:
```
"error while ingesting ad baguqeerakox7bxasaugzzryydb2i5wjc7ryx44eyciur7t3amcqif6b7rrsq: indexerErr: failed to remove provider context: Delete \"http://dhstore-helga.internal.prod.cid.contact/metadata/AUvZrCRZAnyeqeZrnsNsP5knEbdKa1dx6TGGQyQga3jZ\": dial tcp 20.10.3.212:80: i/o timeout"
```

Ingestion errors caused by a failure of the indexer itself have a `errInternal` in their error chain. This acts as a tag for these errors, and the error text is changed to "internal error" when it is put into the provider information.

After this PR it would have:
```
"error while ingesting ad baguqeerakox7bxasaugzzryydb2i5wjc7ryx44eyciur7t3amcqif6b7rrsq: indexerErr: internal error"
```

## Tests
Added unit test to force failed write to indexer core. Checked for expected error return and for internal error in provider info.

## Revert Strategy
Change is safe to revert.
