### PR TITLE
Build ipnigc without CGO in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY go.* .
 RUN go mod download
 COPY . .
 
-RUN CGO_ENABLED=0 go build  && go build ./ipni-gc/cmd/ipnigc
+RUN CGO_ENABLED=0 go build && CGO_ENABLED=0 go build ./ipni-gc/cmd/ipnigc
 
 # Debug non-root image used as base in order to provide easier administration and debugging.
 FROM gcr.io/distroless/static-debian12:debug-nonroot


### PR DESCRIPTION
Looks like `ipnigc` executable cannot find shared lib:
```shell
/home/nonroot $ /usr/local/bin/ipnigc
sh: /usr/local/bin/ipnigc: not found

/home/nonroot $ ls -l /usr/local/bin/ipnigc
-rwxr-xr-x    1 root     root      53153192 Feb 15 17:28 /usr/local/bin/ipnigc
```
Build without CGO