### PR TITLE
Set smaller http sync timeout

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
@@ -86,7 +86,7 @@
     "HttpSyncRetryMax": 0,
     "HttpSyncRetryWaitMax": "30s",
     "HttpSyncRetryWaitMin": "1s",
-    "HttpSyncTimeout": "5m",
+    "HttpSyncTimeout": "30s",
     "IngestWorkerCount": 30,
     "PubSubTopic": "/indexer/ingest/mainnet",
     "ResendDirectAnnounce": false,


### PR DESCRIPTION
Done experimenting with HTTP timeouts, so setting this to something somewhat more reasonable.
