### PR TITLE
claim ownership of project for drips

### DIFF
--- a/FUNDING.json
+++ b/FUNDING.json
@@ -1,0 +1,7 @@
+{
+  "drips": {
+    "ethereum": {
+      "ownedBy": "0xcB2E7F53F446AFA859192194Fc2E7eeCA20f6285"
+    }
+  }
+}


### PR DESCRIPTION
This is used to associate a funding address for drips with the project. This is the project account used for retroPGF rounds so far.