### PR TITLE
Undeploy underused CRDs from dev

### DIFF
--- a/deploy/manifests/dev/us-east-2/cluster/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/kustomization.yaml
@@ -16,5 +16,3 @@ resources:
   - index-provider
   - external-snapshotter
   - snapshots
-  - ../../../base/k6-operator
-  - ../../../base/foundationdb/crds


### PR DESCRIPTION
Undeploy K6 controller and foundation DB CRDs from dev. They are no longer in-use.

