### PR TITLE
delete extended provider info by supplying empty extended provider info

### DIFF
--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -986,9 +986,7 @@ func TestSyncSupplyEmpyExtendedProvidersActsAsRemove(t *testing.T) {
 		// there should be no extended providers
 		pInfo, _ := reg.ProviderInfo(providerID)
 		extendedProviders := pInfo.ExtendedProviders
-		require.NotNil(t, extendedProviders)
-		require.Equal(t, 0, len(extendedProviders.Providers))
-		require.Equal(t, 0, len(extendedProviders.ContextualProviders))
+		require.Nil(t, extendedProviders)
 	})
 }
 

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -746,15 +746,14 @@ func (r *Registry) Update(ctx context.Context, provider, publisher peer.AddrInfo
 			info.AddrInfo.Addrs = provider.Addrs
 		}
 
+		// If extendedProviders is not nil then update existing extended provider info.
 		if extendedProviders != nil {
 			if extendedProviders.Empty() {
-				info.ExtendedProviders = nil
-			} else {
-				if err := validateExtProviders(extendedProviders); err != nil {
-					return err
-				}
-				info.ExtendedProviders = extendedProviders
+				extendedProviders = nil
+			} else if err := validateExtProviders(extendedProviders); err != nil {
+				return err
 			}
+			info.ExtendedProviders = extendedProviders
 		}
 
 		// If publisher ID changed.

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -163,6 +163,10 @@ type ExtendedProviders struct {
 	ContextualProviders map[string]ContextualExtendedProviders `json:",omitempty"`
 }
 
+func (xp *ExtendedProviders) Empty() bool {
+	return len(xp.Providers) == 0 && len(xp.ContextualProviders) == 0
+}
+
 type polling struct {
 	interval        time.Duration
 	retryAfter      time.Duration
@@ -743,10 +747,14 @@ func (r *Registry) Update(ctx context.Context, provider, publisher peer.AddrInfo
 		}
 
 		if extendedProviders != nil {
-			if err := validateExtProviders(extendedProviders); err != nil {
-				return err
+			if extendedProviders.Empty() {
+				info.ExtendedProviders = nil
+			} else {
+				if err := validateExtProviders(extendedProviders); err != nil {
+					return err
+				}
+				info.ExtendedProviders = extendedProviders
 			}
-			info.ExtendedProviders = extendedProviders
 		}
 
 		// If publisher ID changed.
@@ -778,7 +786,7 @@ func (r *Registry) Update(ctx context.Context, provider, publisher peer.AddrInfo
 		info = &ProviderInfo{
 			AddrInfo: provider,
 		}
-		if extendedProviders != nil {
+		if extendedProviders != nil && !extendedProviders.Empty() {
 			if err = validateExtProviders(extendedProviders); err != nil {
 				return err
 			}
@@ -1004,6 +1012,10 @@ func (r *Registry) ImportProviders(ctx context.Context, fromURL *url.URL) (int, 
 			log.Infow("Cannot register provider", "err", ErrCannotPublish,
 				"provider", regInfo.AddrInfo.ID, "publisher", regInfo.Publisher)
 			continue
+		}
+
+		if regInfo.ExtendedProviders != nil && regInfo.ExtendedProviders.Empty() {
+			regInfo.ExtendedProviders = nil
 		}
 
 		err = r.register(ctx, regInfo)
@@ -1497,6 +1509,10 @@ func loadPersistedProviders(ctx context.Context, dstore datastore.Datastore, fil
 		if pinfo.Publisher.Validate() == nil && pinfo.PublisherAddr == nil && pinfo.Publisher == pinfo.AddrInfo.ID &&
 			len(pinfo.AddrInfo.Addrs) != 0 {
 			pinfo.PublisherAddr = pinfo.AddrInfo.Addrs[0]
+		}
+
+		if pinfo.ExtendedProviders != nil && pinfo.ExtendedProviders.Empty() {
+			pinfo.ExtendedProviders = nil
 		}
 
 		providers[peerID] = pinfo

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -215,6 +215,28 @@ func TestDatastore(t *testing.T) {
 	require.ErrorContains(t, err, "missing address")
 	extProviders.ContextualProviders[string(epContextId)].Providers[0].Addrs = prevAddrs
 
+	// Check that extended provider information can be deleted.
+	extProviders.ContextualProviders = nil
+	extProviders.Providers = nil
+	var emptyExtProviders ExtendedProviders
+	err = r.Update(ctx, provider2, publisher, adCid, &emptyExtProviders, 0)
+	require.NoError(t, err)
+	infos = r.AllProviderInfo()
+	require.Equal(t, 2, len(infos))
+	for _, provInfo := range infos {
+		switch provInfo.AddrInfo.ID {
+		case provider1.ID:
+			require.NotNil(t, provInfo.Publisher.Validate())
+		case provider2.ID:
+			require.Equal(t, provInfo.Publisher, publisher.ID, "info2 has wrong publisher ID")
+			require.NotNil(t, provInfo.PublisherAddr, "info2 missing publisher address")
+			require.True(t, provInfo.PublisherAddr.Equal(publisher.Addrs[0]), "provider2 has wrong publisher ID %q, expected %q", provInfo.PublisherAddr, publisher.Addrs[0])
+			require.Nil(t, provInfo.ExtendedProviders)
+		default:
+			t.Fatalf("loaded invalid provider ID: %q", provInfo.AddrInfo.ID)
+		}
+	}
+
 	r.Close()
 	require.NoError(t, dstore.Close())
 


### PR DESCRIPTION
Previously, this would leave an empty `ExtendedProvideds` object in the providers output. Now it correctly deletes the extended provider information.

This PR will clean up some of the empty ExtendedProvider info in the `/providers` output.

Closes #1745
