### PR TITLE
Move inga to c6a-8xl instances with more subnet IPs

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/deployment.yaml
@@ -18,11 +18,11 @@ spec:
               mountPath: /data
           resources:
             limits:
-              cpu: "45"
-              memory: 50Gi
+              cpu: "28"
+              memory: 58Gi
             requests:
-              cpu: "45"
-              memory: 50Gi
+              cpu: "28"
+              memory: 58Gi
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -31,7 +31,7 @@ spec:
                   - key: node.kubernetes.io/instance-type
                     operator: In
                     values:
-                      - c6a.12xlarge
+                      - c6a.8xlarge
                   - key: topology.kubernetes.io/zone
                     operator: In
                     values:


### PR DESCRIPTION
* Move to cheaper instances while the ingest pipeline is out since the previous one was underutilised.

* The worker group associated with the new instance type has spare IPs, which should resolve the scheduling problem.
