### PR TITLE
Cache delegated routing paths and add sf2 origin

### DIFF
--- a/deploy/manifests/prod/us-east-2/tenant/ipni/kustomization.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/ipni/kustomization.yaml
@@ -4,4 +4,5 @@ namespace: ipni
 resources:
   - berg-ingress.yaml
   - sf-ingress.yaml
+  - sf2-ingress.yaml
   - namespace.yaml

--- a/deploy/manifests/prod/us-east-2/tenant/ipni/sf2-ingress.yaml
+++ b/deploy/manifests/prod/us-east-2/tenant/ipni/sf2-ingress.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: indexstar-sf2
+  namespace: storetheindex
+spec:
+  type: ExternalName
+  externalName: sf2.cid.contact
+  ports:
+    - port: 443
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: indexstar-sf2
+  namespace: storetheindex
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+spec:
+  tls:
+    - hosts:
+        - indexstar-sf2.prod.cid.contact
+      secretName: indexstar-sf2-ingress-tls
+  rules:
+    - host: indexstar-sf2.prod.cid.contact
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: indexstar-sf2
+                port:
+                  number: 443


### PR DESCRIPTION
Cache the delegated rouding paths in cloudfront using the default cache policy.

Update cloudfront origin to add the new sf2 endpoint.
