### PR TITLE
Remove redundant c6a-12xl working group

### DIFF
--- a/deploy/infrastructure/prod/us-east-2/eks.tf
+++ b/deploy/infrastructure/prod/us-east-2/eks.tf
@@ -142,13 +142,6 @@ module "eks" {
         data.aws_subnet.ue2c1.id, data.aws_subnet.ue2c2.id, data.aws_subnet.ue2c3.id
       ]
     }
-    prod-ue2-c6a-12xl = {
-      min_size       = 0
-      max_size       = 20
-      desired_size   = 1
-      instance_types = ["c6a.12xlarge"]
-      subnet_ids     = module.vpc.private_subnets
-    }
   }
 }
 

--- a/deploy/manifests/prod/us-east-2/cluster/kube-system/aws-auth.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/kube-system/aws-auth.yaml
@@ -90,11 +90,6 @@ data:
       - system:nodes
       rolearn: arn:aws:iam::407967248065:role/prod-ue2-c6a-8xl-eks-node-group
       username: system:node:{{EC2PrivateDNSName}}
-    - groups:
-      - system:bootstrappers
-      - system:nodes
-      rolearn: arn:aws:iam::407967248065:role/prod-ue2-c6a-12xl-eks-node-group
-      username: system:node:{{EC2PrivateDNSName}}
   mapUsers: |
     - userarn: arn:aws:iam::407967248065:user/masih
       username: masih


### PR DESCRIPTION
No longer needed as inga is migrated off to c6a8xl. This should also bring us cost savings going forward.


<!-- If yes, you can simply say:-->
<!-- Change is safe to revert. -->

<!-- If no, outline the steps required to revert this change. -->
