### PR TITLE
Allow configuration of per-provider publishers policy

### DIFF
--- a/config/policy.go
+++ b/config/policy.go
@@ -47,6 +47,7 @@ type PublishersPolicy struct {
 // NewPolicy returns Policy with values set to their defaults.
 func NewPolicy() Policy {
 	return Policy{
-		Allow: true,
+		Allow:   true,
+		Publish: true,
 	}
 }

--- a/config/policy.go
+++ b/config/policy.go
@@ -21,22 +21,32 @@ type Policy struct {
 	// in Except. in other words, Allow=true means that Except is a deny-list
 	// and Allow=false means that Except is an allow-list.
 	Except []string
-
-	// Publish determines whether or not peers are allowed to publish
+	// Publish is the default Allow policy when a provider has no policy in
+	// PublisherForProviders. It determines if any peers are allowed to publish
 	// advertisements for a provider with a differen peer ID.
 	Publish bool
-	// PublisherExcept is a list of peer IDs that are exceptions to the Publish
-	// policy. If Publish is false, then all allowed peers cannot publish
-	// advertisements for providers with a different peer ID, unless listed in
-	// PublishExcept. If Publish is true, then all allowed peers can publish
-	// advertisements for any provider, unless listed in PublishExcept.
+	// PublisherExcept is a list of peer IDs that are exceptions to the default
+	// Publish policy.
 	PublishExcept []string
+	// PublishersForProvider is a list of policies specifying which publishers
+	// are allowed to publish advertisements on behalf of a specified provider.
+	PublishersForProvider []PublishersPolicy
+}
+
+type PublishersPolicy struct {
+	// Provider is the provider peer ID this policy pertains to.
+	Provider string
+	// Allow determines whether a peer is allowed or blocked from publishing
+	// advertisements on behalf of a provider with a differen peer ID.
+	Allow bool
+	// Except is a list of peer IDs that are exceptions to the Allow
+	// policy.
+	Except []string
 }
 
 // NewPolicy returns Policy with values set to their defaults.
 func NewPolicy() Policy {
 	return Policy{
-		Allow:   true,
-		Publish: true,
+		Allow: true,
 	}
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -569,7 +569,9 @@ func TestPollProviderOverrides(t *testing.T) {
 
 func TestRegistry_RegisterOrUpdateToleratesEmptyPublisherAddrs(t *testing.T) {
 	ctx := context.Background()
-	subject, err := New(ctx, config.NewDiscovery(), datastore.NewMapDatastore())
+	cfg := config.NewDiscovery()
+	cfg.Policy.Publish = true
+	subject, err := New(ctx, cfg, datastore.NewMapDatastore())
 	require.NoError(t, err)
 	t.Cleanup(func() { subject.Close() })
 
@@ -607,6 +609,7 @@ func TestRegistry_RegisterOrUpdateToleratesEmptyPublisherAddrs(t *testing.T) {
 
 func TestFilterIPs(t *testing.T) {
 	cfg := config.NewDiscovery()
+	cfg.Policy.Publish = true
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()


### PR DESCRIPTION
This allows each provider to have its own policy for which publishers are allowed to publish advertisements on behalf of that provider. The previous publisher policy serves as the default when there is no policy configured for a specific provider.
