### PR TITLE
Do not save empty advertisements to mirror

### DIFF
--- a/ipni-gc/reaper/reaper.go
+++ b/ipni-gc/reaper/reaper.go
@@ -997,9 +997,7 @@ func (s *scythe) removeEntries(ctx context.Context, adCid cid.Cid) error {
 		}
 	}
 	newRemoved := s.stats.IndexesRemoved - prevRemoved
-	if newRemoved != 0 {
-		log.Infow("Removed indexes in removed ad", "adCid", adCid, "count", newRemoved, "total", s.stats.IndexesRemoved, "source", source)
-	}
+	log.Infow("Removed indexes in removed ad", "adCid", adCid, "count", newRemoved, "total", s.stats.IndexesRemoved, "source", source)
 	return nil
 }
 


### PR DESCRIPTION
Empty advertisements should not be saved to mirror since they do not help index ingestion. Advertisements may have no multihash entries when:

1. The ad removes a context ID
  When ingesting ads, the indexer does not read removal ads from the mirror since there is no entry data to get.
2. The ad only updates metadata or provider information
  The indexer stores the metadata, but does not read mirror since there are no entries
3. The ad was deleted by a removal ad later in the chain
  Once an ad is known to be deleted, that ad will never be read from the mirror since its content is deleted
4. The publisher is not serving entries data
  This is treated like a no-content ad, as in case 2, but means that at some point in the past the ad had entry data. There is or should be a pending unpublished removal later in the chain. So, do not save this in a mirror since it will end up being deleted later, or may be a temporary publisher error that should be queried by another indexer using the mirror. In either case, the advertisement should not be written to the mirror.

GC also removes any empty (no-content) advertisements from the mirror, and reindexing must not repopulate them.

Other changes:
- GC always logs number of indexes removed
- Always HAMT entries which are not mirrored
