### PR TITLE
Reduce cluster controller replicas

### DIFF
--- a/deploy/manifests/dev/us-east-2/cluster/flux-system/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/flux-system/kustomization.yaml
@@ -10,3 +10,8 @@ resources:
 patchesStrategicMerge:
   - sa-patch.yaml
 
+replicas:
+  - name: helm-controller
+    count: 0
+  - name: notification-controller
+    count: 0

--- a/deploy/manifests/dev/us-east-2/cluster/monitoring/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/monitoring/kustomization.yaml
@@ -11,3 +11,5 @@ patchesStrategicMerge:
 replicas:
   - name: grafana
     count: 0
+  - name: prometheus-adapter
+    count: 1

--- a/deploy/manifests/dev/us-east-2/cluster/monitoring/patch.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/monitoring/patch.yaml
@@ -32,3 +32,11 @@ metadata:
   namespace: monitoring
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::407967248065:role/dev_monitoring"
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Alertmanager
+metadata:
+  name: main
+  namespace: monitoring
+spec:
+  replicas: 0

--- a/deploy/manifests/dev/us-east-2/cluster/monitoring/prometheus-patch.yaml
+++ b/deploy/manifests/dev/us-east-2/cluster/monitoring/prometheus-patch.yaml
@@ -4,6 +4,8 @@ metadata:
   name: k8s
   namespace: monitoring
 spec:
+  alerting: { }
+  replicas: 1
   # Do not include prometheus_replica label in metrics. Because, running more than one replicas
   # results in duplicate metrics.
   replicaExternalLabelName: ""

--- a/deploy/manifests/prod/us-east-2/cluster/flux-system/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/flux-system/kustomization.yaml
@@ -9,3 +9,9 @@ resources:
 
 patchesStrategicMerge:
   - kust-ctrlr-sa-patch.yaml
+
+replicas:
+  - name: helm-controller
+    count: 0
+  - name: notification-controller
+    count: 0

--- a/deploy/manifests/prod/us-east-2/cluster/monitoring/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/monitoring/kustomization.yaml
@@ -11,3 +11,5 @@ patchesStrategicMerge:
 replicas:
   - name: grafana
     count: 0
+  - name: prometheus-adapter
+    count: 1

--- a/deploy/manifests/prod/us-east-2/cluster/monitoring/patch.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/monitoring/patch.yaml
@@ -32,3 +32,11 @@ metadata:
   namespace: monitoring
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::407967248065:role/prod/us-east-2/monitoring"
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Alertmanager
+metadata:
+  name: main
+  namespace: monitoring
+spec:
+  replicas: 0

--- a/deploy/manifests/prod/us-east-2/cluster/monitoring/prometheus-patch.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/monitoring/prometheus-patch.yaml
@@ -4,6 +4,8 @@ metadata:
   name: k8s
   namespace: monitoring
 spec:
+  alerting: { }
+  replicas: 1
   # Do not include prometheus_replica label in metrics. Because, running more than one replicas
   # results in duplicate metrics.
   replicaExternalLabelName: ""


### PR DESCRIPTION
To reduce resource usage, undeploy or reduce unused cluster-level controllers.
