### PR TITLE
2885 ad status update

### DIFF
--- a/doc/ingestion.md
+++ b/doc/ingestion.md
@@ -478,7 +478,7 @@ The response includes:
     skipped ads and will report `indexed` regardless of their actual outcome
   - `"skipped"` - the ad was permanently skipped (malformed, decode error, etc.)
   - `"resyncing"` - the ad is marked for resync (previous processing invalidated)
-- `Reason` - the skip reason string, non-empty only when `State` is `"skipped"`
+- `SkipReason` - the skip reason string (truncated to 256 bytes), non-empty only when `State` is `"skipped"`
 - `Frozen` - true when the ad was processed while the indexer was in frozen mode
 
 `Indexed` is false when:

--- a/doc/ingestion.md
+++ b/doc/ingestion.md
@@ -459,12 +459,25 @@ status.
 
 Whether a single advertisement's content is available from this indexer is
 exposed on the same ingest HTTP API as `GET /sync/status/ad/<adCid>`. The
-response includes:
+endpoint only accepts dag-json CIDs (codec 0x0129); requests with other codecs
+return HTTP 400. If the ingester is not available, the endpoint returns HTTP
+503.
+
+The response includes:
 
 - `Ad` - the requested advertisement CID
 - `Indexed` - true only when the ad was fully processed while the indexer was
   not frozen, and is not currently marked for resync
   (`Processed && !Resync && !Frozen` from `AdState`)
+- `State` - one of `"unknown"`, `"pending"`, `"indexed"`, `"skipped"`, or
+  `"resyncing"`:
+  - `"unknown"` - the ad is not known to the ingester
+  - `"pending"` - the ad is known but not yet fully processed
+  - `"indexed"` - the ad was fully processed and entries were indexed
+  - `"skipped"` - the ad was permanently skipped (malformed, decode error, etc.)
+  - `"resyncing"` - the ad is marked for resync (previous processing invalidated)
+- `Reason` - the skip reason string, non-empty only when `State` is `"skipped"`
+- `Frozen` - true when the ad was processed while the indexer was in frozen mode
 
 `Indexed` is false when:
 

--- a/doc/ingestion.md
+++ b/doc/ingestion.md
@@ -321,9 +321,13 @@ Ingestion markers (`ingest.go`):
 
 - `syncPrefix` (`/sync/<publisherID>`) -> CID bytes of the latest fully
   processed ad for a publisher (`GetLatestSync` / `getLastKnownSync`).
-- `adProcessedPrefix` (`/adProcessed/<adCid>`) -> marks an ad as processed
+- `adProcessedPrefix` (`/adProcessed/<adCid>`) -> marks an ad state
   (used to stop chain walks and skip re-processing). Value is a single byte:
-  `1` = processed, `0` = explicitly unprocessed, `2` = marked for resync.
+  `0` = unprocessed, `1` = processed, `2` = marked for resync,
+  `3` = permanently skipped (will not be retried).
+- `adSkipReasonPrefix` (`/adSkipReason/<adCid>`) -> sidecar string stored
+  alongside the `3` marker, explaining why the ad was permanently skipped
+  (e.g. decoding error, malformed, entry chunk error, content not found).
 - `adProcessedFrozenPrefix` (`/adF/<adCid>`) -> marks ads processed while
   frozen, used to roll back on unfreeze (`Unfreeze` / `removeProcessedFrozen`).
 
@@ -470,10 +474,11 @@ response includes:
 - the ad is marked for resync (previous processing is treated as invalidated
   until the ad is processed again)
 
-`Indexed` does not distinguish successful content indexing from permanent skips
-(malformed/decoding/content-not-found ads are still marked processed, so they
-can report `Indexed: true`). Timestamps and provider identity are not stored
-per ad and are not returned.
+`Indexed` now distinguishes permanent skips from successful processing: ads
+that fail with a permanent error (malformed, decoding, content-not-found, etc.)
+are marked with the `3` (skipped) marker and report `Skipped: true`,
+`Indexed: false`. Timestamps and provider identity are not stored per ad and
+are not returned.
 
 See [`internal/ingest/syncstatus.go`](../internal/ingest/syncstatus.go) for
 the tracker. The ingest HTTP handlers marshal tracker snapshots to JSON.

--- a/doc/ingestion.md
+++ b/doc/ingestion.md
@@ -473,7 +473,9 @@ The response includes:
   `"resyncing"`:
   - `"unknown"` - the ad is not known to the ingester
   - `"pending"` - the ad is known but not yet fully processed
