### PR TITLE
Configurable option to skip ads with 500 error on first entries block

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -612,6 +612,7 @@ func reloadConfig(cfgPath string, ingester *ingest.Ingester, reg *registry.Regis
 
 	if ingester != nil {
 		ingester.RunWorkers(cfg.Ingest.IngestWorkerCount)
+		ingester.Skip500EntriesError(cfg.Ingest.Skip500EntriesError)
 	}
 
 	err = setLoggingConfig(cfg.Logging)

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -52,8 +52,9 @@ type Ingest struct {
 	// IngestWorkerCount sets how many ingest worker goroutines to spawn. This
 	// controls how many concurrent ingest from different providers we can handle.
 	IngestWorkerCount int
-	// MaxAsyncConcurrency sets the maximum number of concurrent asynchrouous syncs
-	// (started by announce messages). Set -1 for unlimited, 0 for default.
+	// MaxAsyncConcurrency sets the maximum number of concurrent asynchrouous
+	// syncs (started by announce messages). Set -1 for unlimited, 0 for
+	// default. This value is reloadable.
 	MaxAsyncConcurrency int
 	// MinimumKeyLengt causes any multihash, that has a digest length less than
 	// this, to be ignored.
@@ -69,6 +70,10 @@ type Ingest struct {
 	// the announce so that other indexers can also receive it. This is always
 	// false if configured to use an assigner.
 	ResendDirectAnnounce bool
+	// Skip500EntriesError, when true, skips advertisements for which the
+	// publisher returns a 500 status code and an error message "failed to sync
+	// first entry". This value is reloadable.
+	Skip500EntriesError bool
 	// SyncSegmentDepthLimit is the depth limit of a single sync in a series of
 	// calls that collectively sync advertisements or their entries. The value
 	// -1 disables the segmentation where the sync will be done in a single call

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
@@ -89,6 +89,7 @@
     "IngestWorkerCount": 30,
     "PubSubTopic": "/indexer/ingest/mainnet",
     "ResendDirectAnnounce": false,
+    "Skip500EntriesError": true,
     "SyncSegmentDepthLimit": 2000,
     "SyncTimeout": "2h0m0s"
   },

--- a/doc/config.md
+++ b/doc/config.md
@@ -13,5 +13,6 @@ The storetheindex daemon can reload some portions of its config without restarti
 - `Indexer.ConfigCheckInterval`
 - `Indexer.ShutdownTimeout`
 - `Ingest.IngestWorkerCount`
+- `Ingest.Skip500EntriesError`
 - `Logging`
 - `Peering`


### PR DESCRIPTION
## Context
A new boolean config option `Ingest.Skip500EntriesError` allows the indexer to skip advertisements when the publisher returns a 500 response with "failed to sync first entry". This value is run-time reloadable.

The purpose of this is to skip ads that to publisher will never deliver content for. There is an issue with providers where they will not return entries from some advertisements, and permanently return a 500 result when trying to sync the entries.

## Proposed Changes
If the option is enabled, then skip ads that result in a 500 error when syncing the first entries block.

## Tests
Manual testing with providers exhibiting this behavior. Also, tested changing this value in the config file is reloadable.

## Revert Strategy
Change is safe to revert.
