### PR TITLE
Remove temporary data-transfer fsm records at startup

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -133,6 +133,10 @@ func daemonAction(cctx *cli.Context) error {
 		return err
 	}
 	defer dsTmp.Close()
+	err = cleanupTempData(cctx.Context, dsTmp)
+	if err != nil {
+		return err
+	}
 	freezeDirs = append(freezeDirs, dsTmpDir)
 
 	if cfg.Indexer.UnfreezeOnStart {
@@ -691,4 +695,15 @@ func createDatastore(ctx context.Context, dir, dsType string) (datastore.Batchin
 		return nil, "", err
 	}
 	return ds, dataStorePath, nil
+}
+
+func cleanupTempData(ctx context.Context, ds datastore.Batching) error {
+	count, err := deletePrefix(ctx, ds, "/data-transfer-v2")
+	if err != nil {
+		return err
+	}
+	if count != 0 {
+		log.Infow("Removed old temporary data-transfer fsm records", "count", count)
+	}
+	return nil
 }


### PR DESCRIPTION
These are building up over time to take up significant space and do not serve any purpose since there is no need to resume data-transfer sessions across restarts.
