### PR TITLE
Write complete CAR file when index content read from CAR file

### DIFF
--- a/command/updatemirror.go
+++ b/command/updatemirror.go
@@ -1,0 +1,148 @@
+package command
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/ipni/storetheindex/carstore"
+	"github.com/ipni/storetheindex/config"
+	"github.com/ipni/storetheindex/filestore"
+	"github.com/urfave/cli/v2"
+)
+
+var UpdateMirrorCmd = &cli.Command{
+	Name:   "update-mirror",
+	Usage:  "Update CAR files from read mirror to write mirror",
+	Action: updateMirrorAction,
+}
+
+func updateMirrorAction(cctx *cli.Context) error {
+	cfgMirror, err := getMirrorConfig()
+	if err != nil {
+		return err
+	}
+
+	readStore, writeStore, err := getMirrorStores(cfgMirror)
+	if err != nil {
+		return err
+	}
+
+	carSuffix, err := getCARSuffix(cfgMirror)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Updating existing CARs in", writeStore.Type(), "write mirror from CARs in", readStore.Type(), "read mirror")
+
+	ctx := cctx.Context
+
+	var totalSize int64
+	var checked, updates, rdErrs, wrErrs int
+	start := time.Now()
+
+	files, errs := writeStore.List(ctx, "/", false)
+	for wrFile := range files {
+		if !strings.HasSuffix(wrFile.Path, carSuffix) {
+			continue
+		}
+		checked++
+
+		rdFile, err := readStore.Head(ctx, wrFile.Path)
+		if err != nil {
+			if !errors.Is(err, fs.ErrNotExist) {
+				fmt.Println("Cannot get info for file in read mirror:", err)
+				rdErrs++
+			}
+			// else CAR file not found in read store.
+			continue
+		}
+
+		if rdFile.Size != wrFile.Size {
+			fmt.Println("Updating CAR", wrFile.Path, "to size", rdFile.Size)
+			_, rc, err := readStore.Get(ctx, rdFile.Path)
+			if err != nil {
+				fmt.Println("Cannot read from read mirror:", err)
+				rdErrs++
+				continue
+			}
+			_, err = writeStore.Put(ctx, wrFile.Path, rc)
+			rc.Close()
+			if err != nil {
+				fmt.Println("Failed to update CAR in write mirror:", err)
+				wrErrs++
+				continue
+			}
+			updates++
+			totalSize += rdFile.Size
+		}
+	}
+	err = <-errs
+	if err != nil {
+		return fmt.Errorf("error listing files in read mirror: %w", err)
+	}
+
+	elapsed := time.Since(start)
+	fmt.Println("Mirror update complete")
+	fmt.Println("   Elapsed:     ", elapsed.String())
+	fmt.Println("   Checked:     ", checked)
+	fmt.Println("   Read errors: ", rdErrs)
+	fmt.Println("   Write errors:", wrErrs)
+	fmt.Println("   Bytes copied:", totalSize)
+	fmt.Println("   Updated CARs:", updates)
+
+	return nil
+}
+
+func getMirrorStores(cfgMirror config.Mirror) (filestore.Interface, filestore.Interface, error) {
+	readStore, err := filestore.MakeFilestore(cfgMirror.Retrieval)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot create car file storage for read mirror: %w", err)
+	}
+	if readStore == nil {
+		return nil, nil, errors.New("read mirror is enabled with no storage backend")
+	}
+
+	writeStore, err := filestore.MakeFilestore(cfgMirror.Storage)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot create car file storage for write mirror: %w", err)
+	}
+	if writeStore == nil {
+		return nil, nil, errors.New("write mirror is enabled with no storage backend")
+	}
+
+	return readStore, writeStore, nil
+}
+
+func getMirrorConfig() (config.Mirror, error) {
+	cfg, err := loadConfig("")
+	if err != nil {
+		return config.Mirror{}, err
+	}
+	cfgMirror := cfg.Ingest.AdvertisementMirror
+
+	if !cfgMirror.Write {
+		return config.Mirror{}, errors.New("write mirror not enabled")
+	}
+	if !cfgMirror.Read {
+		return config.Mirror{}, errors.New("read mirror not enabled")
+	}
+	if reflect.DeepEqual(cfgMirror.Storage, cfgMirror.Retrieval) {
+		return config.Mirror{}, errors.New("read and write mirrors have the same storage")
+	}
+
+	return cfgMirror, nil
+}
+
+func getCARSuffix(cfgMirror config.Mirror) (string, error) {
+	switch cfgMirror.Compress {
+	case carstore.Gzip, "gz":
+		return carstore.CarFileSuffix + carstore.GzipFileSuffix, nil
+	case "", "none", "nil", "null":
+		return carstore.CarFileSuffix, nil
+	}
+	return "", fmt.Errorf("unsupported compression: %s", cfgMirror.Compress)
+}

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ func main() {
 			command.InitCmd,
 			command.LoadtestCmd,
 			command.LogCmd,
+			command.UpdateMirrorCmd,
 		},
 	}
 


### PR DESCRIPTION
## Context
When multihashes are read from a CAR file in the read mirror, the CAR that gets written to the write mirror is missing those multihash entries.

See issue #2598 

## Proposed Changes
Write entries block data to temporary datastore same as if it were read from index-provider.

Manual testing also confirmed that CAR written to storage mirror is identical to CAR read from retrieval mirror, by sha1 hash.

## Tests
e2e test includes test that read and write mirrors end up with identical CAR.

## Revert Strategy
Change is safe to revert.
