### PR TITLE
Allow dhstore on dev to use any available node

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago3/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago3/deployment.yaml
@@ -52,9 +52,3 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: dhstore-data-ago3
-      tolerations:
-        - key: dedicated
-          operator: Equal
-          value: r5n-2xl
-          effect: NoSchedule
-

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago4/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago4/deployment.yaml
@@ -52,9 +52,3 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: dhstore-data-ago4
-      tolerations:
-        - key: dedicated
-          operator: Equal
-          value: r5n-2xl
-          effect: NoSchedule
-

--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago5/deployment.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/dhstore-ago5/deployment.yaml
@@ -52,9 +52,3 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: dhstore-data-ago5
-      tolerations:
-        - key: dedicated
-          operator: Equal
-          value: r5n-2xl
-          effect: NoSchedule
-


### PR DESCRIPTION
Remove dedicated taint requirement for a specific instance type.

This allows dhstore on dev to use any available resource for better infra utilisation.

