### PR TITLE
Undeploy grafana dashboard from K8S clusters

### DIFF
--- a/deploy/manifests/dev/us-east-2/cluster/monitoring/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/monitoring/kustomization.yaml
@@ -7,3 +7,7 @@ resources:
 patchesStrategicMerge:
   - patch.yaml
   - prometheus-patch.yaml
+
+replicas:
+  - name: grafana
+    count: 0

--- a/deploy/manifests/prod/us-east-2/cluster/monitoring/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/monitoring/kustomization.yaml
@@ -7,3 +7,7 @@ resources:
 patchesStrategicMerge:
   - patch.yaml
   - prometheus-patch.yaml
+
+replicas:
+  - name: grafana
+    count: 0


### PR DESCRIPTION
Reduce grafana dashboard replcia count to zero as it is unused.

