### PR TITLE
Reduce cassette replicas to zero due to reduced bitswap cascade traffic

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/cassette/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/cassette/kustomization.yaml
@@ -27,6 +27,10 @@ configMapGenerator:
     files:
       - config.yaml
 
+replicas:
+  - name: cassette
+    count: 0
+
 images:
   - name: cassette
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/cassette

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -25,7 +25,9 @@ spec:
             - '--dhBackends=http://dhstore-ago2.internal.dev.cid.contact/'
             - '--dhBackends=http://dhstore.internal.dev.cid.contact/'
             - '--cascadeBackends=http://caskadht.internal.dev.cid.contact/'
-            - '--cascadeBackends=http://cassette.internal.dev.cid.contact/'
+          # Excluded in prep for sunsetting Cassette
+          # See: https://github.com/ipni/storetheindex/pull/2352
+          # - '--cascadeBackends=http://cassette.internal.dev.cid.contact/'
           env:
             # Increase maximum accepted request body to 1 MiB in order to allow batch finds requests
             # by the `provider verify-ingest` CLI command. 

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/lookout/config.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/lookout/config.yaml
@@ -29,13 +29,6 @@ checkers:
       - ipfs-dht
       - legacy
     parallelism: 10
-  cassette_internal:
-    type: ipni-non-streaming
-    ipniEndpoint: http://cassette.internal.dev.cid.contact
-    timeout: 30s
-    cascadeLabels:
-      - legacy
-    parallelism: 50
 samplers:
   # List of root CIDs of well known IPFS datasets.
   # See: 

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/cassette/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/cassette/kustomization.yaml
@@ -29,7 +29,7 @@ configMapGenerator:
 
 replicas:
   - name: cassette
-    count: 1
+    count: 0
 
 images:
   - name: cassette

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/deployment.yaml
@@ -14,7 +14,7 @@ spec:
           args:
             - '--translateNonStreaming'
             - '--providersBackends=http://inga-indexer:3000/'
-            
+
             - '--backends=http://dhstore-seka:40080/'
             - '--backends=http://dhstore-ravi:40080/'
             - '--backends=http://dhstore-qiu:40080/'
@@ -28,7 +28,9 @@ spec:
             - '--dhBackends=http://dhstore-helga.internal.prod.cid.contact/'
             - '--dhBackends=http://dhstore.internal.prod.cid.contact/'
             - '--cascadeBackends=http://caskadht.internal.prod.cid.contact/'
-            - '--cascadeBackends=http://cassette.internal.prod.cid.contact/'
+            # Excluded in prep for sunsetting Cassette
+            # See: https://github.com/ipni/storetheindex/pull/2352
+            # - '--cascadeBackends=http://cassette.internal.prod.cid.contact/'
           env:
             # Increase maximum accepted request body to 1 MiB in order to allow batch finds requests
             # by the `provider verify-ingest` CLI command. 

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/lookout/config.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/lookout/config.yaml
@@ -29,13 +29,6 @@ checkers:
       - ipfs-dht
       - legacy
     parallelism: 10
-  cassette_internal:
-    type: ipni-non-streaming
-    ipniEndpoint: http://cassette.internal.prod.cid.contact
-    timeout: 30s
-    cascadeLabels:
-      - legacy
-    parallelism: 50
 samplers:
   # List of root CIDs of well known IPFS datasets.
   # See: 


### PR DESCRIPTION
The primary use of Bitswap cascading lookup offered by cassette was Rhea which is no longer generating traffic.

Reduce replicas of cassette to zero in preparation for sunsetting the service.
