### PR TITLE
Fix error loading persisted handoff data

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1518,8 +1518,7 @@ func loadPersistedAssignments(ctx context.Context, dstore datastore.Datastore, d
 
 	// Load all assigned publishers from datastore.
 	q := query.Query{
-		Prefix:   assignmentsKeyPath,
-		KeysOnly: true,
+		Prefix: assignmentsKeyPath,
 	}
 	results, err := dstore.Query(ctx, q)
 	if err != nil {


### PR DESCRIPTION
## Context
When an indexer receives handoff from another frozen indexer it remembers the source of the handoff. This is persisted across restarts, but was not being loaded correctly, and the source was not loaded after a restart.

## Proposed Changes
Reload persisted data correctly from datastore.

## Tests
Added unit test to check that handoff data is loaded after a restart.

## Revert Strategy
Change is safe to revert.
