### PR TITLE
Fix admin sync with no address specified

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,8 +23,8 @@ require (
 	github.com/ipld/go-ipld-prime v0.21.0
 	github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd
 	github.com/ipni/go-indexer-core v0.8.2
-	github.com/ipni/go-libipni v0.5.5
-	github.com/libp2p/go-libp2p v0.32.0
+	github.com/ipni/go-libipni v0.5.6
+	github.com/libp2p/go-libp2p v0.32.1
 	github.com/libp2p/go-msgio v0.3.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/multiformats/go-multiaddr v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -591,8 +591,8 @@ github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236
 github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd/go.mod h1:9DD/GM0JNPoisgR09F62kbBi7kHa4eDIea4XshXYOVc=
 github.com/ipni/go-indexer-core v0.8.2 h1:Vq13NIUDRJQLOTr9WSa9nXBtLjyOd7Ti3rggWpaiF6Y=
 github.com/ipni/go-indexer-core v0.8.2/go.mod h1:28d+2YqNoWM8H8vNeFTUaW2hGqeJoqE7daK1EPvw0bE=
-github.com/ipni/go-libipni v0.5.5 h1:xksZe1ainp+h0KjWdK5tv7FJ8RR45l03UjrET7sWZ8c=
-github.com/ipni/go-libipni v0.5.5/go.mod h1:tdT8a9omKLwm4JEB/hV1Tm9b/4TQY7gKI2cJfN7I/5c=
+github.com/ipni/go-libipni v0.5.6 h1:dg71WdPyUj25z7dR2EW/7hYO+8i+ZG/sBpYzWj4sy8s=
+github.com/ipni/go-libipni v0.5.6/go.mod h1:+S7MXdUoYyrKK37clglSJyzIV8AkQYG5TuMZhLIgJek=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/i18n v0.0.0-20171121225848-987a633949d0/go.mod h1:pMCz62A0xJL6I+umB2YTlFRwWXaDFA0jy+5HzGiJjqI=
@@ -701,8 +701,8 @@ github.com/libp2p/go-libp2p v0.7.4/go.mod h1:oXsBlTLF1q7pxr+9w6lqzS1ILpyHsaBPniV
 github.com/libp2p/go-libp2p v0.8.1/go.mod h1:QRNH9pwdbEBpx5DTJYg+qxcVaDMAz3Ee/qDKwXujH5o=
 github.com/libp2p/go-libp2p v0.13.0/go.mod h1:pM0beYdACRfHO1WcJlp65WXyG2A6NqYM+t2DTVAJxMo=
 github.com/libp2p/go-libp2p v0.14.0/go.mod h1:dsQrWLAoIn+GkHPN/U+yypizkHiB9tnv79Os+kSgQ4Q=
-github.com/libp2p/go-libp2p v0.32.0 h1:86I4B7nBUPIyTgw3+5Ibq6K7DdKRCuZw8URCfPc1hQM=
-github.com/libp2p/go-libp2p v0.32.0/go.mod h1:hXXC3kXPlBZ1eu8Q2hptGrMB4mZ3048JUoS4EKaHW5c=
+github.com/libp2p/go-libp2p v0.32.1 h1:wy1J4kZIZxOaej6NveTWCZmHiJ/kY7GoAqXgqNCnPps=
+github.com/libp2p/go-libp2p v0.32.1/go.mod h1:hXXC3kXPlBZ1eu8Q2hptGrMB4mZ3048JUoS4EKaHW5c=
 github.com/libp2p/go-libp2p-asn-util v0.3.0 h1:gMDcMyYiZKkocGXDQ5nsUQyquC9+H+iLEQHwOCZ7s8s=
 github.com/libp2p/go-libp2p-asn-util v0.3.0/go.mod h1:B1mcOrKUE35Xq/ASTmQ4tN3LNzVVaMNmq2NACuqyB9w=
 github.com/libp2p/go-libp2p-autonat v0.1.0/go.mod h1:1tLf2yXxiE/oKGtDwPYWTSYG3PtvYlJmg7NeVtPRqH8=

--- a/server/admin/handler.go
+++ b/server/admin/handler.go
@@ -332,9 +332,12 @@ func (h *adminHandler) handlePostSyncs(w http.ResponseWriter, r *http.Request) {
 	h.pendingSyncs.Add(1)
 	go func() {
 		peerInfo := peer.AddrInfo{
-			ID:    peerID,
-			Addrs: []multiaddr.Multiaddr{syncAddr},
+			ID: peerID,
 		}
+		if syncAddr != nil {
+			peerInfo.Addrs = []multiaddr.Multiaddr{syncAddr}
+		}
+
 		_, err := h.ingester.Sync(h.ctx, peerInfo, int(depth), resync)
 		if err != nil {
 			log.Errorw("Cannot sync with peer", "err", err)

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.8.7"
+  "version": "v0.8.8"
 }


### PR DESCRIPTION
The admin sync command causes panic when no address is given. Fixed by avoiding nil multiaddr.

Update go-libp2p to fix timer leak.

Fixes #2388
