### PR TITLE
Switch to least saturated dhstore backend as primary write

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/config.json
@@ -51,12 +51,12 @@
     "ValueStoreDir": "/data/valuestore",
     "ValueStoreType": "none",
     "DHBatchSize": 16384,
-    "DHStoreURL": "http://dhstore.internal.prod.cid.contact",
+    "DHStoreURL": "http://dhstore-qiu:40080",
     "DHStoreClusterURLs": [
       "http://dhstore-tetra:40080",          
       "http://dhstore-seka:40080",
       "http://dhstore-ravi:40080",
-      "http://dhstore-qiu:40080",
+      "http://dhstore.internal.prod.cid.contact",
       "http://dhstore-helga.internal.prod.cid.contact",
       "http://dhstore-porvy.internal.prod.cid.contact"
     ],


### PR DESCRIPTION
The current primary is close to full saturation which results in high origin latency on ingress traffic and consequential high 404 rate.

Switch the primary dhstore to `qiu`, the instance with least disk saturation.
