### PR TITLE
Revert "Block bad publisher"

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/assigner/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/assigner/config.json
@@ -9,7 +9,7 @@
     "IndexerPool": [],
     "Policy": {
       "Allow": true,
-      "Except": ["12D3KooWJA2ETdy5wYTbCHVqKdgrqtmuNEwjMVMwEtMrNugrsGkZ"]
+      "Except": null
     },
     "PubSubTopic": "/indexer/ingest/mainnet",
     "Replication": 1

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
@@ -40,7 +40,7 @@
     "IgnoreBadAdsTime": "2h0m0s",
     "Policy": {
       "Allow": true,
-      "Except": ["12D3KooWJA2ETdy5wYTbCHVqKdgrqtmuNEwjMVMwEtMrNugrsGkZ"],
+      "Except": null,
       "Publish": true,
       "PublishExcept": null
     },


### PR DESCRIPTION
Reverts ipni/storetheindex#2500.

PeerID not used anymore, no need to block.