### PR TITLE
Block bad publisher

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/assigner/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/assigner/config.json
@@ -9,7 +9,7 @@
     "IndexerPool": [],
     "Policy": {
       "Allow": true,
-      "Except": null
+      "Except": ["12D3KooWJA2ETdy5wYTbCHVqKdgrqtmuNEwjMVMwEtMrNugrsGkZ"]
     },
     "PubSubTopic": "/indexer/ingest/mainnet",
     "Replication": 1

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
@@ -40,7 +40,7 @@
     "IgnoreBadAdsTime": "2h0m0s",
     "Policy": {
       "Allow": true,
-      "Except": null,
+      "Except": ["12D3KooWJA2ETdy5wYTbCHVqKdgrqtmuNEwjMVMwEtMrNugrsGkZ"],
       "Publish": true,
       "PublishExcept": null
     },


### PR DESCRIPTION
This provider publishes large numbers of advertisements, with each ad having a single multihash. Then publishing separate removal advertisements to delete each of those. Indexing cannot be done like this. It is not only incredibly inefficient but will fill up the indexer's local datastore with remembering processed ad CIDs.

Blocking publisher at both assigner and indexer.
