### PR TITLE
Fix manually expanded PVC volume

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-helga/pvc.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/storetheindex/dhstore-helga/pvc.yaml
@@ -7,5 +7,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 15Ti
+      storage: 16Ti
   storageClassName: gp3


### PR DESCRIPTION
It seems the PVC volume for helga was expanded to 16Ti directly. Reflect
it in specs.
