### PR TITLE
Configurable first sync depth

### DIFF
--- a/config/ingest.go
+++ b/config/ingest.go
@@ -32,6 +32,11 @@ type Ingest struct {
 	// (segments) of size set by SyncSegmentDepthLimit. EntriesDepthLimit sets
 	// the limit on the total number of entries chunks across all segments.
 	EntriesDepthLimit int
+	// FirstSyncDepth sets the advertisement chain depth to sync on the first
+	// sync with a new provider. To sync a new provider with only the most
+	// recent advertisement, set this to 1. A value of 0, the default, means
+	// unlimited depth.
+	FirstSyncDepth int
 	// GsMaxInRequests is the maximum number of incoming in-progress graphsync
 	// requests. Default is 1024.
 	GsMaxInRequests uint64

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/ipld/go-ipld-prime v0.21.0
 	github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd
 	github.com/ipni/go-indexer-core v0.8.7
-	github.com/ipni/go-libipni v0.5.9
+	github.com/ipni/go-libipni v0.5.11
 	github.com/libp2p/go-libp2p v0.32.2
 	github.com/libp2p/go-msgio v0.3.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -594,8 +594,8 @@ github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236
 github.com/ipld/go-ipld-prime/storage/dsadapter v0.0.0-20230102063945-1a409dc236dd/go.mod h1:9DD/GM0JNPoisgR09F62kbBi7kHa4eDIea4XshXYOVc=
 github.com/ipni/go-indexer-core v0.8.7 h1:IaEBoVe1RiTBDTj8MiUlbsYk/L32AOjtCBhQQmXuxIo=
 github.com/ipni/go-indexer-core v0.8.7/go.mod h1:lLWTrQ7dhKwCak1qn6AQBNoSrGYBAXJJy2OGc02BO2Q=
-github.com/ipni/go-libipni v0.5.9 h1:AlYlqZScX2jusGXXWkW5j6OMUtMKgQKNcl1Mi8g3glA=
-github.com/ipni/go-libipni v0.5.9/go.mod h1:c8mHa6J9iFREpDB29GlPIsbvztRq6bnhg5zJKrnvdUg=
+github.com/ipni/go-libipni v0.5.11 h1:h79WCuLwAekIQpw09lzJ5FDc432FtEt1pxHnJavDs10=
+github.com/ipni/go-libipni v0.5.11/go.mod h1:c8mHa6J9iFREpDB29GlPIsbvztRq6bnhg5zJKrnvdUg=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/i18n v0.0.0-20171121225848-987a633949d0/go.mod h1:pMCz62A0xJL6I+umB2YTlFRwWXaDFA0jy+5HzGiJjqI=

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -218,6 +218,7 @@ func NewIngester(cfg config.Ingest, h host.Host, idxr indexer.Interface, reg *re
 	sub, err := dagsync.NewSubscriber(h, ing.dsTmp, ing.lsys, cfg.PubSubTopic,
 		dagsync.AdsDepthLimit(int64(cfg.AdvertisementDepthLimit)),
 		dagsync.EntriesDepthLimit(int64(cfg.EntriesDepthLimit)),
+		dagsync.FirstSyncDepth(int64(cfg.FirstSyncDepth)),
 		dagsync.WithLastKnownSync(ing.getLastKnownSync),
 		dagsync.SegmentDepthLimit(int64(cfg.SyncSegmentDepthLimit)),
 		dagsync.BlockHook(ing.generalDagsyncBlockHook),


### PR DESCRIPTION
A new config item `FirstSyncDepth` sets the advertisement chain depth to sync on the first sync with a new provider. To sync a new provider with only the most recent advertisement, set this to 1. A value of 0, the default, means unlimited depth.

This option is useful to avoid syncing advertisement chains back to the beginning of time.

Unit tests in `go-libipni` test that is feature works, and manual testing with storetheindex was also done.