### PR TITLE
Scale down all AWS deployments in prep for tear down

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/assigner/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/assigner/kustomization.yaml
@@ -22,6 +22,10 @@ configMapGenerator:
     files:
       - config=config.json
 
+replicas:
+  - name: assigner
+    count: 0
+
 images:
 - name: storetheindex
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/storetheindex/storetheindex

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/caskadht/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/caskadht/kustomization.yaml
@@ -24,7 +24,7 @@ configMapGenerator:
 
 replicas:
   - name: caskadht
-    count: 1
+    count: 0
 
 images:
   - name: caskadht

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-helga/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-helga/kustomization.yaml
@@ -20,3 +20,7 @@ images:
   - name: dhstore
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
     newTag: 20240823093542-3078e23bce56b098cf0b55dbc82af166a5590799
+
+replicas:
+  - name: dhstore-helga
+    count: 0

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-porvy/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-porvy/kustomization.yaml
@@ -20,3 +20,7 @@ images:
   - name: dhstore
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
     newTag: 20240823093542-3078e23bce56b098cf0b55dbc82af166a5590799
+
+replicas:
+  - name: dhstore-porvy
+    count: 0

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-qiu/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-qiu/kustomization.yaml
@@ -20,3 +20,7 @@ images:
   - name: dhstore
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
     newTag: 20240823093542-3078e23bce56b098cf0b55dbc82af166a5590799
+
+replicas:
+  - name: dhstore-qiu
+    count: 0

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-ravi/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-ravi/kustomization.yaml
@@ -20,3 +20,7 @@ images:
   - name: dhstore
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
     newTag: 20240823093542-3078e23bce56b098cf0b55dbc82af166a5590799
+
+replicas:
+  - name: dhstore-ravi
+    count: 0

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-seka/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-seka/kustomization.yaml
@@ -20,3 +20,7 @@ images:
   - name: dhstore
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
     newTag: 20240823093542-3078e23bce56b098cf0b55dbc82af166a5590799
+
+replicas:
+  - name: dhstore-seka
+    count: 0

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-tetra/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-tetra/kustomization.yaml
@@ -20,3 +20,7 @@ images:
   - name: dhstore
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
     newTag: 20240823093542-3078e23bce56b098cf0b55dbc82af166a5590799
+
+replicas:
+  - name: dhstore-tetra
+    count: 0

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore/kustomization.yaml
@@ -16,3 +16,7 @@ images:
   - name: dhstore
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/dhstore
     newTag: 20240823093542-3078e23bce56b098cf0b55dbc82af166a5590799
+
+replicas:
+  - name: dhstore
+    count: 0

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/indexstar/kustomization.yaml
@@ -14,7 +14,7 @@ patchesStrategicMerge:
 
 replicas:
   - name: indexstar
-    count: 2
+    count: 0
 
 images:
   - name: indexstar

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/instances/inga/kustomization.yaml
@@ -27,3 +27,7 @@ configMapGenerator:
 
 patchesStrategicMerge:
   - deployment.yaml
+
+replicas:
+  - name: inga-indexer
+    count: 0

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/lookout/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/lookout/kustomization.yaml
@@ -20,3 +20,7 @@ images:
   - name: lookout
     newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/ipni/lookout
     newTag: 20230511104023-2cb718182431d507d5ee33defde11dedad466bd1
+
+replicas:
+  - name: lookout
+    count: 0

--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/telemetry/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/telemetry/kustomization.yaml
@@ -16,3 +16,6 @@ images:
     newTag: 20240308135359-c8e7f0dd9599b74c64b2247580de5987f56ecbd7
 
 
+replicas:
+  - name: telemetry
+    count: 0


### PR DESCRIPTION
Scale all aws deployments down to zero, in preparation for tear down. State is left for a further grace period time to pass.

