### PR TITLE
Set up dedicated routing for berg and sf in a fresh namespace

### DIFF
--- a/deploy/manifests/prod/us-east-2/cluster/ingress-nginx/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/cluster/ingress-nginx/kustomization.yaml
@@ -10,4 +10,4 @@ patchesStrategicMerge:
 
 replicas:
   - name: ingress-nginx-controller
-    count: 0
+    count: 1

--- a/deploy/manifests/prod/us-east-2/tenant/ipni/berg-ingress.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/ipni/berg-ingress.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: indexstar-berg
+  namespace: storetheindex
+spec:
+  type: ExternalName
+  externalName: berg.cid.contact
+  ports:
+    - port: 443
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: indexstar-berg
+  namespace: storetheindex
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+spec:
+  tls:
+    - hosts:
+        - indexstar-berg.prod.cid.contact
+      secretName: indexstar-berg-ingress-tls
+  rules:
+    - host: indexstar-berg.prod.cid.contact
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: indexstar-berg
+                port:
+                  number: 443
+

--- a/deploy/manifests/prod/us-east-2/tenant/ipni/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/ipni/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ipni
+resources:
+  - berg-ingress.yaml
+  - sf-ingress.yaml
+  - namespace.yaml

--- a/deploy/manifests/prod/us-east-2/tenant/ipni/namespace.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/ipni/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+
+metadata:
+  name: ipni

--- a/deploy/manifests/prod/us-east-2/tenant/ipni/sf-ingress.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/ipni/sf-ingress.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: indexstar-sf
+  namespace: storetheindex
+spec:
+  type: ExternalName
+  externalName: sf.cid.contact
+  ports:
+    - port: 443
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: indexstar-sf
+  namespace: storetheindex
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+spec:
+  tls:
+    - hosts:
+        - indexstar-sf.prod.cid.contact
+      secretName: indexstar-sf-ingress-tls
+  rules:
+    - host: indexstar-sf.prod.cid.contact
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: indexstar-sf
+                port:
+                  number: 443


### PR DESCRIPTION
move the services
that handle request proxies for sf and berg to cloudfront onto a dedicated namespace.

