### PR TITLE
Move read-only dhstores to memory optimised instance types

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-helga/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-helga/deployment.yaml
@@ -27,10 +27,10 @@ spec:
               mountPath: /data
           resources:
             limits:
-              cpu: "28"
+              cpu: "7"
               memory: 58Gi
             requests:
-              cpu: "28"
+              cpu: "7"
               memory: 58Gi
           ports:
             - containerPort: 40081
@@ -43,7 +43,7 @@ spec:
                   - key: node.kubernetes.io/instance-type
                     operator: In
                     values:
-                      - c6a.8xlarge
+                      - r6a.2xlarge
                   - key: topology.kubernetes.io/zone
                     operator: In
                     values:

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-porvy/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-porvy/deployment.yaml
@@ -27,10 +27,10 @@ spec:
               mountPath: /data
           resources:
             limits:
-              cpu: "28"
+              cpu: "7"
               memory: 58Gi
             requests:
-              cpu: "28"
+              cpu: "7"
               memory: 58Gi
           ports:
             - containerPort: 40081
@@ -43,7 +43,7 @@ spec:
                   - key: node.kubernetes.io/instance-type
                     operator: In
                     values:
-                      - c6a.8xlarge
+                      - r6a.2xlarge
                   - key: topology.kubernetes.io/zone
                     operator: In
                     values:

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-qiu/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-qiu/deployment.yaml
@@ -20,10 +20,10 @@ spec:
               mountPath: /data
           resources:
             limits:
-              cpu: "28"
+              cpu: "7"
               memory: 58Gi
             requests:
-              cpu: "28"
+              cpu: "7"
               memory: 58Gi
       affinity:
         nodeAffinity:
@@ -33,7 +33,7 @@ spec:
                   - key: node.kubernetes.io/instance-type
                     operator: In
                     values:
-                      - c6a.8xlarge
+                      - r6a.2xlarge
                   - key: topology.kubernetes.io/zone
                     operator: In
                     values:

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-ravi/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-ravi/deployment.yaml
@@ -20,10 +20,10 @@ spec:
               mountPath: /data
           resources:
             limits:
-              cpu: "28"
+              cpu: "7"
               memory: 58Gi
             requests:
-              cpu: "28"
+              cpu: "7"
               memory: 58Gi
       affinity:
         nodeAffinity:
@@ -33,7 +33,7 @@ spec:
                   - key: node.kubernetes.io/instance-type
                     operator: In
                     values:
-                      - c6a.8xlarge
+                      - r6a.2xlarge
                   - key: topology.kubernetes.io/zone
                     operator: In
                     values:


### PR DESCRIPTION
The read-only dhstore instances barely use any CPU. Move them to much cheaper memory optimised instances.

