### PR TITLE
Switch primary to berg now that disk is expanded and caught up

### DIFF
--- a/deploy/infrastructure/prod/us-east-2/cloudfront.tf
+++ b/deploy/infrastructure/prod/us-east-2/cloudfront.tf
@@ -2,7 +2,7 @@ locals {
   indexstar_origin_id     = "${local.environment_name}_${local.region}_indexstar"
   indexstar_berg_origin_id     = "${local.environment_name}_${local.region}_indexstar_berg"
   indexstar_sf_origin_id     = "${local.environment_name}_${local.region}_indexstar_sf"
-  indexstar_primary = local.indexstar_sf_origin_id
+  indexstar_primary = local.indexstar_berg_origin_id
   http_announce_origin_id = "${local.environment_name}_${local.region}_assigner"
   cdn_subdomain           = "cdn"
   cf_log_bucket           = "${local.environment_name}-${local.region}-cf-log"

--- a/deploy/infrastructure/prod/us-east-2/eks.tf
+++ b/deploy/infrastructure/prod/us-east-2/eks.tf
@@ -28,7 +28,7 @@ module "eks" {
   eks_managed_node_groups = {
     # Node groups for running dhstore nodes
     prod-ue2c-r5n-2xl = {
-      min_size       = 1
+      min_size       = 0
       max_size       = 3
       desired_size   = 1
       instance_types = ["r5n.2xlarge"]
@@ -42,7 +42,7 @@ module "eks" {
       }
     }
     prod-ue2a-r5n-2xl = {
-      min_size       = 1
+      min_size       = 0
       max_size       = 3
       desired_size   = 1
       instance_types = ["r5n.2xlarge"]


### PR DESCRIPTION
Switch primary to berlin instance.

Reduce min eks worker group size to zero as part of tearing down AWS
environment.
