### PR TITLE
feat: begin sync after specified advertisement

### DIFF
--- a/admin/client/client.go
+++ b/admin/client/client.go
@@ -153,7 +153,7 @@ func (c *Client) GetPendingSyncs(ctx context.Context) ([]string, error) {
 }
 
 // Sync with a data peer up to the latest ID.
-func (c *Client) Sync(ctx context.Context, peerID peer.ID, peerAddr multiaddr.Multiaddr, depth int64, resync bool) error {
+func (c *Client) Sync(ctx context.Context, peerID peer.ID, peerAddr multiaddr.Multiaddr, depth int64, resync bool, adCid cid.Cid) error {
 	var data []byte
 	var err error
 	if peerAddr != nil {
@@ -174,6 +174,10 @@ func (c *Client) Sync(ctx context.Context, peerID peer.ID, peerAddr multiaddr.Mu
 	// Only set if true, since by default the latest sync is not ignored.
 	if resync {
 		q = append(q, "resync", strconv.FormatBool(resync))
+	}
+
+	if adCid != cid.Undef {
+		q = append(q, "adcid", adCid.String())
 	}
 
 	return c.ingestRequest(ctx, peerID, "sync", http.MethodPost, data, q...)

--- a/command/admin.go
+++ b/command/admin.go
@@ -58,6 +58,10 @@ var adminSyncFlags = []cli.Flag{
 		Aliases: []string{"p"},
 	},
 	&cli.StringFlag{
+		Name:  "adcid",
+		Usage: "Advertisement CID to begin indexing after. Index advertisements that are more recent than the one specified.",
+	},
+	&cli.StringFlag{
 		Name:  "addr",
 		Usage: "Multiaddr address of peer to sync with",
 	},
@@ -279,7 +283,17 @@ func syncAction(cctx *cli.Context) error {
 			return err
 		}
 	}
-	err = cl.Sync(cctx.Context, peerID, addr, cctx.Int64("depth"), cctx.Bool("resync"))
+
+	adCidFlag := cctx.String("adcid")
+	var adCid cid.Cid
+	if adCidFlag != "" {
+		adCid, err = cid.Decode(adCidFlag)
+		if err != nil {
+			return fmt.Errorf("error decoding cid: %s", err)
+		}
+	}
+
+	err = cl.Sync(cctx.Context, peerID, addr, cctx.Int64("depth"), cctx.Bool("resync"), adCid)
 	if err != nil {
 		return err
 	}

--- a/internal/ingest/hamt_ingest_test.go
+++ b/internal/ingest/hamt_ingest_test.go
@@ -3,6 +3,7 @@ package ingest
 import (
 	"testing"
 
+	"github.com/ipfs/go-cid"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipni/storetheindex/test/typehelpers"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -39,7 +40,7 @@ func TestIngester_IngestsMixedEntriesTypeSuccessfully(t *testing.T) {
 		ID: te.publisher.ID(),
 	}
 	// Trigger a sync.
-	gotHeadAd, err := subject.Sync(ctx, pubInfo, 0, false)
+	gotHeadAd, err := subject.Sync(ctx, pubInfo, 0, false, cid.Undef)
 	require.NoError(t, err)
 	require.Equal(t, headAdCid, gotHeadAd, "Expected latest synced cid to match head of ad chain")
 

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -417,12 +417,15 @@ func removeProcessedFrozen(ctx context.Context, dstore datastore.Datastore) erro
 // will continue until either there are no more advertisements left or the
 // recursion depth limit is reached.
 //
+// The adCid argument, if not cid.Undef, specifies that the sync should only
+// include advertisements that are more recent than the ad identified by adCid.
+//
 // The reference to the latest synced advertisement returned by GetLatestSync
 // is only updated if the given depth is zero and resync is set to false.
 //
 // The Context argument controls the lifetime of the sync. Canceling it cancels
 // the sync and causes the multihash channel to close without any data.
-func (ing *Ingester) Sync(ctx context.Context, peerInfo peer.AddrInfo, depth int, resync bool) (cid.Cid, error) {
+func (ing *Ingester) Sync(ctx context.Context, peerInfo peer.AddrInfo, depth int, resync bool, adCid cid.Cid) (cid.Cid, error) {
 	err := peerInfo.ID.Validate()
 	if err != nil {
 		return cid.Undef, errors.New("invalid provider id")
@@ -459,6 +462,10 @@ func (ing *Ingester) Sync(ctx context.Context, peerInfo peer.AddrInfo, depth int
 
 	if depth != 0 {
 		opts = append(opts, dagsync.ScopedDepthLimit(int64(depth)))
+	}
+
+	if adCid != cid.Undef {
+		opts = append(opts, dagsync.WithStopAdCid(adCid))
 	}
 
 	syncDone, cancel := ing.onAdProcessed(peerInfo.ID)

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -636,6 +636,41 @@ func TestSyncWithDepth(t *testing.T) {
 	requireNotIndexed(t, te.ingester.indexer, te.pubHost.ID(), []multihash.Multihash{allMhs[0]})
 }
 
+func TestSyncWithAdCid(t *testing.T) {
+	te := setupTestEnv(t, true)
+
+	chainHead := typehelpers.RandomAdBuilder{
+		EntryBuilders: []typehelpers.EntryBuilder{
+			typehelpers.RandomHamtEntryBuilder{MultihashCount: 1, Seed: 1},
+			typehelpers.RandomEntryChunkBuilder{ChunkCount: 1, EntriesPerChunk: 1, Seed: 2},
+		},
+	}.Build(t, te.publisherLinkSys, te.publisherPriv)
+
+	adNode, err := te.publisherLinkSys.Load(linking.LinkContext{}, chainHead, schema.AdvertisementPrototype)
+	require.NoError(t, err)
+	ad, err := schema.UnwrapAdvertisement(adNode)
+	require.NoError(t, err)
+
+	rootCid := chainHead.(cidlink.Link).Cid
+	te.publisher.SetRoot(rootCid)
+
+	peerInfo := peer.AddrInfo{
+		ID:    te.publisher.ID(),
+		Addrs: te.publisher.Addrs(),
+	}
+
+	c, err := te.ingester.Sync(t.Context(), peerInfo, 0, false, ad.PreviousCid())
+	require.NoError(t, err)
+
+	lcid, err := te.ingester.GetLatestSync(te.pubHost.ID())
+	require.NoError(t, err)
+	require.Equal(t, chainHead.(cidlink.Link).Cid, lcid, "synced up to %s, should have synced up to %s", c, chainHead.(cidlink.Link).Cid)
+
+	allMhs := typehelpers.AllMultihashesFromAdChain(t, ad, te.publisherLinkSys)
+	requireIndexedEventually(t, te.ingester.indexer, te.pubHost.ID(), []multihash.Multihash{allMhs[1]})
+	requireNotIndexed(t, te.ingester.indexer, te.pubHost.ID(), []multihash.Multihash{allMhs[0]})
+}
+
 func TestFreeze(t *testing.T) {
 	te := setupTestEnv(t, true)
 

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -80,7 +80,7 @@ func TestSubscribe(t *testing.T) {
 		Addrs: te.publisher.Addrs(),
 	}
 	ctx := t.Context()
-	_, err := te.ingester.Sync(ctx, peerInfo, 0, false)
+	_, err := te.ingester.Sync(ctx, peerInfo, 0, false, cid.Undef)
 	require.NoError(t, err)
 	mhs := typehelpers.AllMultihashesFromAdLink(t, adHead, te.publisherLinkSys)
 	requireIndexedEventually(t, te.ingester.indexer, te.pubHost.ID(), mhs)
@@ -95,7 +95,7 @@ func TestSubscribe(t *testing.T) {
 		}}.Build(t, te.publisherLinkSys, someOtherProviderPriv)
 	te.publisher.SetRoot(adHead.(cidlink.Link).Cid)
 
-	_, err = te.ingester.Sync(ctx, peerInfo, 0, false)
+	_, err = te.ingester.Sync(ctx, peerInfo, 0, false, cid.Undef)
 	require.NoError(t, err)
 
 	someOtherProvider, err := peer.IDFromPrivateKey(someOtherProviderPriv)
@@ -138,7 +138,7 @@ func TestSubscribe(t *testing.T) {
 
 	// We are manually syncing here to not rely on the pubsub mechanism inside a test.
 	// This will fetch the add and put it into our datastore, but will not process it.
-	_, err = te.ingester.Sync(ctx, peerInfo, 0, false)
+	_, err = te.ingester.Sync(ctx, peerInfo, 0, false, cid.Undef)
 	var aiErr adIngestError
 	require.ErrorAs(t, err, &aiErr)
 	require.ErrorIs(t, err, registry.ErrNotAllowed)
@@ -234,7 +234,7 @@ func TestFailDuringResync(t *testing.T) {
 		ID:    te.publisher.ID(),
 		Addrs: te.publisher.Addrs(),
 	}
-	c, err := te.ingester.Sync(ctx, peerInfo, 1, false)
+	c, err := te.ingester.Sync(ctx, peerInfo, 1, false, cid.Undef)
 	require.NoError(t, err)
 	require.Equal(t, adHead.(cidlink.Link).Cid, c)
 	requireIndexedEventually(t, te.ingester.indexer, te.pubHost.ID(), allMHs[1:])
@@ -244,7 +244,7 @@ func TestFailDuringResync(t *testing.T) {
 	wait := make(chan struct{})
 	go func() {
 		defer close(wait)
-		_, err := te.ingester.Sync(ctx, peerInfo, 2, true)
+		_, err := te.ingester.Sync(ctx, peerInfo, 2, true, cid.Undef)
 		require.Error(t, err)
 	}()
 	<-hitBlockedRead
@@ -264,7 +264,7 @@ func TestFailDuringResync(t *testing.T) {
 
 	// Now we'll resync again and we should succeed.
 	blockedReads.rm(prevAd.Entries.(cidlink.Link).Cid)
-	_, err = te.ingester.Sync(ctx, peerInfo, 2, true)
+	_, err = te.ingester.Sync(ctx, peerInfo, 2, true, cid.Undef)
 	require.NoError(t, err)
 	requireIndexedEventually(t, te.ingester.indexer, te.pubHost.ID(), allMHs)
 }
@@ -290,7 +290,7 @@ func TestFirstAdMissingAddrs(t *testing.T) {
 		Addrs: te.publisher.Addrs(),
 	}
 	ctx := t.Context()
-	_, err = te.ingester.Sync(ctx, peerInfo, 0, false)
+	_, err = te.ingester.Sync(ctx, peerInfo, 0, false, cid.Undef)
 	require.NoError(t, err)
 
 	allMhs := typehelpers.AllMultihashesFromAdChain(t, cAd, te.publisherLinkSys)
@@ -339,7 +339,7 @@ func TestRestartDuringSync(t *testing.T) {
 	}
 
 	go func() {
-		_, err := te.ingester.Sync(sctx, peerInfo, 0, false)
+		_, err := te.ingester.Sync(sctx, peerInfo, 0, false, cid.Undef)
 		// Error may be a number of different errors depending on where in the
 		// sync process the service is closed. So, just check that there is an
 		// error.
@@ -373,7 +373,7 @@ func TestRestartDuringSync(t *testing.T) {
 
 	// And sync to C
 	te.publisher.SetRoot(cCid.(cidlink.Link).Cid)
-	_, err = te.ingester.Sync(ctx, peerInfo, 0, false)
+	_, err = te.ingester.Sync(ctx, peerInfo, 0, false, cid.Undef)
 	require.NoError(t, err)
 
 	allMhs := typehelpers.AllMultihashesFromAdChain(t, cAd, te.publisherLinkSys)
@@ -427,7 +427,7 @@ func TestFailDuringSync(t *testing.T) {
 	}
 
 	go func() {
-		_, err = te.ingester.Sync(sctx, peerInfo, 0, false)
+		_, err = te.ingester.Sync(sctx, peerInfo, 0, false, cid.Undef)
 		require.Error(t, err)
 		// Should see last error since cannot ingest ad entries.
 		pInfo, _ := te.reg.ProviderInfo(te.pubHost.ID())
@@ -447,7 +447,7 @@ func TestFailDuringSync(t *testing.T) {
 	// And sync to C
 	te.publisher.SetRoot(cCid.(cidlink.Link).Cid)
 
-	endCid, err := te.ingester.Sync(sctx, peerInfo, 0, false)
+	endCid, err := te.ingester.Sync(sctx, peerInfo, 0, false, cid.Undef)
 	require.NoError(t, err)
 	require.Equal(t, cCid.(cidlink.Link).Cid, endCid)
 
@@ -591,7 +591,7 @@ func TestWithDuplicatedEntryChunks(t *testing.T) {
 		Addrs: te.publisher.Addrs(),
 	}
 
-	c, err := te.ingester.Sync(t.Context(), peerInfo, 0, false)
+	c, err := te.ingester.Sync(t.Context(), peerInfo, 0, false, cid.Undef)
 	require.NoError(t, err)
 
 	lcid, err := te.ingester.GetLatestSync(te.pubHost.ID())
@@ -624,7 +624,7 @@ func TestSyncWithDepth(t *testing.T) {
 		Addrs: te.publisher.Addrs(),
 	}
 
-	c, err := te.ingester.Sync(t.Context(), peerInfo, 1, false)
+	c, err := te.ingester.Sync(t.Context(), peerInfo, 1, false, cid.Undef)
 	require.NoError(t, err)
 
 	lcid, err := te.ingester.GetLatestSync(te.pubHost.ID())
@@ -652,7 +652,7 @@ func TestFreeze(t *testing.T) {
 		Addrs: te.publisher.Addrs(),
 	}
 
-	_, err := te.ingester.Sync(t.Context(), peerInfo, 0, false)
+	_, err := te.ingester.Sync(t.Context(), peerInfo, 0, false, cid.Undef)
 	require.NoError(t, err)
 	mhs := typehelpers.AllMultihashesFromAdLink(t, adHead, te.publisherLinkSys)
 	requireIndexedEventually(t, te.ingester.indexer, te.pubHost.ID(), mhs)
@@ -676,7 +676,7 @@ func TestFreeze(t *testing.T) {
 	te.publisher.SetRoot(adHead.(cidlink.Link).Cid)
 
 	ctx := t.Context()
-	_, err = te.ingester.Sync(ctx, peerInfo, 0, false)
+	_, err = te.ingester.Sync(ctx, peerInfo, 0, false, cid.Undef)
 	require.NoError(t, err)
 
 	provs = te.reg.AllProviderInfo()
@@ -694,7 +694,7 @@ func TestFreeze(t *testing.T) {
 	}
 
 	rmAdCid := publishRemovalAd(t, te.publisher, te.publisherLinkSys, false, te.pubHost.ID(), te.publisherPriv)
-	_, err = te.ingester.Sync(ctx, peerInfo, 0, false)
+	_, err = te.ingester.Sync(ctx, peerInfo, 0, false, cid.Undef)
 	require.NoError(t, err)
 
 	// Check that last advertisement matches last removal.
@@ -748,7 +748,7 @@ func TestRmWithNoEntries(t *testing.T) {
 		Addrs: te.publisher.Addrs(),
 	}
 	ctx := t.Context()
-	_, err = te.ingester.Sync(ctx, peerInfo, 0, false)
+	_, err = te.ingester.Sync(ctx, peerInfo, 0, false, cid.Undef)
 	require.NoError(t, err)
 	var lcid cid.Cid
 	require.Eventually(t, func() bool {
@@ -795,7 +795,7 @@ func TestSync(t *testing.T) {
 		ID:    pub.ID(),
 		Addrs: pub.Addrs(),
 	}
-	endCid, err := i.Sync(ctx, peerInfo, 0, false)
+	endCid, err := i.Sync(ctx, peerInfo, 0, false, cid.Undef)
 	require.NoError(t, err)
 
 	// We receive the CID that we synced.
@@ -815,16 +815,16 @@ func TestSync(t *testing.T) {
 	requireIndexedEventually(t, i.indexer, providerID, mhs)
 
 	// Test that we finish this sync even if we're already at the latest
-	_, err = i.Sync(ctx, peerInfo, 0, false)
+	_, err = i.Sync(ctx, peerInfo, 0, false, cid.Undef)
 	require.NoError(t, err)
 
 	fmt.Println("Testing final resync")
 	// Test that we finish this sync even if we have a limit
-	_, err = i.Sync(ctx, peerInfo, 1, true)
+	_, err = i.Sync(ctx, peerInfo, 1, true, cid.Undef)
 	require.NoError(t, err)
 
 	publishRemovalAd(t, pub, lsys, false, providerID, privKey)
-	_, err = i.Sync(ctx, peerInfo, 0, false)
+	_, err = i.Sync(ctx, peerInfo, 0, false, cid.Undef)
 	require.NoError(t, err)
 }
 
@@ -850,7 +850,7 @@ func TestSyncInternalError(t *testing.T) {
 		ID:    pub.ID(),
 		Addrs: pub.Addrs(),
 	}
-	_, err := ing.Sync(ctx, peerInfo, 0, false)
+	_, err := ing.Sync(ctx, peerInfo, 0, false, cid.Undef)
 	require.Error(t, err)
 	require.ErrorIs(t, err, errInternal)
 	require.ErrorContains(t, err, errVS.err.Error())
@@ -1021,7 +1021,7 @@ func syncIngester(t *testing.T, ctx context.Context, ingester *Ingester, provide
 		ID:    pubHost.ID(),
 		Addrs: pubHost.Addrs(),
 	}
-	_, err := ingester.Sync(ctx, peerInfo, -1, false)
+	_, err := ingester.Sync(ctx, peerInfo, -1, false, cid.Undef)
 	require.NoError(t, err)
 	for _, mms := range mhs {
 		requireIndexedEventually(t, ingester.indexer, providerID, mms)
@@ -1100,7 +1100,7 @@ func TestSyncTooLargeMetadata(t *testing.T) {
 		ID:    pub.ID(),
 		Addrs: pub.Addrs(),
 	}
-	endCid, err := i.Sync(ctx, peerInfo, 0, false)
+	endCid, err := i.Sync(ctx, peerInfo, 0, false, cid.Undef)
 	require.ErrorContains(t, err, errBadAdvert.Error())
 
 	// We receive the CID that we synced.
@@ -1132,7 +1132,7 @@ func TestSyncSkipNoMetadata(t *testing.T) {
 		ID:    pub.ID(),
 		Addrs: pub.Addrs(),
 	}
-	endCid, err := i.Sync(ctx, peerInfo, 0, false)
+	endCid, err := i.Sync(ctx, peerInfo, 0, false, cid.Undef)
 	require.NoError(t, err)
 
 	// We receive the CID that we synced.
@@ -1152,7 +1152,7 @@ func TestSyncSkipNoMetadata(t *testing.T) {
 
 	// Test ad that has entries and no metadata.
 	adCid, _, providerID, _ = publishRandomIndexAndAdvWithEntriesChunkCount(t, pub, lsys, false, 10, []byte{}, cid.Undef)
-	endCid, err = i.Sync(ctx, peerInfo, 0, false)
+	endCid, err = i.Sync(ctx, peerInfo, 0, false, cid.Undef)
 	require.NoError(t, err)
 	require.Equal(t, adCid, endCid)
 
@@ -1178,20 +1178,20 @@ func TestReSyncWithDepth(t *testing.T) {
 		ID:    te.publisher.ID(),
 		Addrs: te.publisher.Addrs(),
 	}
-	_, err := te.ingester.Sync(t.Context(), peerInfo, 1, false)
+	_, err := te.ingester.Sync(t.Context(), peerInfo, 1, false, cid.Undef)
 	require.NoError(t, err)
 	allMHs := typehelpers.AllMultihashesFromAdLink(t, adHead, te.publisherLinkSys)
 	requireIndexedEventually(t, te.ingester.indexer, te.pubHost.ID(), allMHs[1:])
 	requireNotIndexed(t, te.ingester.indexer, te.pubHost.ID(), allMHs[0:1])
 
 	// When not resync, check that nothing beyond the latest is synced.
-	_, err = te.ingester.Sync(t.Context(), peerInfo, 0, false)
+	_, err = te.ingester.Sync(t.Context(), peerInfo, 0, false, cid.Undef)
 	require.NoError(t, err)
 	requireIndexedEventually(t, te.ingester.indexer, te.pubHost.ID(), allMHs[1:])
 	requireNotIndexed(t, te.ingester.indexer, te.pubHost.ID(), allMHs[0:1])
 
 	// When resync with greater depth, check that everything in synced.
-	_, err = te.ingester.Sync(t.Context(), peerInfo, 0, true)
+	_, err = te.ingester.Sync(t.Context(), peerInfo, 0, true, cid.Undef)
 	require.NoError(t, err)
 	requireIndexedEventually(t, te.ingester.indexer, te.pubHost.ID(), allMHs)
 }
@@ -1216,7 +1216,7 @@ func TestSkipEarlierAdsIfAlreadyProcessedLaterAd(t *testing.T) {
 		ID:    te.publisher.ID(),
 		Addrs: te.publisher.Addrs(),
 	}
-	_, err := te.ingester.Sync(ctx, peerInfo, 0, false)
+	_, err := te.ingester.Sync(ctx, peerInfo, 0, false, cid.Undef)
 	require.NoError(t, err)
 
 	requireIndexedEventually(t, te.ingester.indexer, te.pubHost.ID(), allMHs[0:2])
@@ -1225,7 +1225,7 @@ func TestSkipEarlierAdsIfAlreadyProcessedLaterAd(t *testing.T) {
 	err = te.ingester.sub.SetLatestSync(te.pubHost.ID(), aLink.(cidlink.Link).Cid)
 	require.NoError(t, err)
 	te.publisher.SetRoot(cLink.(cidlink.Link).Cid)
-	_, err = te.ingester.Sync(ctx, peerInfo, 0, false)
+	_, err = te.ingester.Sync(ctx, peerInfo, 0, false, cid.Undef)
 	require.NoError(t, err)
 
 	requireIndexedEventually(t, te.ingester.indexer, te.pubHost.ID(), allMHs)
@@ -1264,7 +1264,7 @@ func TestSegmentedSyncStopsAtProcessedAdOnSplitChain(t *testing.T) {
 
 	// Sync the full chain a <- b <- c <- d; all four ads become processed.
 	te.publisher.SetRoot(dCid)
-	_, err := te.ingester.Sync(ctx, peerInfo, 0, false)
+	_, err := te.ingester.Sync(ctx, peerInfo, 0, false, cid.Undef)
 	require.NoError(t, err)
 	requireIndexedEventually(t, te.ingester.indexer, te.pubHost.ID(), chainMHs)
 
@@ -1313,7 +1313,7 @@ func TestSegmentedSyncStopsAtProcessedAdOnSplitChain(t *testing.T) {
 
 	// Announce e. Scanning: e (new) -> c (already processed, stop).
 	te.publisher.SetRoot(eCid)
-	_, err = te.ingester.Sync(ctx, peerInfo, 0, false)
+	_, err = te.ingester.Sync(ctx, peerInfo, 0, false, cid.Undef)
 	require.NoError(t, err)
 	requireIndexedEventually(t, te.ingester.indexer, te.pubHost.ID(), eMHs)
 
@@ -1351,7 +1351,7 @@ func TestRecursionDepthLimitsEntriesSync(t *testing.T) {
 		ID:    pub.ID(),
 		Addrs: pub.Addrs(),
 	}
-	endCid, err := ing.Sync(ctx, peerInfo, 0, false)
+	endCid, err := ing.Sync(ctx, peerInfo, 0, false, cid.Undef)
 	require.NoError(t, err)
 
 	// We receive the CID that we synced.
@@ -1474,7 +1474,7 @@ func TestMultiplePublishers(t *testing.T) {
 		ID:    pub1.ID(),
 		Addrs: pub1.Addrs(),
 	}
-	gotC1, err := i.Sync(ctx, peerInfo1, 0, false)
+	gotC1, err := i.Sync(ctx, peerInfo1, 0, false, cid.Undef)
 	require.NoError(t, err)
 	require.Equal(t, headAd1Cid, gotC1, "expected latest synced cid to match head of ad chain")
 
@@ -1495,7 +1495,7 @@ func TestMultiplePublishers(t *testing.T) {
 		ID:    pub2.ID(),
 		Addrs: pub2.Addrs(),
 	}
-	gotC2, err := i.Sync(ctx, peerInfo2, 0, false)
+	gotC2, err := i.Sync(ctx, peerInfo2, 0, false, cid.Undef)
 	require.NoError(t, err)
 	require.Equal(t, headAd2Cid, gotC2, "expected latest synced cid to match head of ad chain")
 
@@ -1670,7 +1670,7 @@ func TestSyncGateDoesNotBlockDifferentPublisher(t *testing.T) {
 	// head entries while holding A's per-publisher gate.
 	syncADone := make(chan error, 1)
 	go func() {
-		_, err := te.ingester.Sync(t.Context(), peerInfoA, 0, false)
+		_, err := te.ingester.Sync(t.Context(), peerInfoA, 0, false, cid.Undef)
 		syncADone <- err
 	}()
 
@@ -1703,7 +1703,7 @@ func TestSyncGateDoesNotBlockDifferentPublisher(t *testing.T) {
 
 	// While A is still blocked, sync B. The gate is per-publisher, so B should
 	// complete immediately on the second ingest worker.
-	gotCidB, err := te.ingester.Sync(t.Context(), peerInfoB, 0, false)
+	gotCidB, err := te.ingester.Sync(t.Context(), peerInfoB, 0, false, cid.Undef)
 	require.NoError(t, err)
 	require.Equal(t, headCidB, gotCidB)
 	requireIndexedEventually(t, te.ingester.indexer, pubHostB.ID(), mhsB)
@@ -1744,7 +1744,7 @@ func TestAnnounceIsDeferredWhenProcessingAd(t *testing.T) {
 
 	wait := make(chan cid.Cid, 1)
 	go func() {
-		syncCid, err := te.ingester.Sync(t.Context(), peerInfo, 0, false)
+		syncCid, err := te.ingester.Sync(t.Context(), peerInfo, 0, false, cid.Undef)
 		require.NoError(t, err)
 		wait <- syncCid
 	}()
@@ -1927,7 +1927,7 @@ func TestGetEntryDataFromCar(t *testing.T) {
 		ID:    te.publisher.ID(),
 		Addrs: te.publisher.Addrs(),
 	}
-	_, err = te.ingester.Sync(ctx, peerInfo, 0, false)
+	_, err = te.ingester.Sync(ctx, peerInfo, 0, false, cid.Undef)
 	require.NoError(t, err)
 
 	allMhs := typehelpers.AllMultihashesFromAdChain(t, cAd, te.publisherLinkSys)
@@ -1988,7 +1988,7 @@ func TestGetEntryDataFromCar(t *testing.T) {
 	require.Equal(t, 5, count)
 
 	// Do a resync and see that multihashes are pulled from CAR files.
-	_, err = te.ingester.Sync(ctx, peerInfo, 0, true)
+	_, err = te.ingester.Sync(ctx, peerInfo, 0, true, cid.Undef)
 	require.NoError(t, err)
 
 	allMhs = typehelpers.AllMultihashesFromAdChain(t, cAd, te.publisherLinkSys)

--- a/internal/ingest/invalid_mh_ingest_test.go
+++ b/internal/ingest/invalid_mh_ingest_test.go
@@ -3,6 +3,7 @@ package ingest
 import (
 	"testing"
 
+	"github.com/ipfs/go-cid"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipni/storetheindex/test/typehelpers"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -36,7 +37,7 @@ func TestInvalidMultihashesAreNotIngested(t *testing.T) {
 	pubInfo := peer.AddrInfo{
 		ID: te.publisher.ID(),
 	}
-	gotHeadAd, err := subject.Sync(ctx, pubInfo, 0, false)
+	gotHeadAd, err := subject.Sync(ctx, pubInfo, 0, false, cid.Undef)
 	require.NoError(t, err)
 
 	require.Equal(t, headAdCid, gotHeadAd, "Expected latest synced cid to match head of ad chain")

--- a/internal/ingest/seg_sync_test.go
+++ b/internal/ingest/seg_sync_test.go
@@ -3,6 +3,7 @@ package ingest
 import (
 	"testing"
 
+	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-test/random"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipni/storetheindex/config"
@@ -48,7 +49,7 @@ func TestAdsSyncedViaSegmentsAreProcessed(t *testing.T) {
 	pubInfo := peer.AddrInfo{
 		ID: te.publisher.ID(),
 	}
-	gotHeadAd, err := subject.Sync(ctx, pubInfo, 0, false)
+	gotHeadAd, err := subject.Sync(ctx, pubInfo, 0, false, cid.Undef)
 	require.NoError(t, err)
 	require.Equal(t, headAdCid, gotHeadAd, "Expected latest synced cid to match head of ad chain")
 

--- a/server/admin/handler.go
+++ b/server/admin/handler.go
@@ -321,6 +321,19 @@ func (h *adminHandler) handlePostSyncs(w http.ResponseWriter, r *http.Request) {
 		log = log.With("resync", resync)
 	}
 
+	var adCid cid.Cid
+	adCidStr := query.Get("adcid")
+	if adCidStr != "" {
+		var err error
+		adCid, err = cid.Decode(adCidStr)
+		if err != nil {
+			msg := "cannot decode advertisement cid"
+			log.Errorw(msg, "value", adCidStr, "err", err)
+			http.Error(w, msg, http.StatusBadRequest)
+			return
+		}
+	}
+
 	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		log.Errorw("Failed reading body", "err", err)
@@ -365,7 +378,7 @@ func (h *adminHandler) handlePostSyncs(w http.ResponseWriter, r *http.Request) {
 			peerInfo.Addrs = []multiaddr.Multiaddr{syncAddr}
 		}
 
-		_, err := h.ingester.Sync(h.ctx, peerInfo, int(depth), resync)
+		_, err := h.ingester.Sync(h.ctx, peerInfo, int(depth), resync, adCid)
 		if err != nil {
 			log.Errorw("Cannot sync with peer", "err", err)
 		}


### PR DESCRIPTION
## Context

When syncing with a provider, and limiting how far back into the advertisement chain to sync, it is necessary to know which advertisement marks the depth limit instead of specifying the depth limit as a count of advertisements. This is particularly true when the depth of the provider's ad chain is increasing, but it is necessary to sync back to a particular ad.

## Proposed Changes

Add the ability to begin sync with an SP from after a specified advertisement. The advertisement CID is given by the `-adcid` flag passed to the `admin sync` command.

## Tests

Tested in `go-libipni` and in `ingest/ingest_test.go`.

## Revert Strategy

Change is safe to revert if not yet released, since there will not be external dependencies on new API or command flag.
