### PR TITLE
Avoid mirror head check if CAR was read from write mirror

### DIFF
--- a/carstore/carreader.go
+++ b/carstore/carreader.go
@@ -93,10 +93,12 @@ func carFilePath(adCid cid.Cid, compAlg string) string {
 	return carPath
 }
 
+// CarPath returns the name of the CAR file being read.
 func (cr CarReader) CarPath(adCid cid.Cid) string {
 	return carFilePath(adCid, cr.compAlg)
 }
 
+// Compression returns the name of the compression used to compress CAR files.
 func (cr CarReader) Compression() string {
 	return cr.compAlg
 }

--- a/carstore/carreader_test.go
+++ b/carstore/carreader_test.go
@@ -31,7 +31,7 @@ func TestRead(t *testing.T) {
 	ctx := context.Background()
 
 	// Create car file
-	_, err = carw.Write(ctx, adCid, false, false, false)
+	_, err = carw.Write(ctx, adCid, false, false)
 	require.NoError(t, err)
 
 	// Create reader.

--- a/carstore/carreader_test.go
+++ b/carstore/carreader_test.go
@@ -31,7 +31,7 @@ func TestRead(t *testing.T) {
 	ctx := context.Background()
 
 	// Create car file
-	_, err = carw.Write(ctx, adCid, false, true)
+	_, err = carw.Write(ctx, adCid, false, false, false)
 	require.NoError(t, err)
 
 	// Create reader.

--- a/carstore/carwriter.go
+++ b/carstore/carwriter.go
@@ -264,7 +264,7 @@ func (cw *CarWriter) write(ctx context.Context, adCid cid.Cid, ad schema.Adverti
 // previous advertisement, then it is written also. This continues until there
 // are no more previous advertisements in the datastore or until an
 // advertisement does not have a previous.
-func (cw *CarWriter) WriteChain(ctx context.Context, adCid cid.Cid, overWrite bool) (int, error) {
+func (cw *CarWriter) WriteChain(ctx context.Context, adCid cid.Cid, noOverwrite bool) (int, error) {
 	rmCtxID := make(map[string]struct{})
 	var count int
 
@@ -280,7 +280,7 @@ func (cw *CarWriter) WriteChain(ctx context.Context, adCid cid.Cid, overWrite bo
 		ctxIdStr := string(ad.ContextID)
 		_, skipEnts := rmCtxID[ctxIdStr]
 
-		_, err = cw.write(ctx, adCid, ad, data, skipEnts, !overWrite)
+		_, err = cw.write(ctx, adCid, ad, data, skipEnts, noOverwrite)
 		if err != nil {
 			return 0, err
 		}

--- a/carstore/carwriter_test.go
+++ b/carstore/carwriter_test.go
@@ -60,7 +60,7 @@ func TestWrite(t *testing.T) {
 	require.True(t, ok)
 
 	// Test that car file is created.
-	carInfo, err := carw.Write(ctx, adCid, false, false, false)
+	carInfo, err := carw.Write(ctx, adCid, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, carInfo)
 	headInfo, err := fileStore.Head(ctx, carInfo.Path)
@@ -178,7 +178,7 @@ func TestWriteToExistingAdCar(t *testing.T) {
 	carw, err := carstore.NewWriter(dstore, fileStore, carstore.WithCompress(testCompress))
 	require.NoError(t, err)
 
-	carInfo, err := carw.Write(ctx, adCid, false, false, true)
+	carInfo, err := carw.Write(ctx, adCid, false, true)
 	require.ErrorIs(t, err, fs.ErrExist)
 	require.Zero(t, carInfo.Size)
 

--- a/carstore/carwriter_test.go
+++ b/carstore/carwriter_test.go
@@ -60,7 +60,7 @@ func TestWrite(t *testing.T) {
 	require.True(t, ok)
 
 	// Test that car file is created.
-	carInfo, err := carw.Write(ctx, adCid, false, false)
+	carInfo, err := carw.Write(ctx, adCid, false, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, carInfo)
 	headInfo, err := fileStore.Head(ctx, carInfo.Path)
@@ -178,7 +178,7 @@ func TestWriteToExistingAdCar(t *testing.T) {
 	carw, err := carstore.NewWriter(dstore, fileStore, carstore.WithCompress(testCompress))
 	require.NoError(t, err)
 
-	carInfo, err := carw.Write(ctx, adCid, false, false)
+	carInfo, err := carw.Write(ctx, adCid, false, false, true)
 	require.ErrorIs(t, err, fs.ErrExist)
 	require.Zero(t, carInfo.Size)
 

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -1241,6 +1241,9 @@ func (ing *Ingester) ingestWorkerLogic(ctx context.Context, provider peer.ID, as
 
 		if putMirror {
 			if fromMirror && ing.mirror.readWriteSame() {
+				// If ad data retrieved from same mirror that is being written
+				// to, then only clean up the data from local datastore, but do
+				// not rewrite it to the mirror.
 				err = ing.mirror.cleanupAdData(ctx, ai.cid, false)
 				if err != nil {
 					log.Errorw("Cannot remove advertisement data from datastore", "err", err)

--- a/internal/ingest/mirror.go
+++ b/internal/ingest/mirror.go
@@ -15,6 +15,7 @@ import (
 type adMirror struct {
 	carReader *carstore.CarReader
 	carWriter *carstore.CarWriter
+	rdWrSame  bool
 }
 
 func (m adMirror) canRead() bool {
@@ -28,12 +29,16 @@ func (m adMirror) read(ctx context.Context, adCid cid.Cid, skipEntries bool) (*c
 	return m.carReader.Read(ctx, adCid, skipEntries)
 }
 
-func (m adMirror) write(ctx context.Context, adCid cid.Cid, skipEntries, overWrite bool) (*filestore.File, error) {
-	return m.carWriter.Write(ctx, adCid, skipEntries, overWrite)
+func (m adMirror) write(ctx context.Context, adCid cid.Cid, skipEntries, cleanupOnly, noOoverwrite bool) (*filestore.File, error) {
+	return m.carWriter.Write(ctx, adCid, skipEntries, cleanupOnly, noOoverwrite)
 }
 
 func (m adMirror) writeHead(ctx context.Context, adCid cid.Cid, publisher peer.ID) (*filestore.File, error) {
 	return m.carWriter.WriteHead(ctx, adCid, publisher)
+}
+
+func (m adMirror) readWriteSame() bool {
+	return m.rdWrSame
 }
 
 func newMirror(cfgMirror config.Mirror, dstore datastore.Batching) (adMirror, error) {
@@ -62,6 +67,10 @@ func newMirror(cfgMirror config.Mirror, dstore datastore.Batching) (adMirror, er
 		m.carReader, err = carstore.NewReader(fileStore, carstore.WithCompress(cfgMirror.Compress))
 		if err != nil {
 			return m, fmt.Errorf("cannot create car file reader: %w", err)
+		}
+
+		if m.carWriter != nil { // TODO: && rdFileStore == wrFileStore {
+			m.rdWrSame = true
 		}
 	}
 

--- a/internal/ingest/mirror.go
+++ b/internal/ingest/mirror.go
@@ -25,12 +25,16 @@ func (m adMirror) canWrite() bool {
 	return m.carWriter != nil
 }
 
+func (m adMirror) cleanupAdData(ctx context.Context, adCid cid.Cid, skipEntries bool) error {
+	return m.carWriter.CleanupAdData(ctx, adCid, skipEntries)
+}
+
 func (m adMirror) read(ctx context.Context, adCid cid.Cid, skipEntries bool) (*carstore.AdBlock, error) {
 	return m.carReader.Read(ctx, adCid, skipEntries)
 }
 
-func (m adMirror) write(ctx context.Context, adCid cid.Cid, skipEntries, cleanupOnly, noOoverwrite bool) (*filestore.File, error) {
-	return m.carWriter.Write(ctx, adCid, skipEntries, cleanupOnly, noOoverwrite)
+func (m adMirror) write(ctx context.Context, adCid cid.Cid, skipEntries, noOoverwrite bool) (*filestore.File, error) {
+	return m.carWriter.Write(ctx, adCid, skipEntries, noOoverwrite)
 }
 
 func (m adMirror) writeHead(ctx context.Context, adCid cid.Cid, publisher peer.ID) (*filestore.File, error) {


### PR DESCRIPTION
This prevents checking if the CAR file already exists in the mirror, unless `noOverwrite` is specifically asked for. 