### PR TITLE
Deploy the latest indexstar with tagged release

### DIFF
--- a/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
@@ -18,4 +18,4 @@ replicas:
 images:
   - name: indexstar
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/indexstar/indexstar
-    newTag: 20240423142616-bf104cf952d93703b6d8ac858998bd93b1edc011
+    newTag: 20240423144742-3d60e3d671b85ac129d4cd704a307ec95d60c0d0

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
@@ -18,4 +18,4 @@ replicas:
 images:
   - name: indexstar
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/indexstar/indexstar
-    newTag: 20240118222734-72b3a9a0e40c72c8a9a30eccc42aae08b7ff6a0b
+    newTag: 20240423144742-3d60e3d671b85ac129d4cd704a307ec95d60c0d0


### PR DESCRIPTION
Update to the latest tagged release of indexstar on dev and prod.

Most notable change is the update to delegated routing peer discovery schema.

<!-- If yes, you can simply say:-->
<!-- Change is safe to revert. -->

<!-- If no, outline the steps required to revert this change. -->
