### PR TITLE
Clean up old users and permissions

### DIFF
--- a/deploy/infrastructure/common/github_actions.tf
+++ b/deploy/infrastructure/common/github_actions.tf
@@ -55,10 +55,6 @@ module "github_actions_role" {
   ]
 
   oidc_subjects_with_wildcards = [
-    "repo:filecoin-project/storetheindex:*",
-    "repo:filecoin-project/index-provider:*",
-    "repo:filecoin-shipyard/index-observer:*",
-    "repo:filecoin-shipyard/indexstar:*",
     "repo:ipni/*:*"
   ]
 }

--- a/deploy/infrastructure/dev/us-east-2/index-provider.tf
+++ b/deploy/infrastructure/dev/us-east-2/index-provider.tf
@@ -34,7 +34,6 @@ data "aws_iam_policy_document" "kms_index_provider" {
         "arn:aws:iam::407967248065:user/masih",
         "arn:aws:iam::407967248065:user/gammazero",
         "arn:aws:iam::407967248065:user/will.scott",
-        "arn:aws:iam::407967248065:user/ischasny",
       ]
     }
 

--- a/deploy/infrastructure/dev/us-east-2/kms.tf
+++ b/deploy/infrastructure/dev/us-east-2/kms.tf
@@ -34,7 +34,6 @@ data "aws_iam_policy_document" "kms_sti" {
         "arn:aws:iam::407967248065:user/masih",
         "arn:aws:iam::407967248065:user/gammazero",
         "arn:aws:iam::407967248065:user/will.scott",
-        "arn:aws:iam::407967248065:user/ischasny",
       ]
     }
 
@@ -138,7 +137,6 @@ data "aws_iam_policy_document" "kms_cluster" {
         "arn:aws:iam::407967248065:user/masih",
         "arn:aws:iam::407967248065:user/gammazero",
         "arn:aws:iam::407967248065:user/will.scott",
-        "arn:aws:iam::407967248065:user/ischasny",
       ]
     }
 

--- a/deploy/infrastructure/prod/us-east-2/kms.tf
+++ b/deploy/infrastructure/prod/us-east-2/kms.tf
@@ -32,7 +32,6 @@ data "aws_iam_policy_document" "kms_sti" {
         "arn:aws:iam::407967248065:user/masih",
         "arn:aws:iam::407967248065:user/gammazero",
         "arn:aws:iam::407967248065:user/will.scott",
-        "arn:aws:iam::407967248065:user/ischasny",
       ]
     }
 

--- a/deploy/manifests/dev/us-east-2/cluster/kube-system/aws-auth.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kube-system/aws-auth.yaml
@@ -77,19 +77,3 @@ data:
       username: will.scott
       groups:
         - system:masters
-    - userarn: arn:aws:iam::407967248065:user/hannahhoward
-      username: hannahhoward
-      groups:
-        - system:masters
-    - userarn: arn:aws:iam::407967248065:user/mayank.pandey
-      username: mayank.pandey
-      groups:
-        - system:masters
-    - userarn: arn:aws:iam::407967248065:user/ischasny
-      username: ischasny
-      groups:
-        - system:masters
-    - userarn: arn:aws:iam::407967248065:user/rodvagg
-      username: rodvagg
-      groups:
-        - system:masters

--- a/deploy/manifests/prod/us-east-2/cluster/kube-system/aws-auth.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/kube-system/aws-auth.yaml
@@ -103,11 +103,3 @@ data:
       username: will.scott
       groups:
         - system:masters
-    - userarn: arn:aws:iam::407967248065:user/mayank.pandey
-      username: mayank.pandey
-      groups:
-        - system:masters
-    - userarn: arn:aws:iam::407967248065:user/ischasny
-      username: ischasny
-      groups:
-        - system:masters


### PR DESCRIPTION
Remove redundant access to resources and clean up permissions.

This is in prep for phasing out the AWS environment.