-  - `"indexed"` - the ad was fully processed and entries were indexed
+  - `"indexed"` - the ad was fully processed and entries were indexed; note that
+    ads processed before this change was deployed cannot be distinguished from
+    skipped ads and will report `indexed` regardless of their actual outcome
   - `"skipped"` - the ad was permanently skipped (malformed, decode error, etc.)
   - `"resyncing"` - the ad is marked for resync (previous processing invalidated)
 - `Reason` - the skip reason string, non-empty only when `State` is `"skipped"`

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -44,6 +44,14 @@ const (
 	// adProcessedFrozenPrefix identifies all advertisements processed while in
 	// frozen mode. Used for unfreezing.
 	adProcessedFrozenPrefix = "/adF/"
+	// adSkipReasonPrefix identifies the skip reason for permanently skipped ads.
+	adSkipReasonPrefix = "/adSkipReason/"
+	// Marker byte values for /adProcessed/<cid>.
+	// Explicit values; these are a persisted on-disk format.
+	adMarkerUnprocessed byte = 0 // unprocessed
+	adMarkerProcessed   byte = 1 // processed successfully
+	adMarkerResync      byte = 2 // marked for resync
+	adMarkerSkipped     byte = 3 // processed but permanently skipped
 	// metricsUpdateInterval determines how ofter to update ingestion metrics.
 	metricsUpdateInterval = time.Minute
 	// adsScannedLogInterval is how often to log ad-chain scanning progress.
@@ -257,13 +265,13 @@ func (ing *Ingester) Skip500EntriesError(skip bool) {
 func (ing *Ingester) generalDagsyncBlockHook(publisher peer.ID, c cid.Cid, actions dagsync.SegmentSyncActions) {
 	// If this ad is already fully processed, all older ads are too.
 	// Stop advancing without loading the ad data.
-	processed, _, err := ing.adAlreadyProcessed(c)
+	adState, err := ing.adAlreadyProcessed(c)
 	if err != nil {
 		ing.EndScan(publisher, err)
 		actions.FailSync(err)
 		return
 	}
-	if processed {
+	if adState.Processed {
 		log.Debugw("Reached already processed advertisement; stopping scan", "publisher", publisher, "adCid", c)
 		actions.SetNextSyncCid(cid.Undef)
 		return
@@ -545,29 +553,45 @@ func (ing *Ingester) Announce(ctx context.Context, nextCid cid.Cid, pubAddrInfo 
 // When forResync is true, index counts are not added to the existing index
 // count.
 func (ing *Ingester) markAdUnprocessed(adCid cid.Cid, forResync bool) error {
-	data := []byte{0}
+	data := []byte{adMarkerUnprocessed}
 	if forResync {
-		data = []byte{2}
+		data = []byte{adMarkerResync}
 	}
 	return ing.ds.Put(context.Background(), datastore.NewKey(adProcessedPrefix+adCid.String()), data)
 }
 
-func (ing *Ingester) adAlreadyProcessed(adCid cid.Cid) (bool, bool, error) {
+type adProcessedState struct {
+	Known     bool
+	Processed bool
+	Skipped   bool
+	Resync    bool
+}
+
+func (ing *Ingester) adAlreadyProcessed(adCid cid.Cid) (adProcessedState, error) {
 	v, err := ing.ds.Get(context.Background(), datastore.NewKey(adProcessedPrefix+adCid.String()))
 	if errors.Is(err, datastore.ErrNotFound) {
-		return false, false, nil
+		return adProcessedState{}, nil
 	} else if err != nil {
-		return false, false, err
+		return adProcessedState{}, err
 	}
-	processed := v[0] == byte(1)
-	resync := v[0] == byte(2)
-	return processed, resync, nil
+	if len(v) == 0 {
+		return adProcessedState{}, fmt.Errorf("empty value for ad processed marker %s", adCid)
+	}
+	return adProcessedState{
+		Known:     true,
+		Processed: v[0] == adMarkerProcessed || v[0] == adMarkerSkipped,
+		Skipped:   v[0] == adMarkerSkipped,
+		Resync:    v[0] == adMarkerResync,
+	}, nil
 }
 
 type AdState struct {
-	Processed bool
-	Resync    bool
-	Frozen    bool
+	Known      bool
+	Processed  bool
+	Skipped    bool
+	SkipReason string
+	Resync     bool
+	Frozen     bool
 }
 
 // Indexed reports whether the advertisement's content should be considered
@@ -576,24 +600,37 @@ type AdState struct {
 // An ad is indexed only when it was fully processed while the indexer was not
 // frozen. Ads marked for resync are treated as not indexed because a resync
 // invalidates the previous processing result until the ad is processed again.
-//
-// Note that Processed (and therefore Indexed) does not distinguish successful
-// content indexing from permanent skips such as malformed ads.
+// Ads that were permanently skipped (malformed, decode failure, etc.) are not
+// indexed even though they are marked as processed in the marker layer.
 func (s AdState) Indexed() bool {
-	return s.Processed && !s.Resync && !s.Frozen
+	return s.Processed && !s.Skipped && !s.Resync && !s.Frozen
 }
 
 // GetAdState returns the known state for an advertisement.
 //
 // Processed is true when the ad is marked fully processed (/adProcessed/ value
-// 1). Resync is true when the ad is marked for resync (value 2). Frozen is true
-// when the ad was processed while the indexer was in frozen mode (/adF/ key
-// present); frozen processing updates provider metadata but does not index
-// entry multihashes.
+// 1 or 3). Skipped is true when the ad was permanently skipped (value 3).
+// SkipReason contains the reason for the skip. Resync is true when the ad is
+// marked for resync (value 2). Frozen is true when the ad was processed while
+// the indexer was in frozen mode (/adF/ key present); frozen processing updates
+// provider metadata but does not index entry multihashes. Known is false when
+// the ad has never been seen (datastore.ErrNotFound).
 func (ing *Ingester) GetAdState(adCid cid.Cid) (state AdState, err error) {
-	state.Processed, state.Resync, err = ing.adAlreadyProcessed(adCid)
+	adState, err := ing.adAlreadyProcessed(adCid)
 	if err != nil {
 		return state, err
+	}
+	state.Known = adState.Known
+	state.Processed = adState.Processed
+	state.Skipped = adState.Skipped
+	state.Resync = adState.Resync
+
+	if adState.Skipped {
+		reason, err2 := ing.ds.Get(context.Background(), datastore.NewKey(adSkipReasonPrefix+adCid.String()))
+		if err2 != nil && !errors.Is(err2, datastore.ErrNotFound) {
+			return state, err2
+		}
+		state.SkipReason = string(reason)
 	}
 
 	_, err = ing.ds.Get(context.Background(), datastore.NewKey(adProcessedFrozenPrefix+adCid.String()))
@@ -616,6 +653,28 @@ func (ing *Ingester) MarkAdProcessed(publisher peer.ID, adCid cid.Cid) error {
 }
 
 func (ing *Ingester) markAdProcessed(publisher peer.ID, adCid cid.Cid, frozen, mirrored bool) error {
+	return ing.writeAdMarker(publisher, adCid, adMarkerProcessed, frozen, mirrored)
+}
+
+// MarkAdSkipped explicitly marks an advertisement as permanently skipped. This
+// is used to record that an ad was processed but could not be indexed due to a
+// permanent error (decode failure, malformed, entry chunk error, etc.).
+func (ing *Ingester) MarkAdSkipped(publisher peer.ID, adCid cid.Cid, reason string, frozen bool) error {
+	return ing.markAdSkipped(publisher, adCid, reason, frozen)
+}
+
+func (ing *Ingester) markAdSkipped(publisher peer.ID, adCid cid.Cid, reason string, frozen bool) error {
+	cidStr := adCid.String()
+	ctx := context.Background()
+
+	if err := ing.ds.Put(ctx, datastore.NewKey(adSkipReasonPrefix+cidStr), []byte(reason)); err != nil {
+		return err
+	}
+
+	return ing.writeAdMarker(publisher, adCid, adMarkerSkipped, frozen, false)
+}
+
+func (ing *Ingester) writeAdMarker(publisher peer.ID, adCid cid.Cid, marker byte, frozen, mirrored bool) error {
 	cidStr := adCid.String()
 	ctx := context.Background()
 	if frozen {
@@ -625,7 +684,7 @@ func (ing *Ingester) markAdProcessed(publisher peer.ID, adCid cid.Cid, frozen, m
 		}
 	}
 
-	err := ing.ds.Put(ctx, datastore.NewKey(adProcessedPrefix+cidStr), []byte{1})
+	err := ing.ds.Put(ctx, datastore.NewKey(adProcessedPrefix+cidStr), []byte{marker})
 	if err != nil {
 		return err
 	}
@@ -1058,13 +1117,13 @@ func (ing *Ingester) processRawAdChain(ctx context.Context, syncFinished dagsync
 		// only publish Ads for one provider, but it's possible that an ad
 		// chain can include multiple providers.
 
-		processed, resync, err := ing.adAlreadyProcessed(c)
+		adState, err := ing.adAlreadyProcessed(c)
 		if err != nil {
 			log.Errorw("Failed to read advertisement processed state from datastore", "err", err)
 			// Note: don't stop in case of an error in this place, the same check will be done
 			// later in a context of a specific provider.
 		}
-		if processed {
+		if adState.Processed {
 			// This ad has been processed so all earlier ads already have been
 			// processed.
 			log.Infow("Remainder of ad chain already processed", "cid", c)
@@ -1099,7 +1158,7 @@ func (ing *Ingester) processRawAdChain(ctx context.Context, syncFinished dagsync
 
 		ai := adInfo{
 			cid:    c,
-			resync: resync,
+			resync: adState.Resync,
 		}
 
 		ctxIdStr := string(ad.ContextID)
@@ -1197,7 +1256,7 @@ func (ing *Ingester) ingestWorkerLogic(ctx context.Context, provider, publisher 
 			return
 		}
 
-		processed, _, err := ing.adAlreadyProcessed(ai.cid)
+		adState, err := ing.adAlreadyProcessed(ai.cid)
 		if err != nil {
 			log.Errorw("Failed to check if advertisement is processed. Bailing early, not ingesting later ads.", "adCid", ai.cid, "err", err)
 			ing.inEvents <- adProcessedEvent{
@@ -1209,7 +1268,7 @@ func (ing *Ingester) ingestWorkerLogic(ctx context.Context, provider, publisher 
 			procErr = err
 			return
 		}
-		if processed {
+		if adState.Processed {
 			log.Infow("Skipping advertisement that has already been processed",
 				"adCid", ai.cid,
 				"progress", fmt.Sprintf("%d of %d", count, total))
@@ -1248,6 +1307,7 @@ func (ing *Ingester) ingestWorkerLogic(ctx context.Context, provider, publisher 
 		syncStatus.SetCurrentAd(ai.cid, count)
 
 		hasEnts, adDataSource, err := ing.ingestAd(ctx, publisher, ai.cid, ai.resync, frozen, lag, headProvider, wkrNum)
+		skipReason := ""
 		if err != nil {
 			syncStatus.IncError()
 			var adIngestErr adIngestError
@@ -1258,11 +1318,13 @@ func (ing *Ingester) ingestWorkerLogic(ctx context.Context, provider, publisher 
 					// error will happen. So log and drop this error.
 					log.Errorw("Skipping ad because of a permanent error", "adCid", ai.cid, "err", err, "errKind", adIngestErr.state)
 					stats.Record(context.Background(), metrics.AdIngestSkippedCount.M(1))
+					skipReason = string(adIngestErr.state)
 					err = nil
 				case adIngestSyncEntriesErr:
 					if skip500EntsErr && strings.Contains(err.Error(), "failed to sync first entry") && strings.Contains(err.Error(), ": 500") {
 						log.Errorw("Skipping ad because of a permanent 500 error", "adCid", ai.cid, "err", err, "errKind", adIngestErr.state)
 						stats.Record(context.Background(), metrics.AdIngestSkippedCount.M(1))
+						skipReason = string(adIngestErr.state)
 						err = nil
 					}
 				}
@@ -1310,8 +1372,14 @@ func (ing *Ingester) ingestWorkerLogic(ctx context.Context, provider, publisher 
 		ing.reg.SetLastError(provider, nil)
 
 		putMirror := hasEnts && ing.mirror.canWrite()
-		if markErr := ing.markAdProcessed(publisher, ai.cid, frozen, putMirror); markErr != nil {
-			log.Errorw("Failed to mark ad as processed", "err", markErr)
+		if skipReason != "" {
+			if markErr := ing.markAdSkipped(publisher, ai.cid, skipReason, frozen); markErr != nil {
+				log.Errorw("Failed to mark ad as skipped", "err", markErr)
+			}
+		} else {
+			if markErr := ing.markAdProcessed(publisher, ai.cid, frozen, putMirror); markErr != nil {
+				log.Errorw("Failed to mark ad as processed", "err", markErr)
+			}
 		}
 
 		if putMirror {

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -1117,9 +1117,9 @@ func (ing *Ingester) processRawAdChain(ctx context.Context, syncFinished dagsync
 		// only publish Ads for one provider, but it's possible that an ad
 		// chain can include multiple providers.
 
-		adState, err := ing.adAlreadyProcessed(c)
-		if err != nil {
-			log.Errorw("Failed to read advertisement processed state from datastore", "err", err)
+		adState, stateErr := ing.adAlreadyProcessed(c)
+		if stateErr != nil {
+			log.Errorw("Failed to read advertisement processed state from datastore", "err", stateErr)
 			// Note: don't stop in case of an error in this place, the same check will be done
 			// later in a context of a specific provider.
 		}
@@ -1170,7 +1170,7 @@ func (ing *Ingester) processRawAdChain(ctx context.Context, syncFinished dagsync
 			ai.skip = true
 		}
 
-		if !adState.Known {
+		if stateErr == nil && !adState.Known {
 			if err := ing.markAdUnprocessed(c, false); err != nil {
 				log.Errorw("Failed to mark advertisement as unprocessed", "cid", c, "err", err)
 			}

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -277,6 +277,12 @@ func (ing *Ingester) generalDagsyncBlockHook(publisher peer.ID, c cid.Cid, actio
 		return
 	}
 
+	if !adState.Known {
+		if err := ing.markAdUnprocessed(c, false); err != nil {
+			log.Errorw("Failed to mark advertisement as unprocessed in block hook", "cid", c, "err", err)
+		}
+	}
+
 	// The only kind of block we should get by loading CIDs here should be
 	// Advertisement.
 	//
@@ -660,12 +666,12 @@ func (ing *Ingester) markAdProcessed(publisher peer.ID, adCid cid.Cid, frozen, m
 // is used to record that an ad was processed but could not be indexed due to a
 // permanent error (decode failure, malformed, entry chunk error, etc.).
 func (ing *Ingester) MarkAdSkipped(publisher peer.ID, adCid cid.Cid, reason string, frozen bool) error {
-	return ing.markAdSkipped(publisher, adCid, reason, frozen)
-}
-
-func (ing *Ingester) markAdSkipped(publisher peer.ID, adCid cid.Cid, reason string, frozen bool) error {
 	cidStr := adCid.String()
 	ctx := context.Background()
+
+	if len(reason) > 256 {
+		reason = string([]byte(reason)[:256])
+	}
 
 	if err := ing.ds.Put(ctx, datastore.NewKey(adSkipReasonPrefix+cidStr), []byte(reason)); err != nil {
 		return err
@@ -1324,13 +1330,13 @@ func (ing *Ingester) ingestWorkerLogic(ctx context.Context, provider, publisher 
 					// error will happen. So log and drop this error.
 					log.Errorw("Skipping ad because of a permanent error", "adCid", ai.cid, "err", err, "errKind", adIngestErr.state)
 					stats.Record(context.Background(), metrics.AdIngestSkippedCount.M(1))
-					skipReason = string(adIngestErr.state)
+					skipReason = adIngestErr.Error()
 					err = nil
 				case adIngestSyncEntriesErr:
 					if skip500EntsErr && strings.Contains(err.Error(), "failed to sync first entry") && strings.Contains(err.Error(), ": 500") {
 						log.Errorw("Skipping ad because of a permanent 500 error", "adCid", ai.cid, "err", err, "errKind", adIngestErr.state)
 						stats.Record(context.Background(), metrics.AdIngestSkippedCount.M(1))
-						skipReason = string(adIngestErr.state)
+						skipReason = adIngestErr.Error()
 						err = nil
 					}
 				}
@@ -1379,7 +1385,7 @@ func (ing *Ingester) ingestWorkerLogic(ctx context.Context, provider, publisher 
 
 		putMirror := hasEnts && ing.mirror.canWrite()
 		if skipReason != "" {
-			if markErr := ing.markAdSkipped(publisher, ai.cid, skipReason, frozen); markErr != nil {
+			if markErr := ing.MarkAdSkipped(publisher, ai.cid, skipReason, frozen); markErr != nil {
 				log.Errorw("Failed to mark ad as skipped", "err", markErr)
 			}
 		} else {

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -1170,6 +1170,12 @@ func (ing *Ingester) processRawAdChain(ctx context.Context, syncFinished dagsync
 			ai.skip = true
 		}
 
+		if !adState.Known {
+			if err := ing.markAdUnprocessed(c, false); err != nil {
+				log.Errorw("Failed to mark advertisement as unprocessed", "cid", c, "err", err)
+			}
+		}
+
 		adsGroupedByProvider[providerID] = append(adsGroupedByProvider[providerID], ai)
 		if totalAds%1000 == 0 {
 			log.Debugf("Added %d ads to stack", totalAds)

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -2617,6 +2617,15 @@ func TestMarkAdSkipped(t *testing.T) {
 	syncCid, ok := te.ingester.getLastKnownSync(publisher)
 	require.True(t, ok)
 	require.Equal(t, ad, syncCid)
+
+	// Test truncation: reason longer than 256 bytes is truncated on write
+	longReason := strings.Repeat("x", 300)
+	ad2 := random.Cids(1)[0]
+	require.NoError(t, te.ingester.MarkAdSkipped(publisher, ad2, longReason, false))
+	state, err = te.ingester.GetAdState(ad2)
+	require.NoError(t, err)
+	require.Equal(t, 256, len(state.SkipReason))
+	require.Equal(t, strings.Repeat("x", 256), state.SkipReason)
 }
 
 func TestSkippedAdNotReprocessed(t *testing.T) {

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -174,14 +174,14 @@ func (e *errReader) Read([]byte) (int, error) {
 	return 0, errors.New("blocked read")
 }
 
-func failBlockedRead() (io.Reader, error) {
+func failBlockedRead(l datamodel.Link, fallback func(linking.LinkContext, datamodel.Link) (io.Reader, error)) (io.Reader, error) {
 	// Returning an error here will cause a "content not found" will cause the
 	// ad will be skipped without failing the sync. So, return an io.Reader
 	// that will return an error on calling Read.
 	return &errReader{}, nil
 }
 
-func blockableLinkSys(afterBlock func() (io.Reader, error)) (opt func(teo *testEnvOpts), blockedReads *blockList, hitBlockedRead chan cid.Cid) {
+func blockableLinkSys(afterBlock func(datamodel.Link, func(linking.LinkContext, datamodel.Link) (io.Reader, error)) (io.Reader, error)) (opt func(teo *testEnvOpts), blockedReads *blockList, hitBlockedRead chan cid.Cid) {
 	blockedReads = &blockList{list: make(map[cid.Cid]bool)}
 	hitBlockedRead = make(chan cid.Cid)
 	return func(teo *testEnvOpts) {
@@ -198,7 +198,7 @@ func blockableLinkSys(afterBlock func() (io.Reader, error)) (opt func(teo *testE
 						fmt.Println("blocked read")
 						hitBlockedRead <- l.(cidlink.Link).Cid
 						if afterBlock != nil {
-							return afterBlock()
+							return afterBlock(l, backendLsys.StorageReadOpener)
 						}
 					}
 					return backendLsys.StorageReadOpener(lc, l)
@@ -459,9 +459,9 @@ func TestIngestDoesNotSkipAdIfFirstTryFailed(t *testing.T) {
 	// Use this to block the second ingest step from happening while we verify the above
 	afterBlockedRead := make(chan struct{})
 
-	blockableLsysOpt, blockedReads, hitBlockedRead := blockableLinkSys(func() (io.Reader, error) {
+	blockableLsysOpt, blockedReads, hitBlockedRead := blockableLinkSys(func(l datamodel.Link, fallback func(linking.LinkContext, datamodel.Link) (io.Reader, error)) (io.Reader, error) {
 		afterBlockedRead <- struct{}{}
-		return failBlockedRead()
+		return failBlockedRead(l, fallback)
 	})
 
 	te := setupTestEnv(t, true, blockableLsysOpt)
@@ -2634,7 +2634,11 @@ func TestSkippedAdNotReprocessed(t *testing.T) {
 }
 
 func TestAdmittedAdIsPending(t *testing.T) {
-	blockableLsysOpt, blockedReads, hitBlockedRead := blockableLinkSys(nil)
+	releaseBlock := make(chan struct{})
+	blockableLsysOpt, blockedReads, hitBlockedRead := blockableLinkSys(func(l datamodel.Link, fallback func(linking.LinkContext, datamodel.Link) (io.Reader, error)) (io.Reader, error) {
+		<-releaseBlock
+		return nil, errors.New("blocked read released")
+	})
 	te := setupTestEnv(t, true, blockableLsysOpt)
 
 	adHead := typehelpers.RandomAdBuilder{
@@ -2661,9 +2665,10 @@ func TestAdmittedAdIsPending(t *testing.T) {
 		Addrs: te.publisher.Addrs(),
 	}
 
+	syncDone := make(chan struct{})
 	go func() {
-		_, err = te.ingester.Sync(t.Context(), peerInfo, 0, false, cid.Undef)
-		require.Error(t, err)
+		_, _ = te.ingester.Sync(t.Context(), peerInfo, 0, false, cid.Undef)
+		close(syncDone)
 	}()
 	<-hitBlockedRead
 
@@ -2679,6 +2684,14 @@ func TestAdmittedAdIsPending(t *testing.T) {
 	require.True(t, cState.Known)
 	require.False(t, cState.Processed)
 	require.False(t, cState.Resync)
+
+	// Release the block and wait for sync to complete
+	close(releaseBlock)
+	select {
+	case <-syncDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("sync did not complete")
+	}
 }
 
 func TestResyncMarkerNotDowngraded(t *testing.T) {
@@ -2696,11 +2709,6 @@ func TestResyncMarkerNotDowngraded(t *testing.T) {
 	adState, err := te.ingester.adAlreadyProcessed(ad)
 	require.NoError(t, err)
 	require.True(t, adState.Known)
-	if !adState.Known {
-		if err := te.ingester.markAdUnprocessed(ad, false); err != nil {
-			t.Fatal(err)
-		}
-	}
 
 	state, err = te.ingester.GetAdState(ad)
 	require.NoError(t, err)
@@ -2743,7 +2751,11 @@ func TestPendingMarkerPersistsAcrossRestart(t *testing.T) {
 }
 
 func TestPendingMarkerClearedAfterProcessing(t *testing.T) {
-	blockableLsysOpt, blockedReads, hitBlockedRead := blockableLinkSys(nil)
+	releaseBlock := make(chan struct{})
+	blockableLsysOpt, blockedReads, hitBlockedRead := blockableLinkSys(func(l datamodel.Link, fallback func(linking.LinkContext, datamodel.Link) (io.Reader, error)) (io.Reader, error) {
+		<-releaseBlock
+		return fallback(linking.LinkContext{}, l)
+	})
 	te := setupTestEnv(t, true, blockableLsysOpt)
 
 	adHead := typehelpers.RandomAdBuilder{
@@ -2769,7 +2781,7 @@ func TestPendingMarkerClearedAfterProcessing(t *testing.T) {
 
 	syncDone := make(chan struct{})
 	go func() {
-		te.ingester.Sync(t.Context(), peerInfo, 0, false, cid.Undef)
+		_, _ = te.ingester.Sync(t.Context(), peerInfo, 0, false, cid.Undef)
 		close(syncDone)
 	}()
 	<-hitBlockedRead
@@ -2781,8 +2793,7 @@ func TestPendingMarkerClearedAfterProcessing(t *testing.T) {
 	require.False(t, bState.Processed)
 
 	// Release the block and let the sync complete
-	blockedReads.rm(bAd.Entries.(cidlink.Link).Cid)
-	close(hitBlockedRead)
+	close(releaseBlock)
 
 	// Wait for sync to finish
 	select {

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -2633,6 +2633,171 @@ func TestSkippedAdNotReprocessed(t *testing.T) {
 	require.True(t, adState.Skipped)
 }
 
+func TestAdmittedAdIsPending(t *testing.T) {
+	blockableLsysOpt, blockedReads, hitBlockedRead := blockableLinkSys(nil)
+	te := setupTestEnv(t, true, blockableLsysOpt)
+
+	adHead := typehelpers.RandomAdBuilder{
+		EntryBuilders: []typehelpers.EntryBuilder{
+			typehelpers.RandomEntryChunkBuilder{ChunkCount: 1, EntriesPerChunk: 1, Seed: 1},
+			typehelpers.RandomEntryChunkBuilder{ChunkCount: 1, EntriesPerChunk: 1, Seed: 2},
+			typehelpers.RandomEntryChunkBuilder{ChunkCount: 1, EntriesPerChunk: 1, Seed: 3},
+		},
+	}.Build(t, te.publisherLinkSys, te.publisherPriv)
+	allAdLinks := typehelpers.AllAdLinks(t, adHead, te.publisherLinkSys)
+	aLink := allAdLinks[0]
+	bLink := allAdLinks[1]
+	cLink := allAdLinks[2]
+
+	bAdNode, err := te.publisherLinkSys.Load(linking.LinkContext{}, bLink, schema.AdvertisementPrototype)
+	require.NoError(t, err)
+	bAd, err := schema.UnwrapAdvertisement(bAdNode)
+	require.NoError(t, err)
+	blockedReads.add(bAd.Entries.(cidlink.Link).Cid)
+
+	te.publisher.SetRoot(cLink.(cidlink.Link).Cid)
+	peerInfo := peer.AddrInfo{
+		ID:    te.publisher.ID(),
+		Addrs: te.publisher.Addrs(),
+	}
+
+	go func() {
+		_, err = te.ingester.Sync(t.Context(), peerInfo, 0, false, cid.Undef)
+		require.Error(t, err)
+	}()
+	<-hitBlockedRead
+
+	// A should be processed already (worker processes oldest first)
+	aState, err := te.ingester.GetAdState(aLink.(cidlink.Link).Cid)
+	require.NoError(t, err)
+	require.True(t, aState.Known)
+	require.True(t, aState.Processed)
+
+	// C should be pending (admitted but not yet reached by worker)
+	cState, err := te.ingester.GetAdState(cLink.(cidlink.Link).Cid)
+	require.NoError(t, err)
+	require.True(t, cState.Known)
+	require.False(t, cState.Processed)
+	require.False(t, cState.Resync)
+}
+
+func TestResyncMarkerNotDowngraded(t *testing.T) {
+	te := setupTestEnv(t, false)
+	ad := random.Cids(1)[0]
+
+	require.NoError(t, te.ingester.markAdUnprocessed(ad, true))
+
+	state, err := te.ingester.GetAdState(ad)
+	require.NoError(t, err)
+	require.True(t, state.Known)
+	require.True(t, state.Resync)
+
+	// Simulate admission (what processRawAdChain does)
+	adState, err := te.ingester.adAlreadyProcessed(ad)
+	require.NoError(t, err)
+	require.True(t, adState.Known)
+	if !adState.Known {
+		if err := te.ingester.markAdUnprocessed(ad, false); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	state, err = te.ingester.GetAdState(ad)
+	require.NoError(t, err)
+	require.True(t, state.Known)
+	require.True(t, state.Resync)
+	require.False(t, state.Processed)
+}
+
+func TestPendingMarkerPersistsAcrossRestart(t *testing.T) {
+	ds := dssync.MutexWrap(datastore.NewMapDatastore())
+	tmpDs := dssync.MutexWrap(datastore.NewMapDatastore())
+	h := dstest.MkTestHost(t)
+	reg := mkRegistry(t)
+	core := mkIndexer(t, true)
+	i, err := NewIngester(defaultTestIngestConfig, h, core, reg, ds, tmpDs)
+	require.NoError(t, err)
+
+	ad := random.Cids(1)[0]
+	require.NoError(t, i.markAdUnprocessed(ad, false))
+
+	state, err := i.GetAdState(ad)
+	require.NoError(t, err)
+	require.True(t, state.Known)
+	require.False(t, state.Processed)
+
+	require.NoError(t, i.Close())
+
+	i2, err := NewIngester(defaultTestIngestConfig, h, core, reg, ds, tmpDs)
+	require.NoError(t, err)
+	defer func() {
+		i2.Close()
+		reg.Close()
+		core.Close()
+	}()
+
+	state, err = i2.GetAdState(ad)
+	require.NoError(t, err)
+	require.True(t, state.Known)
+	require.False(t, state.Processed)
+}
+
+func TestPendingMarkerClearedAfterProcessing(t *testing.T) {
+	blockableLsysOpt, blockedReads, hitBlockedRead := blockableLinkSys(nil)
+	te := setupTestEnv(t, true, blockableLsysOpt)
+
+	adHead := typehelpers.RandomAdBuilder{
+		EntryBuilders: []typehelpers.EntryBuilder{
+			typehelpers.RandomEntryChunkBuilder{ChunkCount: 1, EntriesPerChunk: 1, Seed: 1},
+			typehelpers.RandomEntryChunkBuilder{ChunkCount: 1, EntriesPerChunk: 1, Seed: 2},
+		},
+	}.Build(t, te.publisherLinkSys, te.publisherPriv)
+	allAdLinks := typehelpers.AllAdLinks(t, adHead, te.publisherLinkSys)
+	bLink := allAdLinks[1]
+
+	bAdNode, err := te.publisherLinkSys.Load(linking.LinkContext{}, bLink, schema.AdvertisementPrototype)
+	require.NoError(t, err)
+	bAd, err := schema.UnwrapAdvertisement(bAdNode)
+	require.NoError(t, err)
+	blockedReads.add(bAd.Entries.(cidlink.Link).Cid)
+
+	te.publisher.SetRoot(bLink.(cidlink.Link).Cid)
+	peerInfo := peer.AddrInfo{
+		ID:    te.publisher.ID(),
+		Addrs: te.publisher.Addrs(),
+	}
+
+	syncDone := make(chan struct{})
+	go func() {
+		te.ingester.Sync(t.Context(), peerInfo, 0, false, cid.Undef)
+		close(syncDone)
+	}()
+	<-hitBlockedRead
+
+	// b should be pending
+	bState, err := te.ingester.GetAdState(bLink.(cidlink.Link).Cid)
+	require.NoError(t, err)
+	require.True(t, bState.Known)
+	require.False(t, bState.Processed)
+
+	// Release the block and let the sync complete
+	blockedReads.rm(bAd.Entries.(cidlink.Link).Cid)
+	close(hitBlockedRead)
+
+	// Wait for sync to finish
+	select {
+	case <-syncDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("sync did not complete")
+	}
+
+	// b should now be processed (marker 1, not 0)
+	bState, err = te.ingester.GetAdState(bLink.(cidlink.Link).Cid)
+	require.NoError(t, err)
+	require.True(t, bState.Known)
+	require.True(t, bState.Processed)
+}
+
 type testEnvOpts struct {
 	publisherLinkSysFn func(ds datastore.Batching) ipld.LinkSystem
 	ingestConfig       *config.Ingest

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -2793,6 +2793,7 @@ func TestPendingMarkerClearedAfterProcessing(t *testing.T) {
 	require.False(t, bState.Processed)
 
 	// Release the block and let the sync complete
+	blockedReads.rm(bAd.Entries.(cidlink.Link).Cid)
 	close(releaseBlock)
 
 	// Wait for sync to finish

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -1199,6 +1199,49 @@ func TestSyncSkipNoMetadata(t *testing.T) {
 	require.Equal(t, adCid, pInfo.LastAdvertisement)
 }
 
+func TestPermanentErrorRoutesToSkippedMarker(t *testing.T) {
+	srcStore := dssync.MutexWrap(datastore.NewMapDatastore())
+	h := dstest.MkTestHost(t)
+	pubHost := dstest.MkTestHost(t)
+	i, reg := mkIngest(t, h)
+	pub, lsys := mkMockPublisher(t, pubHost, h, srcStore)
+	connectHosts(t, h, pubHost)
+
+	// Publish an ad with entries but no metadata (permanent error — malformed).
+	adCid, _, providerID, _ := publishRandomIndexAndAdvWithEntriesChunkCount(t, pub, lsys, false, 10, []byte{}, cid.Undef)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	peerInfo := peer.AddrInfo{
+		ID:    pub.ID(),
+		Addrs: pub.Addrs(),
+	}
+	endCid, err := i.Sync(ctx, peerInfo, 0, false, cid.Undef)
+	require.NoError(t, err)
+	require.Equal(t, adCid, endCid)
+
+	// Verify the ad was marked as skipped with marker byte 3.
+	state, err := i.GetAdState(adCid)
+	require.NoError(t, err)
+	require.True(t, state.Known)
+	require.True(t, state.Processed)
+	require.True(t, state.Skipped)
+	require.Contains(t, state.SkipReason, "malformedErr")
+	require.False(t, state.Indexed())
+
+	// Verify adAlreadyProcessed treats it as done (won't reprocess).
+	apState, err := i.adAlreadyProcessed(adCid)
+	require.NoError(t, err)
+	require.True(t, apState.Known)
+	require.True(t, apState.Processed)
+	require.True(t, apState.Skipped)
+
+	// Verify provider info still updated.
+	pInfo, found := reg.ProviderInfo(providerID)
+	require.True(t, found)
+	require.Equal(t, adCid, pInfo.LastAdvertisement)
+}
+
 func TestReSyncWithDepth(t *testing.T) {
 	te := setupTestEnv(t, false)
 	adHead := typehelpers.RandomAdBuilder{
@@ -2378,25 +2421,25 @@ func TestGetAdState(t *testing.T) {
 	require.NoError(t, te.ingester.MarkAdProcessed(publisher, ads[0]))
 	state, err = te.ingester.GetAdState(ads[0])
 	require.NoError(t, err)
-	require.Equal(t, AdState{Processed: true}, state)
+	require.Equal(t, AdState{Known: true, Processed: true}, state)
 	require.True(t, state.Indexed())
 
 	require.NoError(t, te.ingester.markAdUnprocessed(ads[1], true))
 	state, err = te.ingester.GetAdState(ads[1])
 	require.NoError(t, err)
-	require.Equal(t, AdState{Resync: true}, state)
+	require.Equal(t, AdState{Known: true, Resync: true}, state)
 	require.False(t, state.Indexed())
 
 	require.NoError(t, te.ingester.markAdUnprocessed(ads[2], false))
 	state, err = te.ingester.GetAdState(ads[2])
 	require.NoError(t, err)
-	require.Equal(t, AdState{}, state)
+	require.Equal(t, AdState{Known: true}, state)
 	require.False(t, state.Indexed())
 
 	require.NoError(t, te.ingester.markAdProcessed(publisher, ads[3], true, false))
 	state, err = te.ingester.GetAdState(ads[3])
 	require.NoError(t, err)
-	require.Equal(t, AdState{Processed: true, Frozen: true}, state)
+	require.Equal(t, AdState{Known: true, Processed: true, Frozen: true}, state)
 	require.False(t, state.Indexed())
 }
 
@@ -2413,12 +2456,181 @@ func TestAdStateIndexed(t *testing.T) {
 		{name: "frozen", state: AdState{Frozen: true}, want: false},
 		{name: "processed and frozen", state: AdState{Processed: true, Frozen: true}, want: false},
 		{name: "all flags", state: AdState{Processed: true, Resync: true, Frozen: true}, want: false},
+		{name: "skipped", state: AdState{Processed: true, Skipped: true, SkipReason: "malformedErr"}, want: false},
+		{name: "skipped and frozen", state: AdState{Processed: true, Skipped: true, SkipReason: "decodeErr", Frozen: true}, want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.want, tt.state.Indexed())
 		})
 	}
+}
+
+func TestAdStateByMarkerByte(t *testing.T) {
+	te := setupTestEnv(t, false)
+	publisher := te.pubHost.ID()
+	ads := random.Cids(5)
+
+	// Test marker byte 0 (unprocessed) via markAdUnprocessed
+	require.NoError(t, te.ingester.markAdUnprocessed(ads[0], false))
+	state, err := te.ingester.GetAdState(ads[0])
+	require.NoError(t, err)
+	require.True(t, state.Known)
+	require.False(t, state.Processed)
+	require.False(t, state.Skipped)
+	require.False(t, state.Resync)
+	require.False(t, state.Indexed())
+
+	// Test marker byte 1 (processed) via MarkAdProcessed
+	require.NoError(t, te.ingester.MarkAdProcessed(publisher, ads[1]))
+	state, err = te.ingester.GetAdState(ads[1])
+	require.NoError(t, err)
+	require.True(t, state.Known)
+	require.True(t, state.Processed)
+	require.False(t, state.Skipped)
+	require.False(t, state.Resync)
+	require.True(t, state.Indexed())
+
+	// Test marker byte 2 (resync) via markAdUnprocessed(forResync=true)
+	require.NoError(t, te.ingester.markAdUnprocessed(ads[2], true))
+	state, err = te.ingester.GetAdState(ads[2])
+	require.NoError(t, err)
+	require.True(t, state.Known)
+	require.False(t, state.Processed)
+	require.False(t, state.Skipped)
+	require.True(t, state.Resync)
+	require.False(t, state.Indexed())
+
+	// Test marker byte 3 (skipped) via MarkAdSkipped
+	require.NoError(t, te.ingester.MarkAdSkipped(publisher, ads[3], "malformedErr", false))
+	state, err = te.ingester.GetAdState(ads[3])
+	require.NoError(t, err)
+	require.True(t, state.Known)
+	require.True(t, state.Processed)
+	require.True(t, state.Skipped)
+	require.False(t, state.Resync)
+	require.Equal(t, "malformedErr", state.SkipReason)
+	require.False(t, state.Indexed())
+
+	// Test adAlreadyProcessed for each marker byte
+	tests := []struct {
+		name string
+		ad   cid.Cid
+		want adProcessedState
+	}{
+		{name: "unprocessed", ad: ads[0], want: adProcessedState{Known: true}},
+		{name: "processed", ad: ads[1], want: adProcessedState{Known: true, Processed: true}},
+		{name: "resync", ad: ads[2], want: adProcessedState{Known: true, Resync: true}},
+		{name: "skipped", ad: ads[3], want: adProcessedState{Known: true, Processed: true, Skipped: true}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := te.ingester.adAlreadyProcessed(tt.ad)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAdStateByRawByte(t *testing.T) {
+	te := setupTestEnv(t, false)
+	ads := random.Cids(5)
+
+	tests := []struct {
+		name    string
+		marker  byte
+		want    AdState
+		sidecar string
+	}{
+		{
+			name:   "unprocessed",
+			marker: 0,
+			want:   AdState{Known: true},
+		},
+		{
+			name:   "processed",
+			marker: 1,
+			want:   AdState{Known: true, Processed: true},
+		},
+		{
+			name:   "resync",
+			marker: 2,
+			want:   AdState{Known: true, Resync: true},
+		},
+		{
+			name:    "skipped",
+			marker:  3,
+			want:    AdState{Known: true, Processed: true, Skipped: true, SkipReason: "decodeErr"},
+			sidecar: "decodeErr",
+		},
+		{
+			name:   "undefined",
+			marker: 9,
+			want:   AdState{Known: true},
+		},
+	}
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ad := ads[i]
+			require.NoError(t, te.ingester.ds.Put(context.Background(), datastore.NewKey(adProcessedPrefix+ad.String()), []byte{tt.marker}))
+			if tt.sidecar != "" {
+				require.NoError(t, te.ingester.ds.Put(context.Background(), datastore.NewKey(adSkipReasonPrefix+ad.String()), []byte(tt.sidecar)))
+			}
+
+			state, err := te.ingester.GetAdState(ad)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, state)
+		})
+	}
+}
+
+func TestAdStateEmptyValue(t *testing.T) {
+	te := setupTestEnv(t, false)
+	ad := random.Cids(1)[0]
+
+	require.NoError(t, te.ingester.ds.Put(context.Background(), datastore.NewKey(adProcessedPrefix+ad.String()), []byte{}))
+	_, err := te.ingester.GetAdState(ad)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty value")
+
+	_, err = te.ingester.adAlreadyProcessed(ad)
+	require.Error(t, err)
+}
+
+func TestMarkAdSkipped(t *testing.T) {
+	te := setupTestEnv(t, false)
+	publisher := te.pubHost.ID()
+	ad := random.Cids(1)[0]
+
+	require.NoError(t, te.ingester.MarkAdSkipped(publisher, ad, "decodeErr", false))
+
+	state, err := te.ingester.GetAdState(ad)
+	require.NoError(t, err)
+	require.True(t, state.Known)
+	require.True(t, state.Processed)
+	require.True(t, state.Skipped)
+	require.Equal(t, "decodeErr", state.SkipReason)
+	require.False(t, state.Frozen)
+	require.False(t, state.Indexed())
+
+	// Verify sync head updated
+	syncCid, ok := te.ingester.getLastKnownSync(publisher)
+	require.True(t, ok)
+	require.Equal(t, ad, syncCid)
+}
+
+func TestSkippedAdNotReprocessed(t *testing.T) {
+	te := setupTestEnv(t, false)
+	publisher := te.pubHost.ID()
+	ad := random.Cids(1)[0]
+
+	require.NoError(t, te.ingester.MarkAdSkipped(publisher, ad, "malformedErr", false))
+
+	adState, err := te.ingester.adAlreadyProcessed(ad)
+	require.NoError(t, err)
+	require.True(t, adState.Known)
+	require.True(t, adState.Processed)
+	require.True(t, adState.Skipped)
 }
 
 type testEnvOpts struct {

--- a/server/ingest/protocol_test.go
+++ b/server/ingest/protocol_test.go
@@ -64,7 +64,7 @@ func TestRegisterProvider(t *testing.T) {
 	// Initialize everything
 	ind := initIndex(t, true)
 	reg := initRegistry(t, providerIdent.PeerID)
-	ing := initIngest(t, ind, reg)
+	ing, _ := initIngest(t, ind, reg)
 	s := setupServer(ind, ing, reg, t)
 	cl := setupClient(s.URL(), t)
 
@@ -88,7 +88,7 @@ func TestAnnounce(t *testing.T) {
 	// Initialize everything
 	ind := initIndex(t, true)
 	reg := initRegistry(t, providerIdent.PeerID)
-	ing := initIngest(t, ind, reg)
+	ing, _ := initIngest(t, ind, reg)
 	s := setupServer(ind, ing, reg, t)
 	httpSender := setupSender(t, s.URL())
 	peerID, _, err := providerIdent.Decode()
@@ -132,7 +132,7 @@ func initRegistry(t *testing.T, trustedID string) *registry.Registry {
 	return reg
 }
 
-func initIngest(t *testing.T, indx indexer.Interface, reg *registry.Registry) *ingest.Ingester {
+func initIngest(t *testing.T, indx indexer.Interface, reg *registry.Registry) (*ingest.Ingester, datastore.Batching) {
 	cfg := config.NewIngest()
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
 	dsTmp := dssync.MutexWrap(datastore.NewMapDatastore())
@@ -145,7 +145,7 @@ func initIngest(t *testing.T, indx indexer.Interface, reg *registry.Registry) *i
 		ing.Close()
 		host.Close()
 	})
-	return ing
+	return ing, ds
 }
 
 func announceTest(t *testing.T, peerID peer.ID, sender announce.Sender) {
@@ -170,7 +170,7 @@ func announceTest(t *testing.T, peerID peer.ID, sender announce.Sender) {
 func TestAdStatus(t *testing.T) {
 	ind := initIndex(t, true)
 	reg := initRegistry(t, providerIdent.PeerID)
-	ing := initIngest(t, ind, reg)
+	ing, ds := initIngest(t, ind, reg)
 	s := setupServer(ind, ing, reg, t)
 	errChan := make(chan error, 1)
 	go func() {
@@ -187,7 +187,11 @@ func TestAdStatus(t *testing.T) {
 
 	pubID, _, err := providerIdent.Decode()
 	require.NoError(t, err)
-	ads := random.Cids(2)
+
+	dagJSONAds := random.Cids(5)
+	for i := range dagJSONAds {
+		dagJSONAds[i] = cid.NewCidV1(cid.DagJSON, dagJSONAds[i].Hash())
+	}
 
 	getAdStatus := func(t *testing.T, ad cid.Cid) (int, http.Header, string) {
 		t.Helper()
@@ -199,32 +203,73 @@ func TestAdStatus(t *testing.T) {
 		return res.StatusCode, res.Header, string(body)
 	}
 
-	// Unknown ad is not indexed.
-	status, hdr, body := getAdStatus(t, ads[0])
+	// Unknown ad returns state "unknown".
+	status, hdr, body := getAdStatus(t, dagJSONAds[0])
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, "*", hdr.Get("Access-Control-Allow-Origin"))
 	require.Equal(t, "application/json; charset=utf-8", hdr.Get("Content-Type"))
-	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false}`, ads[0].String()), body)
+	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"unknown","Reason":"","Frozen":false}`, dagJSONAds[0].String()), body)
 
 	// Fully processed ad is indexed.
-	require.NoError(t, ing.MarkAdProcessed(pubID, ads[0]))
-	status, hdr, body = getAdStatus(t, ads[0])
+	require.NoError(t, ing.MarkAdProcessed(pubID, dagJSONAds[0]))
+	status, hdr, body = getAdStatus(t, dagJSONAds[0])
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, "*", hdr.Get("Access-Control-Allow-Origin"))
-	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":true}`, ads[0].String()), body)
+	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":true,"State":"indexed","Reason":"","Frozen":false}`, dagJSONAds[0].String()), body)
 
-	// A different unknown ad remains not indexed.
-	status, _, body = getAdStatus(t, ads[1])
+	// Skipped ad returns state "skipped" with reason, Indexed false.
+	require.NoError(t, ing.MarkAdSkipped(pubID, dagJSONAds[1], "decodeErr", false))
+	status, _, body = getAdStatus(t, dagJSONAds[1])
 	require.Equal(t, http.StatusOK, status)
-	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false}`, ads[1].String()), body)
+	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"skipped","Reason":"decodeErr","Frozen":false}`, dagJSONAds[1].String()), body)
 
-	res, err := http.Get(s.URL() + "/sync/status/ad/not-a-cid")
+	// Pending ad (marker byte 0 written directly).
+	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adProcessed/"+dagJSONAds[2].String()), []byte{0}))
+	status, _, body = getAdStatus(t, dagJSONAds[2])
+	require.Equal(t, http.StatusOK, status)
+	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"pending","Reason":"","Frozen":false}`, dagJSONAds[2].String()), body)
+
+	// Resyncing ad (marker byte 2 written directly).
+	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adProcessed/"+dagJSONAds[3].String()), []byte{2}))
+	status, _, body = getAdStatus(t, dagJSONAds[3])
+	require.Equal(t, http.StatusOK, status)
+	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"resyncing","Reason":"","Frozen":false}`, dagJSONAds[3].String()), body)
+
+	// Frozen ad (processed + frozen key set).
+	require.NoError(t, ing.MarkAdProcessed(pubID, dagJSONAds[4]))
+	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adF/"+dagJSONAds[4].String()), []byte{1}))
+	status, _, body = getAdStatus(t, dagJSONAds[4])
+	require.Equal(t, http.StatusOK, status)
+	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"indexed","Reason":"","Frozen":true}`, dagJSONAds[4].String()), body)
+
+	// Codec guard: raw CID returns 400.
+	rawCid := cid.NewCidV1(cid.Raw, random.Multihashes(1)[0])
+	res, err := http.Get(s.URL() + "/sync/status/ad/" + rawCid.String())
+	require.NoError(t, err)
+	bodyBytes, err := io.ReadAll(res.Body)
+	res.Body.Close()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, res.StatusCode)
+	require.Contains(t, string(bodyBytes), "dag-json")
+
+	// Codec guard: raw CID v0 returns 400.
+	v0Cid := cid.NewCidV0(random.Multihashes(1)[0])
+	res, err = http.Get(s.URL() + "/sync/status/ad/" + v0Cid.String())
+	require.NoError(t, err)
+	bodyBytes, err = io.ReadAll(res.Body)
+	res.Body.Close()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, res.StatusCode)
+	require.Contains(t, string(bodyBytes), "dag-json")
+
+	// Bad CID format returns 400.
+	res, err = http.Get(s.URL() + "/sync/status/ad/not-a-cid")
 	require.NoError(t, err)
 	res.Body.Close()
 	require.Equal(t, http.StatusBadRequest, res.StatusCode)
 
 	// OPTIONS is required for CORS preflight.
-	req, err := http.NewRequest(http.MethodOptions, s.URL()+"/sync/status/ad/"+ads[0].String(), nil)
+	req, err := http.NewRequest(http.MethodOptions, s.URL()+"/sync/status/ad/"+dagJSONAds[0].String(), nil)
 	require.NoError(t, err)
 	req.Header.Set("Origin", "http://example.com")
 	req.Header.Set("Access-Control-Request-Method", http.MethodGet)
@@ -238,7 +283,7 @@ func TestAdStatus(t *testing.T) {
 func TestSyncStatus(t *testing.T) {
 	ind := initIndex(t, true)
 	reg := initRegistry(t, providerIdent.PeerID)
-	ing := initIngest(t, ind, reg)
+	ing, _ := initIngest(t, ind, reg)
 	s := setupServer(ind, ing, reg, t)
 	errChan := make(chan error, 1)
 	go func() {

--- a/server/ingest/protocol_test.go
+++ b/server/ingest/protocol_test.go
@@ -208,14 +208,14 @@ func TestAdStatus(t *testing.T) {
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, "*", hdr.Get("Access-Control-Allow-Origin"))
 	require.Equal(t, "application/json; charset=utf-8", hdr.Get("Content-Type"))
-	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"unknown","Reason":"","Frozen":false}`, dagJSONAds[0].String()), body)
+	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"unknown","Frozen":false}`, dagJSONAds[0].String()), body)
 
 	// Fully processed ad is indexed.
 	require.NoError(t, ing.MarkAdProcessed(pubID, dagJSONAds[0]))
 	status, hdr, body = getAdStatus(t, dagJSONAds[0])
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, "*", hdr.Get("Access-Control-Allow-Origin"))
-	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":true,"State":"indexed","Reason":"","Frozen":false}`, dagJSONAds[0].String()), body)
+	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":true,"State":"indexed","Frozen":false}`, dagJSONAds[0].String()), body)
 
 	// Skipped ad returns state "skipped" with reason, Indexed false.
 	require.NoError(t, ing.MarkAdSkipped(pubID, dagJSONAds[1], "decodeErr", false))
@@ -227,20 +227,20 @@ func TestAdStatus(t *testing.T) {
 	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adProcessed/"+dagJSONAds[2].String()), []byte{0}))
 	status, _, body = getAdStatus(t, dagJSONAds[2])
 	require.Equal(t, http.StatusOK, status)
-	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"pending","Reason":"","Frozen":false}`, dagJSONAds[2].String()), body)
+	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"pending","Frozen":false}`, dagJSONAds[2].String()), body)
 
 	// Resyncing ad (marker byte 2 written directly).
 	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adProcessed/"+dagJSONAds[3].String()), []byte{2}))
 	status, _, body = getAdStatus(t, dagJSONAds[3])
 	require.Equal(t, http.StatusOK, status)
-	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"resyncing","Reason":"","Frozen":false}`, dagJSONAds[3].String()), body)
+	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"resyncing","Frozen":false}`, dagJSONAds[3].String()), body)
 
 	// Frozen ad (processed + frozen key set).
 	require.NoError(t, ing.MarkAdProcessed(pubID, dagJSONAds[4]))
 	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adF/"+dagJSONAds[4].String()), []byte{1}))
 	status, _, body = getAdStatus(t, dagJSONAds[4])
 	require.Equal(t, http.StatusOK, status)
-	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"indexed","Reason":"","Frozen":true}`, dagJSONAds[4].String()), body)
+	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"indexed","Frozen":true}`, dagJSONAds[4].String()), body)
 
 	// Codec guard: raw CID returns 400.
 	rawCid := cid.NewCidV1(cid.Raw, random.Multihashes(1)[0])
@@ -267,6 +267,32 @@ func TestAdStatus(t *testing.T) {
 	require.NoError(t, err)
 	res.Body.Close()
 	require.Equal(t, http.StatusBadRequest, res.StatusCode)
+
+	// Empty marker value returns 500 without panicking.
+	emptyCid := cid.NewCidV1(cid.DagJSON, random.Multihashes(1)[0])
+	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adProcessed/"+emptyCid.String()), []byte{}))
+	status, _, _ = getAdStatus(t, emptyCid)
+	require.Equal(t, http.StatusInternalServerError, status)
+
+	// Nil ingester returns 503.
+	nilServer, err := httpserver.New("127.0.0.1:0", ind, nil, reg)
+	require.NoError(t, err)
+	errChan2 := make(chan error, 1)
+	go func() {
+		err := nilServer.Start()
+		if err != http.ErrServerClosed {
+			errChan2 <- err
+		}
+		close(errChan2)
+	}()
+	t.Cleanup(func() {
+		require.NoError(t, nilServer.Close())
+		require.NoError(t, <-errChan2)
+	})
+	res, err = http.Get(nilServer.URL() + "/sync/status/ad/" + dagJSONAds[0].String())
+	require.NoError(t, err)
+	res.Body.Close()
+	require.Equal(t, http.StatusServiceUnavailable, res.StatusCode)
 
 	// OPTIONS is required for CORS preflight.
 	req, err := http.NewRequest(http.MethodOptions, s.URL()+"/sync/status/ad/"+dagJSONAds[0].String(), nil)

--- a/server/ingest/protocol_test.go
+++ b/server/ingest/protocol_test.go
@@ -222,7 +222,7 @@ func TestAdStatus(t *testing.T) {
 	require.NoError(t, ing.MarkAdSkipped(pubID, dagJSONAds[1], "decodeErr", false))
 	status, _, body = getAdStatus(t, dagJSONAds[1])
 	require.Equal(t, http.StatusOK, status)
-	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"skipped","Reason":"decodeErr","Frozen":false}`, dagJSONAds[1].String()), body)
+	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"skipped","SkipReason":"decodeErr","Frozen":false}`, dagJSONAds[1].String()), body)
 
 	// Pending ad (marker byte 0 written directly).
 	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adProcessed/"+dagJSONAds[2].String()), []byte{0}))
@@ -252,6 +252,7 @@ func TestAdStatus(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, res.StatusCode)
 	require.Contains(t, string(bodyBytes), "dag-json")
+	require.Contains(t, string(bodyBytes), "dag-cbor")
 
 	// Codec guard: raw CID v0 returns 400.
 	v0Cid := cid.NewCidV0(random.Multihashes(1)[0])
@@ -262,6 +263,16 @@ func TestAdStatus(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, res.StatusCode)
 	require.Contains(t, string(bodyBytes), "dag-json")
+	require.Contains(t, string(bodyBytes), "dag-cbor")
+
+	// Codec guard: dag-cbor CID is accepted.
+	dagCBORCid := cid.NewCidV1(cid.DagCBOR, random.Multihashes(1)[0])
+	res, err = http.Get(s.URL() + "/sync/status/ad/" + dagCBORCid.String())
+	require.NoError(t, err)
+	bodyBytes, err = io.ReadAll(res.Body)
+	res.Body.Close()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
 
 	// Bad CID format returns 400.
 	res, err = http.Get(s.URL() + "/sync/status/ad/not-a-cid")

--- a/server/ingest/protocol_test.go
+++ b/server/ingest/protocol_test.go
@@ -265,7 +265,7 @@ func TestAdStatus(t *testing.T) {
 	require.Contains(t, string(bodyBytes), "dag-json")
 	require.Contains(t, string(bodyBytes), "dag-cbor")
 
-	// Codec guard: dag-cbor CID is accepted.
+	// Codec guard: dag-cbor CID is accepted and reaches the state path.
 	dagCBORCid := cid.NewCidV1(cid.DagCBOR, random.Multihashes(1)[0])
 	res, err = http.Get(s.URL() + "/sync/status/ad/" + dagCBORCid.String())
 	require.NoError(t, err)
@@ -273,6 +273,7 @@ func TestAdStatus(t *testing.T) {
 	res.Body.Close()
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"unknown","Frozen":false}`, dagCBORCid.String()), string(bodyBytes))
 
 	// Bad CID format returns 400.
 	res, err = http.Get(s.URL() + "/sync/status/ad/not-a-cid")

--- a/server/ingest/protocol_test.go
+++ b/server/ingest/protocol_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
@@ -289,6 +290,14 @@ func TestAdStatus(t *testing.T) {
 		require.NoError(t, nilServer.Close())
 		require.NoError(t, <-errChan2)
 	})
+	for i := 0; i < 50; i++ {
+		res, err = http.Get(nilServer.URL() + "/health")
+		if err == nil {
+			res.Body.Close()
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 	res, err = http.Get(nilServer.URL() + "/sync/status/ad/" + dagJSONAds[0].String())
 	require.NoError(t, err)
 	res.Body.Close()

--- a/server/ingest/server.go
+++ b/server/ingest/server.go
@@ -222,6 +222,9 @@ func (s *Server) getSyncStatus(w http.ResponseWriter, r *http.Request) {
 type adStatusResponse struct {
 	Ad      string `json:"Ad"`
 	Indexed bool   `json:"Indexed"`
+	State   string `json:"State"`
+	Reason  string `json:"Reason"`
+	Frozen  bool   `json:"Frozen"`
 }
 
 func (s *Server) getAdStatus(w http.ResponseWriter, r *http.Request) {
@@ -243,17 +246,43 @@ func (s *Server) getAdStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp := adStatusResponse{
-		Ad: adCid.String(),
+	if adCid.Prefix().Codec != cid.DagJSON {
+		msg := fmt.Sprintf("this endpoint expects an advertisement CID (dag-json codec), got %d; use /cid/%s for content lookups", adCid.Prefix().Codec, cidStr)
+		log.Errorw(msg, "cid", cidStr)
+		http.Error(w, msg, http.StatusBadRequest)
+		return
 	}
-	if s.ingester != nil {
-		adState, err := s.ingester.GetAdState(adCid)
-		if err != nil {
-			log.Errorw("Failed to read advertisement processed state", "adCid", adCid, "err", err)
-			http.Error(w, "", http.StatusInternalServerError)
-			return
-		}
-		resp.Indexed = adState.Indexed()
+
+	if s.ingester == nil {
+		http.Error(w, "ingester not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	adState, err := s.ingester.GetAdState(adCid)
+	if err != nil {
+		log.Errorw("Failed to read advertisement processed state", "adCid", adCid, "err", err)
+		http.Error(w, "", http.StatusInternalServerError)
+		return
+	}
+
+	resp := adStatusResponse{
+		Ad:      adCid.String(),
+		Indexed: adState.Indexed(),
+		Frozen:  adState.Frozen,
+	}
+
+	switch {
+	case !adState.Known:
+		resp.State = "unknown"
+	case adState.Resync:
+		resp.State = "resyncing"
+	case adState.Processed && adState.Skipped:
+		resp.State = "skipped"
+		resp.Reason = adState.SkipReason
+	case adState.Processed && !adState.Skipped:
+		resp.State = "indexed"
+	default:
+		resp.State = "pending"
 	}
 
 	data, err := json.Marshal(resp)

--- a/server/ingest/server.go
+++ b/server/ingest/server.go
@@ -220,11 +220,11 @@ func (s *Server) getSyncStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 type adStatusResponse struct {
-	Ad      string `json:"Ad"`
-	Indexed bool   `json:"Indexed"`
-	State   string `json:"State"`
-	Reason  string `json:"Reason,omitempty"`
-	Frozen  bool   `json:"Frozen"`
+	Ad         string `json:"Ad"`
+	Indexed    bool   `json:"Indexed"`
+	State      string `json:"State"`
+	SkipReason string `json:"SkipReason,omitempty"`
+	Frozen     bool   `json:"Frozen"`
 }
 
 func (s *Server) getAdStatus(w http.ResponseWriter, r *http.Request) {
@@ -246,8 +246,8 @@ func (s *Server) getAdStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if adCid.Prefix().Codec != cid.DagJSON {
-		msg := fmt.Sprintf("this endpoint expects an advertisement CID (dag-json codec), got %d; use /cid/%s for content lookups", adCid.Prefix().Codec, cidStr)
+	if adCid.Prefix().Codec != cid.DagJSON && adCid.Prefix().Codec != cid.DagCBOR {
+		msg := fmt.Sprintf("this endpoint expects an advertisement CID (dag-json or dag-cbor codec), got %d; use /cid/%s for content lookups", adCid.Prefix().Codec, cidStr)
 		log.Debugw(msg, "cid", cidStr)
 		http.Error(w, msg, http.StatusBadRequest)
 		return
@@ -278,7 +278,7 @@ func (s *Server) getAdStatus(w http.ResponseWriter, r *http.Request) {
 		resp.State = "resyncing"
 	case adState.Processed && adState.Skipped:
 		resp.State = "skipped"
-		resp.Reason = adState.SkipReason
+		resp.SkipReason = adState.SkipReason
 	case adState.Processed && !adState.Skipped:
 		resp.State = "indexed"
 	default:

--- a/server/ingest/server.go
+++ b/server/ingest/server.go
@@ -223,7 +223,7 @@ type adStatusResponse struct {
 	Ad      string `json:"Ad"`
 	Indexed bool   `json:"Indexed"`
 	State   string `json:"State"`
-	Reason  string `json:"Reason"`
+	Reason  string `json:"Reason,omitempty"`
 	Frozen  bool   `json:"Frozen"`
 }
 
@@ -248,7 +248,7 @@ func (s *Server) getAdStatus(w http.ResponseWriter, r *http.Request) {
 
 	if adCid.Prefix().Codec != cid.DagJSON {
 		msg := fmt.Sprintf("this endpoint expects an advertisement CID (dag-json codec), got %d; use /cid/%s for content lookups", adCid.Prefix().Codec, cidStr)
-		log.Errorw(msg, "cid", cidStr)
+		log.Debugw(msg, "cid", cidStr)
 		http.Error(w, msg, http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION
## Context

The `/sync/status/ad/<adCid>` endpoint collapses ad state into one boolean. Permanently skipped ads (malformed, decode failure, missing entry chunk) report `Indexed: true`, and a never-seen CID is indistinguishable from an enqueued one. Callers passing content CIDs get a silently wrong answer. Reported by @jennijuju and the Filecoin Onchain Cloud team. Closes #2885.

## Proposed Changes

- New persisted marker byte `3` for processed-but-skipped ads, with a skip reason sidecar; skipped ads now report `Indexed: false`
- Pending marker written at chain admission, so enqueued ads are distinguishable from unknown, surviving restarts
- Response keeps `Indexed` unchanged and adds `State` (`unknown`, `pending`, `indexed`, `skipped`, `resyncing`), `Reason` (skipped only), and `Frozen`
- Non dag-json CIDs return 400 with a pointer to `/cid/`; nil ingester returns 503; zero-length marker values return 500 instead of panicking

Ads processed before this change cannot be distinguished from skipped and continue to report `indexed`. Pending marking adds one datastore write per admitted ad. Test helpers `blockableLinkSys` and `initIngest` changed signature, which is why some pre-existing tests appear in the diff.

## Tests

Raw marker byte table (including legacy byte `1` and undefined bytes), end-to-end permanent-error ingest writing the skipped marker and reason, skipped ads not reprocessed on later syncs, pending marker at admission with restart persistence and no resync downgrade, endpoint assertions for all five states, codec guard, empty marker 500, and nil ingester 503.

## Revert Strategy

Change is safe to revert. Persisted `3` and `0` markers read as unprocessed under the old code, so previously skipped ads would be re-attempted once and skipped again; skip reason sidecar keys are orphaned but harmless.