### PR TITLE
Very long http timeout

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
@@ -86,7 +86,7 @@
     "HttpSyncRetryMax": 0,
     "HttpSyncRetryWaitMax": "30s",
     "HttpSyncRetryWaitMin": "1s",
-    "HttpSyncTimeout": "3m",
+    "HttpSyncTimeout": "5m",
     "IngestWorkerCount": 30,
     "PubSubTopic": "/indexer/ingest/mainnet",
     "ResendDirectAnnounce": false,


### PR DESCRIPTION
Temporary fix to clients that do not respond to entry requests until entries chain is built.
