### PR TITLE
Increase http timeout to 3m

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
@@ -86,7 +86,7 @@
     "HttpSyncRetryMax": 0,
     "HttpSyncRetryWaitMax": "30s",
     "HttpSyncRetryWaitMin": "1s",
-    "HttpSyncTimeout": "60s",
+    "HttpSyncTimeout": "3m",
     "IngestWorkerCount": 30,
     "PubSubTopic": "/indexer/ingest/mainnet",
     "ResendDirectAnnounce": false,


### PR DESCRIPTION
When a request for ad entries if made, then advertisement provider builds its entries chain at the time the request is made. If the entries chain is long, as it the case for at least one provider, then the response is not sent for some time. This may cause the indexer to time out waiting for a response.
