### PR TITLE
Update FUNDING.json

### DIFF
--- a/FUNDING.json
+++ b/FUNDING.json
@@ -2,6 +2,9 @@
   "drips": {
     "ethereum": {
       "ownedBy": "0xcB2E7F53F446AFA859192194Fc2E7eeCA20f6285"
+    },
+    "filecoin": {
+      "ownedBy": "0xcB2E7F53F446AFA859192194Fc2E7eeCA20f6285"
     }
   }
 }


### PR DESCRIPTION
the filecoin retropgf program has decided that the drips standard is insufficient and that they're going to use a new network name as additional burden on maintainers for no particular reason