### PR TITLE
Revert assigner startup config change

### DIFF
--- a/deploy/manifests/base/assigner/deployment.yaml
+++ b/deploy/manifests/base/assigner/deployment.yaml
@@ -28,8 +28,9 @@ spec:
       containers:
         - name: assigner
           image: storetheindex
+          command: ["/sbin/tini", "--", "/usr/local/bin/start_assigner"]
           args:
-            - 'assigner'
+            - 'daemon'
           env:
             - name: GOLOG_LOG_LEVEL
               value: INFO


### PR DESCRIPTION
FYI, looks like assigner is now failing:
```
cannot write to /data/storetheindex: permission denied
```
Reverting last change to assigner startup.