### PR TITLE
Scale in `caskadht` in prod

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/caskadht/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/caskadht/kustomization.yaml
@@ -24,7 +24,7 @@ configMapGenerator:
 
 replicas:
   - name: caskadht
-    count: 5
+    count: 1
 
 images:
   - name: caskadht


### PR DESCRIPTION
Now there there is no more Rhea traffic, reduce the caskadht instances to 1 in order to reduce cost.

