### PR TITLE
Reduce ingress and indexstar replicas to 2

### DIFF
--- a/deploy/manifests/dev/us-east-2/cluster/ingress-nginx/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/ingress-nginx/kustomization.yaml
@@ -10,4 +10,4 @@ patchesStrategicMerge:
 
 replicas:
   - name: ingress-nginx-controller
-    count: 3
+    count: 2

--- a/deploy/manifests/prod/us-east-2/cluster/ingress-nginx/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/ingress-nginx/kustomization.yaml
@@ -10,4 +10,4 @@ patchesStrategicMerge:
 
 replicas:
   - name: ingress-nginx-controller
-    count: 3
+    count: 2

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
@@ -13,7 +13,7 @@ patchesStrategicMerge:
 
 replicas:
   - name: indexstar
-    count: 3
+    count: 2
 
 images:
   - name: indexstar


### PR DESCRIPTION
Due to reduced traffic, instances seem under utilised. Reduce replica count from 3 to 2 for both nginx ingress controller and indexstar.

