### PR TITLE
Scale up old dhstore in prep for making it primary

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-seka/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-seka/deployment.yaml
@@ -20,10 +20,10 @@ spec:
               mountPath: /data
           resources:
             limits:
-              cpu: "28"
+              cpu: "7"
               memory: 58Gi
             requests:
-              cpu: "28"
+              cpu: "7"
               memory: 58Gi
       affinity:
         nodeAffinity:

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/deployment.yaml
@@ -37,7 +37,7 @@ spec:
                   - key: node.kubernetes.io/instance-type
                     operator: In
                     values:
-                      - r6a.2xlarge
+                      - c6a.8xlarge
                   - key: topology.kubernetes.io/zone
                     operator: In
                     values:

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/deployment.yaml
@@ -21,11 +21,11 @@ spec:
               mountPath: /data
           resources:
             limits:
-              cpu: "5"
-              memory: 32Gi
+              cpu: "28"
+              memory: 58Gi
             requests:
-              cpu: "5"
-              memory: 32Gi
+              cpu: "28"
+              memory: 58Gi
           ports:
             - containerPort: 40081
               name: metrics

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/pvc-gp3.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/pvc-gp3.yaml
@@ -8,4 +8,8 @@ spec:
   resources:
     requests:
       storage: 16Ti
+  dataSource:
+    name: dhstore-20230427
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
   storageClassName: gp3-iops5k-t300

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/pvc-gp3.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/pvc-gp3.yaml
@@ -8,8 +8,4 @@ spec:
   resources:
     requests:
       storage: 16Ti
-  dataSource:
-    name: dhstore-20230427
-    kind: VolumeSnapshot
-    apiGroup: snapshot.storage.k8s.io
   storageClassName: gp3-iops5k-t300


### PR DESCRIPTION
The current primary dhstore, where new data is written to, is nearly out of space. The oldest dhstore is only 61% full, so prepare it to become the primary.

Storage IOPS and throughput will be scaled up administratively with AWS volume management.

This also scales down dhstore-seka. dhstore-tetra will be scaled down after prod is using the new (refurbished) dhstore.