### PR TITLE
Allocate larger instance to primary write dhstore

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-porvy/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-porvy/deployment.yaml
@@ -27,10 +27,10 @@ spec:
               mountPath: /data
           resources:
             limits:
-              cpu: "7"
+              cpu: "28"
               memory: 58Gi
             requests:
-              cpu: "7"
+              cpu: "28"
               memory: 58Gi
           ports:
             - containerPort: 40081
@@ -43,7 +43,7 @@ spec:
                   - key: node.kubernetes.io/instance-type
                     operator: In
                     values:
-                      - r6a.2xlarge
+                      - c6a.8xlarge
                   - key: topology.kubernetes.io/zone
                     operator: In
                     values:

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/deployment.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/deployment.yaml
@@ -21,10 +21,10 @@ spec:
               mountPath: /data
           resources:
             limits:
-              cpu: "28"
+              cpu: "7"
               memory: 58Gi
             requests:
-              cpu: "28"
+              cpu: "7"
               memory: 58Gi
           ports:
             - containerPort: 40081
@@ -37,7 +37,7 @@ spec:
                   - key: node.kubernetes.io/instance-type
                     operator: In
                     values:
-                      - c6a.8xlarge
+                      - r6a.2xlarge
                   - key: topology.kubernetes.io/zone
                     operator: In
                     values:


### PR DESCRIPTION
Main dhstore needs to have largest instance. Writes were previously failing.
