### PR TITLE
Update timers for go1.23

### DIFF
--- a/assigner/core/assigner_test.go
+++ b/assigner/core/assigner_test.go
@@ -141,9 +141,7 @@ func TestAssignerAll(t *testing.T) {
 			t.Fatal("timed out waiting for assignment")
 		}
 	}
-	if !timeout.Stop() {
-		<-timeout.C
-	}
+	timeout.Stop()
 	require.Equal(t, 1, len(assigns))
 	require.Equal(t, 0, assigns[0])
 
@@ -178,9 +176,7 @@ func TestAssignerAll(t *testing.T) {
 			t.Fatal("timed out waiting for assignment")
 		}
 	}
-	if !timeout.Stop() {
-		<-timeout.C
-	}
+	timeout.Stop()
 	sort.Ints(assigns)
 	require.Equal(t, []int{0, 1}, assigns)
 
@@ -271,9 +267,7 @@ func TestAssignerOne(t *testing.T) {
 			t.Fatal("timed out waiting for assignment")
 		}
 	}
-	if !timeout.Stop() {
-		<-timeout.C
-	}
+	timeout.Stop()
 	require.Equal(t, 1, len(assigns))
 	require.Equal(t, 0, assigns[0])
 
@@ -306,9 +300,7 @@ func TestAssignerOne(t *testing.T) {
 			t.Fatal("timed out waiting for assignment")
 		}
 	}
-	if !timeout.Stop() {
-		<-timeout.C
-	}
+	timeout.Stop()
 	require.Equal(t, 1, len(assigns))
 	require.Equal(t, 1, assigns[0])
 
@@ -431,9 +423,7 @@ func TestAssignerPreferred(t *testing.T) {
 			t.Fatal("timed out waiting for assignment")
 		}
 	}
-	if !timeout.Stop() {
-		<-timeout.C
-	}
+	timeout.Stop()
 	require.Equal(t, 1, len(assigns))
 	require.Equal(t, 1, assigns[0], "expected assignment to indexer 1")
 
@@ -466,9 +456,7 @@ func TestAssignerPreferred(t *testing.T) {
 			t.Fatal("timed out waiting for assignment")
 		}
 	}
-	if !timeout.Stop() {
-		<-timeout.C
-	}
+	timeout.Stop()
 	require.Equal(t, 1, len(assigns))
 	require.Equal(t, 1, assigns[0], "expected assignment to indexer 1")
 
@@ -743,9 +731,7 @@ func TestFreezeHandoff(t *testing.T) {
 			t.Fatal("timed out waiting for assignment")
 		}
 	}
-	if !timeout.Stop() {
-		<-timeout.C
-	}
+	timeout.Stop()
 	require.Equal(t, 1, len(assigns))
 	require.Equal(t, 0, assigns[0])
 
@@ -770,9 +756,6 @@ func TestFreezeHandoff(t *testing.T) {
 		case <-timeout.C:
 			t.Fatal("timed out waiting for handoff")
 		}
-	}
-	if !timeout.Stop() {
-		<-timeout.C
 	}
 
 	timeout.Reset(time.Second)

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -410,9 +410,7 @@ func TestPollProvider(t *testing.T) {
 	case <-timeout.C:
 		t.Fatal("Expected sync channel to be written")
 	}
-	if !timeout.Stop() {
-		<-timeout.C
-	}
+	timeout.Stop()
 
 	// Check that registry is not blocked by unread auto-sync channel.
 	poll.retryAfter = 0


### PR DESCRIPTION
Do not read timer channel after call to Stop.

This PR only affects tests. It will still work for go1.22- because the timers do not fire before getting stopped or reset.