### PR TITLE
Deploy indexer without graphsync to dev

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/kustomization.yaml
@@ -18,4 +18,4 @@ resources:
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex # {"$imagepolicy": "storetheindex:storetheindex:name"}
-  newTag: 20240308120224-503379c9f186e9c9063ebc105e651f6e93d3e6bb # {"$imagepolicy": "storetheindex:storetheindex:tag"}
+  newTag: 20240318083023-1b4a75671868ddda4026bbea575d84707877c688 # {"$imagepolicy": "storetheindex:storetheindex:tag"}


### PR DESCRIPTION
Experimentally deploy indexer with no data-transfer/graphsync support to see if it still exhibits worker deadlock issues.