### PR TITLE
Deploy dhstore on dev that supports index deletion

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago2/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago2/kustomization.yaml
@@ -18,4 +18,4 @@ patchesStrategicMerge:
 images:
   - name: dhstore
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
-    newTag: 20231121181533-cea5ef70253e284ea8cf9fc529adf5470a16e774
+    newTag: 20231130062633-638e69afc14179ce171c98f0045f03efb8773cd4

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago3/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago3/kustomization.yaml
@@ -18,4 +18,4 @@ patchesStrategicMerge:
 images:
   - name: dhstore
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
-    newTag: 20231121181533-cea5ef70253e284ea8cf9fc529adf5470a16e774
+    newTag: 20231130062633-638e69afc14179ce171c98f0045f03efb8773cd4

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago4/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago4/kustomization.yaml
@@ -18,4 +18,4 @@ patchesStrategicMerge:
 images:
   - name: dhstore
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
-    newTag: 20231121181533-cea5ef70253e284ea8cf9fc529adf5470a16e774
+    newTag: 20231130062633-638e69afc14179ce171c98f0045f03efb8773cd4

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore/kustomization.yaml
@@ -15,4 +15,4 @@ patchesStrategicMerge:
 images:
   - name: dhstore
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
-    newTag: 20231121181533-cea5ef70253e284ea8cf9fc529adf5470a16e774
+    newTag: 20231130062633-638e69afc14179ce171c98f0045f03efb8773cd4


### PR DESCRIPTION
Latest is already running on write instance, so this only deploys the read instances.