### PR TITLE
Fix shutdown failure after manual sync

### DIFF
--- a/internal/httpserver/util.go
+++ b/internal/httpserver/util.go
@@ -29,7 +29,9 @@ func MethodOK(w http.ResponseWriter, r *http.Request, method string) bool {
 
 func WriteJsonResponse(w http.ResponseWriter, status int, body []byte) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.WriteHeader(status)
+	if status != http.StatusOK {
+		w.WriteHeader(status)
+	}
 	if _, err := w.Write(body); err != nil {
 		log.Errorw("cannot write response", "err", err)
 		http.Error(w, "", http.StatusInternalServerError)

--- a/server/admin/handler.go
+++ b/server/admin/handler.go
@@ -323,7 +323,6 @@ func (h *adminHandler) handlePostSyncs(w http.ResponseWriter, r *http.Request) {
 	log.Info("Syncing with peer")
 
 	// Start the sync, but do not wait for it to complete.
-	h.pendingSyncs.Add(1)
 	h.pendingSyncsLock.Lock()
 	if _, ok := h.pendingSyncsPeers[peerID]; ok {
 		h.pendingSyncsLock.Unlock()
@@ -334,6 +333,7 @@ func (h *adminHandler) handlePostSyncs(w http.ResponseWriter, r *http.Request) {
 	h.pendingSyncsPeers[peerID] = struct{}{}
 	h.pendingSyncsLock.Unlock()
 
+	h.pendingSyncs.Add(1)
 	go func() {
 		peerInfo := peer.AddrInfo{
 			ID:    peerID,

--- a/server/admin/handler.go
+++ b/server/admin/handler.go
@@ -680,7 +680,6 @@ func (h *adminHandler) healthCheckHandler(w http.ResponseWriter, r *http.Request
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	w.WriteHeader(http.StatusOK)
 	if _, err := w.Write([]byte("\"OK\"")); err != nil {
 		log.Errorw("Cannot write HealthCheck response:", "err", err)
 	}


### PR DESCRIPTION
If a manual synce request is given when there is already a sync in progress, the WaitGroup is being incremented even though a new goroutine is not started. This causes the server shutdown to hang waiting for the WaitGroup.