### PR TITLE
Expose pebble config option PebbleFormatMajorVersion

### DIFF
--- a/config/indexer.go
+++ b/config/indexer.go
@@ -51,6 +51,12 @@ type Indexer struct {
 	PebbleDisableWAL bool
 	// PebbleBlockCacheSize is a size of pebble block cache in bytes
 	PebbleBlockCacheSize ByteSize
+	// PebbleFormatMajorVersion sets the format of on-disk files. It is
+	// recommended to set the format major version to an explicit version, as
+	// the default may change over time. When unset or 0, use the current
+	// format version. When set to -1 update the format to the latest supported
+	// version.
+	PebbleFormatMajorVersion int
 	// UnfreezeOnStart tells that indexer to unfreeze itself on startup if it
 	// is frozen. This reverts the indexer to the state it was in before it was
 	// frozen. It only retains the most recent provider and publisher

--- a/config/init.go
+++ b/config/init.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/cockroachdb/pebble"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
@@ -32,6 +33,10 @@ func InitWithIdentity(identity Identity) (*Config, error) {
 		ReverseIndexer: NewReverseIndexer(),
 		Ingest:         NewIngest(),
 		Logging:        NewLogging(),
+	}
+
+	if conf.Indexer.ValueStoreType == "pebble" {
+		conf.Indexer.PebbleFormatMajorVersion = int(pebble.FormatNewest)
 	}
 
 	return conf, nil

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -26,11 +26,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	// When this environ var is set to a value and running tests with -v flag,
-	// then TestIpniRunner output is logged.
-	envTestIpniRunnerOutput = "TEST_IPNI_RUNNER_OUTPUT"
+// When the environ var "TEST_RUNNER_OUTPUT" is set to a value and running
+// tests with -v flag, then testcmd.Runner output is logged.
 
+const (
 	indexerReadyMatch    = "Indexer is ready"
 	providerHasPeerMatch = "connected to peer successfully"
 	providerReadyMatch   = "admin http server listening"


### PR DESCRIPTION
## Context

- There need to be a way to upgrade the pebble database format for existing storetheindex instances.
  - We need to update the format in use to something newer, before upgrading to pebble/v2, because the version in use in cid.contact sites if no longer compatible with pebble/v2.
  - We want to deploy this capability without forcing an immediate upgrade to the latest version, in case it is necessary to revert to a previous version of storetheindex for some reason. Iinstead of automatic upgrade, an administrator will change the value in the config file when it is determined reverting the storetheindex update is not needed..
- Newly initialized storetheindex instances should be configured to use latest supported pebble format version.
  - This will generally make the pebble database usable across major pebble version updates in the future.
  - Provides a place holder for updating the version in the config
  - Allows the daemon to check the configured version against the latest and alert the user that a newer version is available.

## Proposed Changes

The config value `Indexer.PebbleFormatMajorVersion` sets the format of on-disk files. It is recommended to set the format major version to an explicit version, as the default may change over time. When unset or 0, use the current format version. When set to -1 update the format to the latest supported  version.

In a newly initialized storetheindex instance, the value of `Indexer.PebbleFormatMajorVersion` is set to the latest supported version. This can be updated at a later sime should a newer version become available. If a version that is newer than the configured value becomes available, this is logged as a warning in the storetheindex logs at startup.

## Tests
Manual tests with small database.

Larger scale tests are needed to estimate overhead of format upgrade.

## Revert Strategy
Change is safe to revert.
