### PR TITLE
Stop using archived `go-homedir` repo

### DIFF
--- a/assigner/config/config.go
+++ b/assigner/config/config.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 
 	sticfg "github.com/ipni/storetheindex/config"
-	"github.com/mitchellh/go-homedir"
+	"github.com/ipni/storetheindex/fsutil"
 )
 
 // Config is used to load config files.
@@ -44,14 +44,25 @@ func Marshal(value interface{}) ([]byte, error) {
 // empty string is provided for `configRoot`, the default root is used. If
 // configFile is an absolute path, then configRoot is ignored.
 func Path(configRoot, configFile string) (string, error) {
+	var err error
 	if configFile == "" {
 		configFile = DefaultConfigFile
-	} else if filepath.IsAbs(configFile) {
-		return filepath.Clean(configFile), nil
+	} else {
+		configFile, err = fsutil.Expand(configFile)
+		if err != nil {
+			return "", err
+		}
+		if filepath.IsAbs(configFile) {
+			return filepath.Clean(configFile), nil
+		}
 	}
 	if configRoot == "" {
-		var err error
 		configRoot, err = PathRoot()
+		if err != nil {
+			return "", err
+		}
+	} else {
+		configRoot, err = fsutil.Expand(configRoot)
 		if err != nil {
 			return "", err
 		}
@@ -62,10 +73,10 @@ func Path(configRoot, configFile string) (string, error) {
 // PathRoot returns the default configuration root directory.
 func PathRoot() (string, error) {
 	dir := os.Getenv(EnvDir)
-	if dir != "" {
-		return dir, nil
+	if dir == "" {
+		dir = DefaultPathRoot
 	}
-	return homedir.Expand(DefaultPathRoot)
+	return fsutil.Expand(dir)
 }
 
 // Load reads the json-serialized config at the specified path.
@@ -73,9 +84,11 @@ func Load(filePath string) (*Config, error) {
 	var err error
 	if filePath == "" {
 		filePath, err = Path("", "")
-		if err != nil {
-			return nil, err
-		}
+	} else {
+		filePath, err = fsutil.Expand(filePath)
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	f, err := os.Open(filePath)
@@ -128,9 +141,11 @@ func (c *Config) Save(filePath string) error {
 	var err error
 	if filePath == "" {
 		filePath, err = Path("", "")
-		if err != nil {
-			return err
-		}
+	} else {
+		filePath, err = fsutil.Expand(filePath)
+	}
+	if err != nil {
+		return err
 	}
 
 	err = os.MkdirAll(filepath.Dir(filePath), 0755)

--- a/assigner/server/server_test.go
+++ b/assigner/server/server_test.go
@@ -85,7 +85,8 @@ func TestAssignOnAnnounce(t *testing.T) {
 	require.NoError(t, err)
 	indexerID := stiCfg.Identity.PeerID
 	stiCfg.Indexer.FreezeAtPercent = 99.0
-	stiCfg.Save(stiCfgPath)
+	err = stiCfg.Save(stiCfgPath)
+	require.NoError(t, err)
 	t.Log("Initialized indexer", indexerID)
 
 	indexerReady := testcmd.NewStdoutWatcher(indexerReadyMatch)

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -150,7 +150,8 @@ func testEndToEndWithReferenceProvider(t *testing.T, publisherProto string) {
 		},
 	}
 	rdMirrorDir := rnr.Dir
-	cfg.Save(stiCfgPath)
+	err = cfg.Save(stiCfgPath)
+	require.NoError(t, err)
 
 	// start provider
 	providerReady := testcmd.NewStderrWatcher(providerReadyMatch)
@@ -264,7 +265,8 @@ func testEndToEndWithReferenceProvider(t *testing.T, publisherProto string) {
 			},
 		},
 	}
-	cfg.Save(sti2CfgPath)
+	err = cfg.Save(sti2CfgPath)
+	require.NoError(t, err)
 	wrMirrorDir := rnr.Dir
 
 	indexerReady2 := testcmd.NewStdoutWatcher(indexerReadyMatch)

--- a/fsutil/fsutil_test.go
+++ b/fsutil/fsutil_test.go
@@ -99,9 +99,7 @@ func TestExpand(t *testing.T) {
 		homeEnv = "USERPROFILE"
 	}
 	origHome := os.Getenv(homeEnv)
-	defer func() {
-		os.Setenv(homeEnv, origHome)
-	}()
+	defer os.Setenv(homeEnv, origHome)
 	homeDir := filepath.Join(t.TempDir(), "testhome")
 	os.Setenv(homeEnv, homeDir)
 

--- a/fsutil/fsutil_test.go
+++ b/fsutil/fsutil_test.go
@@ -94,7 +94,10 @@ func TestExpand(t *testing.T) {
 	_, err = fsutil.Expand(filepath.FromSlash("~nosuchuser/somedir"))
 	require.Error(t, err)
 
-	const homeEnv = "HOME"
+	homeEnv := "HOME"
+	if runtime.GOOS == "windows" {
+		homeEnv = "USERPROFILE"
+	}
 	origHome := os.Getenv(homeEnv)
 	defer func() {
 		os.Setenv(homeEnv, origHome)

--- a/fsutil/fsutil_test.go
+++ b/fsutil/fsutil_test.go
@@ -99,7 +99,7 @@ func TestExpand(t *testing.T) {
 	defer func() {
 		os.Setenv(homeEnv, origHome)
 	}()
-	homeDir := filepath.FromSlash("/tmp/testhome")
+	homeDir := filepath.Join(t.TempDir(), "testhome")
 	os.Setenv(homeEnv, homeDir)
 
 	const subDir = "mytmp"

--- a/fsutil/fsutil_test.go
+++ b/fsutil/fsutil_test.go
@@ -80,3 +80,35 @@ func TestFileExists(t *testing.T) {
 
 	require.True(t, fsutil.FileExists(fileName))
 }
+
+func TestExpand(t *testing.T) {
+	dir, err := fsutil.Expand("")
+	require.NoError(t, err)
+	require.Equal(t, "", dir)
+
+	origDir := filepath.Join("somedir", "somesub")
+	dir, err = fsutil.Expand(origDir)
+	require.NoError(t, err)
+	require.Equal(t, origDir, dir)
+
+	_, err = fsutil.Expand(filepath.FromSlash("~nosuchuser/somedir"))
+	require.Error(t, err)
+
+	const homeEnv = "HOME"
+	origHome := os.Getenv(homeEnv)
+	defer func() {
+		os.Setenv(homeEnv, origHome)
+	}()
+	homeDir := filepath.FromSlash("/tmp/testhome")
+	os.Setenv(homeEnv, homeDir)
+
+	const subDir = "mytmp"
+	origDir = filepath.Join("~", subDir)
+	dir, err = fsutil.Expand(origDir)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(homeDir, subDir), dir)
+
+	os.Unsetenv(homeEnv)
+	_, err = fsutil.Expand(origDir)
+	require.Error(t, err)
+}

--- a/gc/reaper/option.go
+++ b/gc/reaper/option.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ipni/go-libipni/pcache"
 	"github.com/ipni/storetheindex/carstore"
+	"github.com/ipni/storetheindex/fsutil"
 	"github.com/libp2p/go-libp2p/core/host"
 )
 
@@ -89,6 +90,11 @@ func WithCarDelete(del bool) Option {
 // provider-specific datastores.
 func WithDatastoreDir(dir string) Option {
 	return func(c *config) error {
+		var err error
+		dir, err = fsutil.Expand(dir)
+		if err != nil {
+			return err
+		}
 		c.dstoreDir = dir
 		return nil
 	}
@@ -98,6 +104,11 @@ func WithDatastoreDir(dir string) Option {
 // provider-specific temproary datastores.
 func WithDatastoreTempDir(dir string) Option {
 	return func(c *config) error {
+		var err error
+		dir, err = fsutil.Expand(dir)
+		if err != nil {
+			return err
+		}
 		c.dstoreTmpDir = dir
 		return nil
 	}

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/ipni/go-libipni v0.5.25
 	github.com/libp2p/go-libp2p v0.36.3
 	github.com/libp2p/go-msgio v0.3.0
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/multiformats/go-multiaddr v0.13.0
 	github.com/multiformats/go-multicodec v0.9.0
 	github.com/multiformats/go-multihash v0.2.3

--- a/go.sum
+++ b/go.sum
@@ -581,8 +581,6 @@ github.com/minio/sha256-simd v0.1.1-0.20190913151208-6de447530771/go.mod h1:B5e1
 github.com/minio/sha256-simd v0.1.1/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=
 github.com/minio/sha256-simd v1.0.1 h1:6kaan5IFmwTNynnKKpDHe6FWHohJOHhCPchzK49dzMM=
 github.com/minio/sha256-simd v1.0.1/go.mod h1:Pz6AKMiUdngCLpeTL/RJY1M9rUuPMYujV5xJjtbRSN8=
-github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
-github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 h1:dcztxKSvZ4Id8iPpHERQBbIJfabdt4wUm5qy3wOL2Zc=


### PR DESCRIPTION

The `go-homedir` repo is unnecessary now that there is go support for getting a user's home directory.

- Add `fsutil.Expand` function to replace "~" at start of path with user's home directory
- Config calls expand in additional places to ensure that config paths with "~" are handled.