### PR TITLE
Add API to administratively mark advertisement as processed

### DIFF
--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -570,6 +570,12 @@ func (ing *Ingester) adAlreadyProcessed(adCid cid.Cid) (bool, bool) {
 	return processed, resync
 }
 
+// MarkAdProcessed explicitly marks an advertisement as processed. This is used
+// to avoid ingesting this and previous advertisements.
+func (ing *Ingester) MarkAdProcessed(publisher peer.ID, adCid cid.Cid) error {
+	return ing.markAdProcessed(publisher, adCid, false, false)
+}
+
 func (ing *Ingester) markAdProcessed(publisher peer.ID, adCid cid.Cid, frozen, keep bool) error {
 	cidStr := adCid.String()
 	ctx := context.Background()

--- a/server/admin/server.go
+++ b/server/admin/server.go
@@ -63,6 +63,7 @@ func New(listen string, id peer.ID, indexer indexer.Interface, ingester *ingest.
 	mux.HandleFunc("/healthcheck", h.healthCheckHandler)
 	mux.HandleFunc("/importproviders", h.importProviders)
 	mux.HandleFunc("/reloadconfig", h.reloadConfig)
+	mux.HandleFunc("/markadprocessed/", h.markAdProcessed)
 
 	// Ingester routes
 	mux.HandleFunc("/ingest/allow/", h.allowPeer)

--- a/server/admin/server_test.go
+++ b/server/admin/server_test.go
@@ -214,6 +214,25 @@ func TestStatus(t *testing.T) {
 	require.True(t, status.Frozen)
 }
 
+func TestMarkAdProcessed(t *testing.T) {
+	te := makeTestenv(t)
+
+	provAddr, _ := multiaddr.NewMultiaddr("/ip4/127.0.0.1/tcp/9999")
+	peerInfo := peer.AddrInfo{
+		ID:    peerID,
+		Addrs: []multiaddr.Multiaddr{provAddr},
+	}
+
+	err := te.registry.Update(context.Background(), peerInfo, peerInfo, cid.Undef, nil, 0)
+	require.NoError(t, err)
+
+	adCid, err := cid.Decode("bafybeigvgzoolc3drupxhlevdp2ugqcrbcsqfmcek2zxiw5wctk3xjpjwy")
+	require.NoError(t, err)
+
+	err = te.client.MarkAdProcessed(context.Background(), peerID, adCid)
+	require.NoError(t, err)
+}
+
 func writeJsonResponse(w http.ResponseWriter, status int, body []byte) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(status)


### PR DESCRIPTION
This allows explicitly marking an advertisement as processed to avoid processing an advertisement or those before it.
