### PR TITLE
Deploy the latest dhstore to prod

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-helga/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-helga/kustomization.yaml
@@ -19,4 +19,4 @@ patchesStrategicMerge:
 images:
   - name: dhstore
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
-    newTag: 20240329194700-c675b49d541d03666c621ee11e53a76c63ae4fac
+    newTag: 20240616004458-be0fc3101dad6e4d706e4efb52b3ca990c19b0c1

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-porvy/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-porvy/kustomization.yaml
@@ -19,4 +19,4 @@ patchesStrategicMerge:
 images:
   - name: dhstore
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
-    newTag: 20240329194700-c675b49d541d03666c621ee11e53a76c63ae4fac
+    newTag: 20240616004458-be0fc3101dad6e4d706e4efb52b3ca990c19b0c1

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-qiu/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-qiu/kustomization.yaml
@@ -19,4 +19,4 @@ patchesStrategicMerge:
 images:
   - name: dhstore
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
-    newTag: 20240329194700-c675b49d541d03666c621ee11e53a76c63ae4fac
+    newTag: 20240616004458-be0fc3101dad6e4d706e4efb52b3ca990c19b0c1

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-ravi/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-ravi/kustomization.yaml
@@ -19,4 +19,4 @@ patchesStrategicMerge:
 images:
   - name: dhstore
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
-    newTag: 20240329194700-c675b49d541d03666c621ee11e53a76c63ae4fac
+    newTag: 20240616004458-be0fc3101dad6e4d706e4efb52b3ca990c19b0c1

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-seka/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-seka/kustomization.yaml
@@ -19,4 +19,4 @@ patchesStrategicMerge:
 images:
   - name: dhstore
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
-    newTag: 20240329194700-c675b49d541d03666c621ee11e53a76c63ae4fac
+    newTag: 20240616004458-be0fc3101dad6e4d706e4efb52b3ca990c19b0c1

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-tetra/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-tetra/kustomization.yaml
@@ -19,4 +19,4 @@ patchesStrategicMerge:
 images:
   - name: dhstore
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
-    newTag: 20240329194700-c675b49d541d03666c621ee11e53a76c63ae4fac
+    newTag: 20240616004458-be0fc3101dad6e4d706e4efb52b3ca990c19b0c1

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/kustomization.yaml
@@ -15,4 +15,4 @@ patchesStrategicMerge:
 images:
   - name: dhstore
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
-    newTag: 20240329194700-c675b49d541d03666c621ee11e53a76c63ae4fac
+    newTag: 20240616004458-be0fc3101dad6e4d706e4efb52b3ca990c19b0c1


### PR DESCRIPTION
New dhstore has updated libp2p (v0.35.1) and pebbe (v1.1.1)