### PR TITLE
Remove c6a8xl node group from dev and fix terraform

### DIFF
--- a/deploy/infrastructure/dev/us-east-2/eks.tf
+++ b/deploy/infrastructure/dev/us-east-2/eks.tf
@@ -91,17 +91,6 @@ module "eks" {
         data.aws_subnet.ue2c1.id, data.aws_subnet.ue2c2.id, data.aws_subnet.ue2c3.id,
       ]
     }
-    dev-ue2-c6a-8xl = {
-      min_size       = 0
-      max_size       = 15
-      desired_size   = 1
-      instance_types = ["c6a.8xlarge"]
-      subnet_ids = [
-        data.aws_subnet.ue2a1.id, data.aws_subnet.ue2a2.id, data.aws_subnet.ue2a3.id,
-        data.aws_subnet.ue2b1.id, data.aws_subnet.ue2b2.id, data.aws_subnet.ue2b3.id,
-        data.aws_subnet.ue2c1.id, data.aws_subnet.ue2c2.id, data.aws_subnet.ue2c3.id,
-      ]
-    }
 
     # Memory optimised node groups primarily used to run indexer nodes.
     dev-ue2a-r5n-2xl = {

--- a/deploy/infrastructure/dev/us-east-2/saturn-lassie-event-recorder.tf
+++ b/deploy/infrastructure/dev/us-east-2/saturn-lassie-event-recorder.tf
@@ -15,12 +15,12 @@ module "saturn_lassie_events_db" {
   identifier = "${local.environment_name}-saturn-lassie-events"
 
   engine               = "postgres"
-  engine_version       = "14.3"
+  engine_version       = "14.7"
   family               = "postgres14"
   major_engine_version = "14"
   instance_class       = "db.m5.large"
 
-  allocated_storage   = 2000
+  allocated_storage   = 2500
   skip_final_snapshot = true
   db_name             = "SaturnLassieEvents"
   username            = "postgres"

--- a/deploy/manifests/dev/us-east-2/cluster/kube-system/aws-auth.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kube-system/aws-auth.yaml
@@ -64,11 +64,6 @@ data:
       - system:nodes
       rolearn: arn:aws:iam::407967248065:role/dev-ue2c-r5n-2xl-eks-node-group
       username: system:node:{{EC2PrivateDNSName}}
-    - groups:
-      - system:bootstrappers
-      - system:nodes
-      rolearn: arn:aws:iam::407967248065:role/dev-ue2-c6a-8xl-eks-node-group
-      username: system:node:{{EC2PrivateDNSName}}
   mapUsers: |
     - userarn: arn:aws:iam::407967248065:user/masih
       username: masih


### PR DESCRIPTION
No deployment explicitly demands this instance type in dev; remove this node group.

Fix manually edited lassie event recorder DB params in infra-as-code.

