### PR TITLE
Reduce max ASG size for prod worker node group

### DIFF
--- a/deploy/infrastructure/prod/us-east-2/eks.tf
+++ b/deploy/infrastructure/prod/us-east-2/eks.tf
@@ -133,7 +133,7 @@ module "eks" {
     }
     prod-ue2-c6a-8xl = {
       min_size       = 0
-      max_size       = 25
+      max_size       = 10
       desired_size   = 1
       instance_types = ["c6a.8xlarge"]
       subnet_ids     = [


### PR DESCRIPTION
The size was increased last week as part of investigating deployment issues.

Since then the issue has been resolved. Reduce to avoid excessively large number of nodes.
