### PR TITLE
Unfreeze even if freezing is disabled.

### DIFF
--- a/config/indexer.go
+++ b/config/indexer.go
@@ -27,9 +27,11 @@ type Indexer struct {
 	DHStoreClusterURLs []string
 	// DHStoreHttpClientTimeout is a timeout for the DHStore http client
 	DHStoreHttpClientTimeout Duration
-	// FreezeAtPercent is the percent used, of the file system that
-	// ValueStoreDir is on, at which to trigger the indexer to enter frozen
-	// mode. A zero value uses the default. A negative value disables freezing.
+	// FreezeAtPercent is the filesystem percent used at which to trigger the
+	// indexer to enter frozen mode. The indexer checks the file system of
+	// ValueStoreDir, Datastore.Dir, and Datastore.TmpDir and enters frozen
+	// mode if any one's usage is at or above FreezeAtPercent. A zero value
+	// uses the default. A negative value disables freezing.
 	FreezeAtPercent float64
 	// ShutdownTimeout is the duration that a graceful shutdown has to complete
 	// before the daemon process is terminated. If unset or zero, configures no
@@ -62,7 +64,7 @@ func NewIndexer() Indexer {
 		CacheSize:            300000,
 		PebbleBlockCacheSize: 1 << 30, // 1 Gi
 		ConfigCheckInterval:  Duration(30 * time.Second),
-		FreezeAtPercent:      90.0,
+		FreezeAtPercent:      95.0,
 		ShutdownTimeout:      0,
 		ValueStoreDir:        "valuestore",
 		ValueStoreType:       "pebble",

--- a/internal/registry/errors.go
+++ b/internal/registry/errors.go
@@ -10,7 +10,6 @@ var (
 	ErrMissingProviderAddr = errors.New("advertisement missing provider address")
 	ErrNotAllowed          = errors.New("peer not allowed by policy")
 	ErrNoDiscovery         = errors.New("discovery not available")
-	ErrNoFreeze            = errors.New("freeze not configured")
 	ErrNotVerified         = errors.New("provider cannot be verified")
 	ErrPublisherNotAllowed = errors.New("publisher not allowed by policy")
 	ErrTooSoon             = errors.New("not enough time since previous discovery")

--- a/server/admin/handler.go
+++ b/server/admin/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipni/go-indexer-core"
 	"github.com/ipni/storetheindex/admin/model"
+	"github.com/ipni/storetheindex/internal/freeze"
 	"github.com/ipni/storetheindex/internal/httpserver"
 	"github.com/ipni/storetheindex/internal/ingest"
 	"github.com/ipni/storetheindex/internal/registry"
@@ -468,7 +469,7 @@ func (h *adminHandler) freeze(w http.ResponseWriter, r *http.Request) {
 
 	err := h.reg.Freeze()
 	if err != nil {
-		if errors.Is(err, registry.ErrNoFreeze) {
+		if errors.Is(err, freeze.ErrNoFreeze) {
 			log.Infow("Cannot freeze indexer", "reason", err)
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return


### PR DESCRIPTION
Freezing may be disabled after an indexer becomes frozen to prevent the indexer from freezing again. Unfreezing the indexer should still work even if freezing is disabled. This PR makes this possible, whereas previously an indexer could not be unfrozen if freezing was disabled.

Closes #2670

This PR also allows disk usage to be queried even when freezing is disabled.
