### PR TITLE
2881 batch ad status

### DIFF
--- a/doc/ingestion.md
+++ b/doc/ingestion.md
@@ -469,8 +469,13 @@ same shape as the single-ad response. The batch size limit is 128 CIDs;
 requests exceeding the limit return HTTP 400. The request body size limit is
 1 MiB. Per-item errors (invalid CID, unsupported codec) are returned as
 individual entries with an `Error` field (and `State` omitted), while the
-overall response is still HTTP 200. OPTIONS preflight requests are supported
-for CORS.
+overall response is still HTTP 200; on such error entries, `Indexed` and
+`Frozen` carry no meaning since no datastore lookup was performed. A datastore
+read failure during batch processing returns HTTP 500 for the entire request,
+in contrast to per-item validation errors which return 200. Callers checking a
+single advertisement should prefer `GET /sync/status/ad/<adCid>`, because GET
+responses are cacheable at the CDN while POST requests always reach the origin.
+OPTIONS preflight requests are supported for CORS.
 
 The response includes:
 

--- a/doc/ingestion.md
+++ b/doc/ingestion.md
@@ -459,9 +459,18 @@ status.
 
 Whether a single advertisement's content is available from this indexer is
 exposed on the same ingest HTTP API as `GET /sync/status/ad/<adCid>`. The
-endpoint only accepts dag-json CIDs (codec 0x0129); requests with other codecs
-return HTTP 400. If the ingester is not available, the endpoint returns HTTP
-503.
+endpoint accepts dag-json or dag-cbor CIDs; requests with other codecs return
+HTTP 400. If the ingester is not available, the endpoint returns HTTP 503.
+
+A batch variant is available at `POST /sync/status/ad`. The request body is
+`{"Ads": ["<cid>", ...]}` and the response is `{"Statuses": [...]}` with
+entries returned in the same order as the request. Each status entry has the
+same shape as the single-ad response. The batch size limit is 128 CIDs;
+requests exceeding the limit return HTTP 400. The request body size limit is
+1 MiB. Per-item errors (invalid CID, unsupported codec) are returned as
+individual entries with an `Error` field (and `State` omitted), while the
+overall response is still HTTP 200. OPTIONS preflight requests are supported
+for CORS.
 
 The response includes:
 
@@ -544,7 +553,7 @@ listed in [config.md](config.md).
 | `internal/ingest/mirror.go` | CAR mirror read/write over the filestore. |
 | `internal/ingest/error.go` | `adIngestError` states and helpers. |
 | `internal/ingest/syncstatus.go` | Live per-publisher sync status tracker. |
-| `server/ingest/server.go` | `/announce`, `/register`, `/sync/status`, and `/sync/status/ad/<cid>` HTTP handlers. |
+| `server/ingest/server.go` | `/announce`, `/register`, `/sync/status`, `/sync/status/ad/<cid>` (single), and `POST /sync/status/ad` (batch) HTTP handlers. |
 | `internal/registry/registry.go` | Provider registry, policy, freeze, auto-sync channel. |
 | `server/find/server.go` | Find HTTP API. |
 | `config/ingest.go` | Ingestion configuration and defaults. |

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -669,7 +669,7 @@ func (ing *Ingester) GetAdStates(ctx context.Context, adCids []cid.Cid) ([]AdSta
 			results[i] = st
 			continue
 		}
-		st, err := ing.getAdState(ctx, adCid)
+		st, err := ing.GetAdState(ctx, adCid)
 		if err != nil {
 			return nil, fmt.Errorf("reading ad state for %s: %w", adCid, err)
 		}

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -653,15 +653,15 @@ func (ing *Ingester) getAdState(ctx context.Context, adCid cid.Cid) (state AdSta
 }
 
 // GetAdState returns the known state for an advertisement.
-func (ing *Ingester) GetAdState(adCid cid.Cid) (AdState, error) {
-	return ing.getAdState(context.Background(), adCid)
+func (ing *Ingester) GetAdState(ctx context.Context, adCid cid.Cid) (AdState, error) {
+	return ing.getAdState(ctx, adCid)
 }
 
 // GetAdStates returns the known state for a batch of advertisements.
 // Results are returned in the same order as the input slice. Duplicate CIDs
 // are read once and answered per position. On error, returns nil and an
 // error wrapping the failing CID; no partial results are returned.
-func (ing *Ingester) GetAdStates(adCids []cid.Cid) ([]AdState, error) {
+func (ing *Ingester) GetAdStates(ctx context.Context, adCids []cid.Cid) ([]AdState, error) {
 	results := make([]AdState, len(adCids))
 	seen := make(map[cid.Cid]AdState, len(adCids))
 	for i, adCid := range adCids {
@@ -669,9 +669,9 @@ func (ing *Ingester) GetAdStates(adCids []cid.Cid) ([]AdState, error) {
 			results[i] = st
 			continue
 		}
-		st, err := ing.getAdState(context.Background(), adCid)
+		st, err := ing.getAdState(ctx, adCid)
 		if err != nil {
-			return nil, fmt.Errorf("getAdState(%s): %w", adCid, err)
+			return nil, fmt.Errorf("reading ad state for %s: %w", adCid, err)
 		}
 		seen[adCid] = st
 		results[i] = st

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -265,7 +265,7 @@ func (ing *Ingester) Skip500EntriesError(skip bool) {
 func (ing *Ingester) generalDagsyncBlockHook(publisher peer.ID, c cid.Cid, actions dagsync.SegmentSyncActions) {
 	// If this ad is already fully processed, all older ads are too.
 	// Stop advancing without loading the ad data.
-	adState, err := ing.adAlreadyProcessed(c)
+	adState, err := ing.adAlreadyProcessed(context.Background(), c)
 	if err != nil {
 		ing.EndScan(publisher, err)
 		actions.FailSync(err)
@@ -573,8 +573,8 @@ type adProcessedState struct {
 	Resync    bool
 }
 
-func (ing *Ingester) adAlreadyProcessed(adCid cid.Cid) (adProcessedState, error) {
-	v, err := ing.ds.Get(context.Background(), datastore.NewKey(adProcessedPrefix+adCid.String()))
+func (ing *Ingester) adAlreadyProcessed(ctx context.Context, adCid cid.Cid) (adProcessedState, error) {
+	v, err := ing.ds.Get(ctx, datastore.NewKey(adProcessedPrefix+adCid.String()))
 	if errors.Is(err, datastore.ErrNotFound) {
 		return adProcessedState{}, nil
 	} else if err != nil {
@@ -612,7 +612,7 @@ func (s AdState) Indexed() bool {
 	return s.Processed && !s.Skipped && !s.Resync && !s.Frozen
 }
 
-// GetAdState returns the known state for an advertisement.
+// getAdState returns the known state for an advertisement.
 //
 // Processed is true when the ad is marked fully processed (/adProcessed/ value
 // 1 or 3). Skipped is true when the ad was permanently skipped (value 3).
@@ -621,8 +621,8 @@ func (s AdState) Indexed() bool {
 // the indexer was in frozen mode (/adF/ key present); frozen processing updates
 // provider metadata but does not index entry multihashes. Known is false when
 // the ad has never been seen (datastore.ErrNotFound).
-func (ing *Ingester) GetAdState(adCid cid.Cid) (state AdState, err error) {
-	adState, err := ing.adAlreadyProcessed(adCid)
+func (ing *Ingester) getAdState(ctx context.Context, adCid cid.Cid) (state AdState, err error) {
+	adState, err := ing.adAlreadyProcessed(ctx, adCid)
 	if err != nil {
 		return state, err
 	}
@@ -632,14 +632,14 @@ func (ing *Ingester) GetAdState(adCid cid.Cid) (state AdState, err error) {
 	state.Resync = adState.Resync
 
 	if adState.Skipped {
-		reason, err2 := ing.ds.Get(context.Background(), datastore.NewKey(adSkipReasonPrefix+adCid.String()))
+		reason, err2 := ing.ds.Get(ctx, datastore.NewKey(adSkipReasonPrefix+adCid.String()))
 		if err2 != nil && !errors.Is(err2, datastore.ErrNotFound) {
 			return state, err2
 		}
 		state.SkipReason = string(reason)
 	}
 
-	_, err = ing.ds.Get(context.Background(), datastore.NewKey(adProcessedFrozenPrefix+adCid.String()))
+	_, err = ing.ds.Get(ctx, datastore.NewKey(adProcessedFrozenPrefix+adCid.String()))
 	switch {
 	case errors.Is(err, datastore.ErrNotFound):
 		state.Frozen = false
@@ -650,6 +650,33 @@ func (ing *Ingester) GetAdState(adCid cid.Cid) (state AdState, err error) {
 	}
 
 	return state, nil
+}
+
+// GetAdState returns the known state for an advertisement.
+func (ing *Ingester) GetAdState(adCid cid.Cid) (AdState, error) {
+	return ing.getAdState(context.Background(), adCid)
+}
+
+// GetAdStates returns the known state for a batch of advertisements.
+// Results are returned in the same order as the input slice. Duplicate CIDs
+// are read once and answered per position. On error, returns nil and an
+// error wrapping the failing CID; no partial results are returned.
+func (ing *Ingester) GetAdStates(adCids []cid.Cid) ([]AdState, error) {
+	results := make([]AdState, len(adCids))
+	seen := make(map[cid.Cid]AdState, len(adCids))
+	for i, adCid := range adCids {
+		if st, ok := seen[adCid]; ok {
+			results[i] = st
+			continue
+		}
+		st, err := ing.getAdState(context.Background(), adCid)
+		if err != nil {
+			return nil, fmt.Errorf("getAdState(%s): %w", adCid, err)
+		}
+		seen[adCid] = st
+		results[i] = st
+	}
+	return results, nil
 }
 
 // MarkAdProcessed explicitly marks an advertisement as processed. This is used
@@ -1123,7 +1150,7 @@ func (ing *Ingester) processRawAdChain(ctx context.Context, syncFinished dagsync
 		// only publish Ads for one provider, but it's possible that an ad
 		// chain can include multiple providers.
 
-		adState, stateErr := ing.adAlreadyProcessed(c)
+		adState, stateErr := ing.adAlreadyProcessed(ctx, c)
 		if stateErr != nil {
 			log.Errorw("Failed to read advertisement processed state from datastore", "err", stateErr)
 			// Note: don't stop in case of an error in this place, the same check will be done
@@ -1268,7 +1295,7 @@ func (ing *Ingester) ingestWorkerLogic(ctx context.Context, provider, publisher 
 			return
 		}
 
-		adState, err := ing.adAlreadyProcessed(ai.cid)
+		adState, err := ing.adAlreadyProcessed(ctx, ai.cid)
 		if err != nil {
 			log.Errorw("Failed to check if advertisement is processed. Bailing early, not ingesting later ads.", "adCid", ai.cid, "err", err)
 			ing.inEvents <- adProcessedEvent{

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -612,7 +612,7 @@ func (s AdState) Indexed() bool {
 	return s.Processed && !s.Skipped && !s.Resync && !s.Frozen
 }
 
-// getAdState returns the known state for an advertisement.
+// GetAdState returns the known state for an advertisement.
 //
 // Processed is true when the ad is marked fully processed (/adProcessed/ value
 // 1 or 3). Skipped is true when the ad was permanently skipped (value 3).
@@ -621,7 +621,7 @@ func (s AdState) Indexed() bool {
 // the indexer was in frozen mode (/adF/ key present); frozen processing updates
 // provider metadata but does not index entry multihashes. Known is false when
 // the ad has never been seen (datastore.ErrNotFound).
-func (ing *Ingester) getAdState(ctx context.Context, adCid cid.Cid) (state AdState, err error) {
+func (ing *Ingester) GetAdState(ctx context.Context, adCid cid.Cid) (state AdState, err error) {
 	adState, err := ing.adAlreadyProcessed(ctx, adCid)
 	if err != nil {
 		return state, err
@@ -650,11 +650,6 @@ func (ing *Ingester) getAdState(ctx context.Context, adCid cid.Cid) (state AdSta
 	}
 
 	return state, nil
-}
-
-// GetAdState returns the known state for an advertisement.
-func (ing *Ingester) GetAdState(ctx context.Context, adCid cid.Cid) (AdState, error) {
-	return ing.getAdState(ctx, adCid)
 }
 
 // GetAdStates returns the known state for a batch of advertisements.

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -1221,7 +1221,7 @@ func TestPermanentErrorRoutesToSkippedMarker(t *testing.T) {
 	require.Equal(t, adCid, endCid)
 
 	// Verify the ad was marked as skipped with marker byte 3.
-	state, err := i.GetAdState(adCid)
+	state, err := i.GetAdState(t.Context(), adCid)
 	require.NoError(t, err)
 	require.True(t, state.Known)
 	require.True(t, state.Processed)
@@ -2413,31 +2413,31 @@ func TestGetAdState(t *testing.T) {
 	publisher := te.pubHost.ID()
 	ads := random.Cids(4)
 
-	state, err := te.ingester.GetAdState(ads[0])
+	state, err := te.ingester.GetAdState(t.Context(), ads[0])
 	require.NoError(t, err)
 	require.Equal(t, AdState{}, state)
 	require.False(t, state.Indexed())
 
 	require.NoError(t, te.ingester.MarkAdProcessed(publisher, ads[0]))
-	state, err = te.ingester.GetAdState(ads[0])
+	state, err = te.ingester.GetAdState(t.Context(), ads[0])
 	require.NoError(t, err)
 	require.Equal(t, AdState{Known: true, Processed: true}, state)
 	require.True(t, state.Indexed())
 
 	require.NoError(t, te.ingester.markAdUnprocessed(ads[1], true))
-	state, err = te.ingester.GetAdState(ads[1])
+	state, err = te.ingester.GetAdState(t.Context(), ads[1])
 	require.NoError(t, err)
 	require.Equal(t, AdState{Known: true, Resync: true}, state)
 	require.False(t, state.Indexed())
 
 	require.NoError(t, te.ingester.markAdUnprocessed(ads[2], false))
-	state, err = te.ingester.GetAdState(ads[2])
+	state, err = te.ingester.GetAdState(t.Context(), ads[2])
 	require.NoError(t, err)
 	require.Equal(t, AdState{Known: true}, state)
 	require.False(t, state.Indexed())
 
 	require.NoError(t, te.ingester.markAdProcessed(publisher, ads[3], true, false))
-	state, err = te.ingester.GetAdState(ads[3])
+	state, err = te.ingester.GetAdState(t.Context(), ads[3])
 	require.NoError(t, err)
 	require.Equal(t, AdState{Known: true, Processed: true, Frozen: true}, state)
 	require.False(t, state.Indexed())
@@ -2473,7 +2473,7 @@ func TestAdStateByMarkerByte(t *testing.T) {
 
 	// Test marker byte 0 (unprocessed) via markAdUnprocessed
 	require.NoError(t, te.ingester.markAdUnprocessed(ads[0], false))
-	state, err := te.ingester.GetAdState(ads[0])
+	state, err := te.ingester.GetAdState(t.Context(), ads[0])
 	require.NoError(t, err)
 	require.True(t, state.Known)
 	require.False(t, state.Processed)
@@ -2483,7 +2483,7 @@ func TestAdStateByMarkerByte(t *testing.T) {
 
 	// Test marker byte 1 (processed) via MarkAdProcessed
 	require.NoError(t, te.ingester.MarkAdProcessed(publisher, ads[1]))
-	state, err = te.ingester.GetAdState(ads[1])
+	state, err = te.ingester.GetAdState(t.Context(), ads[1])
 	require.NoError(t, err)
 	require.True(t, state.Known)
 	require.True(t, state.Processed)
@@ -2493,7 +2493,7 @@ func TestAdStateByMarkerByte(t *testing.T) {
 
 	// Test marker byte 2 (resync) via markAdUnprocessed(forResync=true)
 	require.NoError(t, te.ingester.markAdUnprocessed(ads[2], true))
-	state, err = te.ingester.GetAdState(ads[2])
+	state, err = te.ingester.GetAdState(t.Context(), ads[2])
 	require.NoError(t, err)
 	require.True(t, state.Known)
 	require.False(t, state.Processed)
@@ -2503,7 +2503,7 @@ func TestAdStateByMarkerByte(t *testing.T) {
 
 	// Test marker byte 3 (skipped) via MarkAdSkipped
 	require.NoError(t, te.ingester.MarkAdSkipped(publisher, ads[3], "malformedErr", false))
-	state, err = te.ingester.GetAdState(ads[3])
+	state, err = te.ingester.GetAdState(t.Context(), ads[3])
 	require.NoError(t, err)
 	require.True(t, state.Known)
 	require.True(t, state.Processed)
@@ -2577,7 +2577,7 @@ func TestAdStateByRawByte(t *testing.T) {
 				require.NoError(t, te.ingester.ds.Put(context.Background(), datastore.NewKey(adSkipReasonPrefix+ad.String()), []byte(tt.sidecar)))
 			}
 
-			state, err := te.ingester.GetAdState(ad)
+			state, err := te.ingester.GetAdState(t.Context(), ad)
 			require.NoError(t, err)
 			require.Equal(t, tt.want, state)
 		})
@@ -2589,7 +2589,7 @@ func TestAdStateEmptyValue(t *testing.T) {
 	ad := random.Cids(1)[0]
 
 	require.NoError(t, te.ingester.ds.Put(context.Background(), datastore.NewKey(adProcessedPrefix+ad.String()), []byte{}))
-	_, err := te.ingester.GetAdState(ad)
+	_, err := te.ingester.GetAdState(t.Context(), ad)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "empty value")
 
@@ -2604,7 +2604,7 @@ func TestMarkAdSkipped(t *testing.T) {
 
 	require.NoError(t, te.ingester.MarkAdSkipped(publisher, ad, "decodeErr", false))
 
-	state, err := te.ingester.GetAdState(ad)
+	state, err := te.ingester.GetAdState(t.Context(), ad)
 	require.NoError(t, err)
 	require.True(t, state.Known)
 	require.True(t, state.Processed)
@@ -2622,7 +2622,7 @@ func TestMarkAdSkipped(t *testing.T) {
 	longReason := strings.Repeat("x", 300)
 	ad2 := random.Cids(1)[0]
 	require.NoError(t, te.ingester.MarkAdSkipped(publisher, ad2, longReason, false))
-	state, err = te.ingester.GetAdState(ad2)
+	state, err = te.ingester.GetAdState(t.Context(), ad2)
 	require.NoError(t, err)
 	require.Equal(t, 256, len(state.SkipReason))
 	require.Equal(t, strings.Repeat("x", 256), state.SkipReason)
@@ -2682,13 +2682,13 @@ func TestAdmittedAdIsPending(t *testing.T) {
 	<-hitBlockedRead
 
 	// A should be processed already (worker processes oldest first)
-	aState, err := te.ingester.GetAdState(aLink.(cidlink.Link).Cid)
+	aState, err := te.ingester.GetAdState(t.Context(), aLink.(cidlink.Link).Cid)
 	require.NoError(t, err)
 	require.True(t, aState.Known)
 	require.True(t, aState.Processed)
 
 	// C should be pending (admitted but not yet reached by worker)
-	cState, err := te.ingester.GetAdState(cLink.(cidlink.Link).Cid)
+	cState, err := te.ingester.GetAdState(t.Context(), cLink.(cidlink.Link).Cid)
 	require.NoError(t, err)
 	require.True(t, cState.Known)
 	require.False(t, cState.Processed)
@@ -2709,7 +2709,7 @@ func TestResyncMarkerNotDowngraded(t *testing.T) {
 
 	require.NoError(t, te.ingester.markAdUnprocessed(ad, true))
 
-	state, err := te.ingester.GetAdState(ad)
+	state, err := te.ingester.GetAdState(t.Context(), ad)
 	require.NoError(t, err)
 	require.True(t, state.Known)
 	require.True(t, state.Resync)
@@ -2719,7 +2719,7 @@ func TestResyncMarkerNotDowngraded(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, adState.Known)
 
-	state, err = te.ingester.GetAdState(ad)
+	state, err = te.ingester.GetAdState(t.Context(), ad)
 	require.NoError(t, err)
 	require.True(t, state.Known)
 	require.True(t, state.Resync)
@@ -2738,7 +2738,7 @@ func TestPendingMarkerPersistsAcrossRestart(t *testing.T) {
 	ad := random.Cids(1)[0]
 	require.NoError(t, i.markAdUnprocessed(ad, false))
 
-	state, err := i.GetAdState(ad)
+	state, err := i.GetAdState(t.Context(), ad)
 	require.NoError(t, err)
 	require.True(t, state.Known)
 	require.False(t, state.Processed)
@@ -2753,7 +2753,7 @@ func TestPendingMarkerPersistsAcrossRestart(t *testing.T) {
 		core.Close()
 	}()
 
-	state, err = i2.GetAdState(ad)
+	state, err = i2.GetAdState(t.Context(), ad)
 	require.NoError(t, err)
 	require.True(t, state.Known)
 	require.False(t, state.Processed)
@@ -2796,7 +2796,7 @@ func TestPendingMarkerClearedAfterProcessing(t *testing.T) {
 	<-hitBlockedRead
 
 	// b should be pending
-	bState, err := te.ingester.GetAdState(bLink.(cidlink.Link).Cid)
+	bState, err := te.ingester.GetAdState(t.Context(), bLink.(cidlink.Link).Cid)
 	require.NoError(t, err)
 	require.True(t, bState.Known)
 	require.False(t, bState.Processed)
@@ -2813,7 +2813,7 @@ func TestPendingMarkerClearedAfterProcessing(t *testing.T) {
 	}
 
 	// b should now be processed (marker 1, not 0)
-	bState, err = te.ingester.GetAdState(bLink.(cidlink.Link).Cid)
+	bState, err = te.ingester.GetAdState(t.Context(), bLink.(cidlink.Link).Cid)
 	require.NoError(t, err)
 	require.True(t, bState.Known)
 	require.True(t, bState.Processed)
@@ -2889,6 +2889,18 @@ func newErrorValueStore() *errorValueStore {
 	}
 }
 
+func (vs *errorValueStore) Get(_ multihash.Multihash) ([]indexer.Value, bool, error) {
+	return nil, false, vs.err
+}
+func (vs *errorValueStore) Put(_ indexer.Value, _ ...multihash.Multihash) error    { return vs.err }
+func (vs *errorValueStore) Remove(_ indexer.Value, _ ...multihash.Multihash) error { return vs.err }
+func (vs *errorValueStore) RemoveProvider(_ context.Context, _ peer.ID) error      { return vs.err }
+func (vs *errorValueStore) RemoveProviderContext(_ peer.ID, _ []byte) error        { return vs.err }
+func (vs *errorValueStore) Size() (int64, error)                                   { return 0, vs.err }
+func (vs *errorValueStore) Flush() error                                           { return vs.err }
+func (vs *errorValueStore) Close() error                                           { return vs.err }
+func (vs *errorValueStore) Stats() (*indexer.Stats, error)                         { return nil, vs.err }
+
 func TestGetAdStates(t *testing.T) {
 	te := setupTestEnv(t, false)
 	publisher := te.pubHost.ID()
@@ -2903,12 +2915,12 @@ func TestGetAdStates(t *testing.T) {
 	require.NoError(t, te.ingester.markAdUnprocessed(adResync, true))
 
 	input := []cid.Cid{adProcessed, adSkipped, adResync, adUnknown}
-	states, err := te.ingester.GetAdStates(input)
+	states, err := te.ingester.GetAdStates(t.Context(), input)
 	require.NoError(t, err)
 	require.Len(t, states, 4)
 
 	for i, adCid := range input {
-		single, err := te.ingester.GetAdState(adCid)
+		single, err := te.ingester.GetAdState(t.Context(), adCid)
 		require.NoError(t, err)
 		require.Equal(t, single, states[i], "batch[%d] for %s should equal GetAdState", i, adCid)
 	}
@@ -2927,12 +2939,12 @@ func TestGetAdStatesOrderAndDedup(t *testing.T) {
 	require.NoError(t, te.ingester.markAdUnprocessed(adC, true))
 
 	shuffled := []cid.Cid{adC, adA, adB, adA, adC}
-	states, err := te.ingester.GetAdStates(shuffled)
+	states, err := te.ingester.GetAdStates(t.Context(), shuffled)
 	require.NoError(t, err)
 	require.Len(t, states, 5)
 
 	for i, adCid := range shuffled {
-		single, err := te.ingester.GetAdState(adCid)
+		single, err := te.ingester.GetAdState(t.Context(), adCid)
 		require.NoError(t, err)
 		require.Equal(t, single, states[i])
 	}
@@ -2945,13 +2957,13 @@ func TestGetAdStatesFrozen(t *testing.T) {
 	ad := random.Cids(1)[0]
 	require.NoError(t, te.ingester.markAdProcessed(publisher, ad, true, false))
 
-	states, err := te.ingester.GetAdStates([]cid.Cid{ad})
+	states, err := te.ingester.GetAdStates(t.Context(), []cid.Cid{ad})
 	require.NoError(t, err)
 	require.Len(t, states, 1)
 	require.True(t, states[0].Frozen)
 	require.False(t, states[0].Indexed())
 
-	single, err := te.ingester.GetAdState(ad)
+	single, err := te.ingester.GetAdState(t.Context(), ad)
 	require.NoError(t, err)
 	require.Equal(t, single, states[0])
 }
@@ -2959,51 +2971,29 @@ func TestGetAdStatesFrozen(t *testing.T) {
 func TestGetAdStatesEmpty(t *testing.T) {
 	te := setupTestEnv(t, false)
 
-	states, err := te.ingester.GetAdStates(nil)
+	states, err := te.ingester.GetAdStates(t.Context(), nil)
 	require.NoError(t, err)
 	require.NotNil(t, states)
 	require.Len(t, states, 0)
 
-	states, err = te.ingester.GetAdStates([]cid.Cid{})
+	states, err = te.ingester.GetAdStates(t.Context(), []cid.Cid{})
 	require.NoError(t, err)
 	require.NotNil(t, states)
 	require.Len(t, states, 0)
 }
 
 func TestGetAdStatesErrorNoPartial(t *testing.T) {
-	ds := dssync.MutexWrap(datastore.NewMapDatastore())
-	h := dstest.MkTestHost(t)
-	reg := mkRegistry(t)
-	core := mkIndexer(t, true)
-	i, err := NewIngester(defaultTestIngestConfig, h, core, reg, ds, ds)
-	require.NoError(t, err)
-	defer func() {
-		i.Close()
-		reg.Close()
-		core.Close()
-	}()
+	te := setupTestEnv(t, false)
 
 	badAd := random.Cids(1)[0]
-	ds.Put(context.Background(), datastore.NewKey(adProcessedPrefix+badAd.String()), []byte{})
+	require.NoError(t, te.ingester.ds.Put(context.Background(), datastore.NewKey(adProcessedPrefix+badAd.String()), []byte{}))
 
 	goodAd := random.Cids(1)[0]
-	states, err := i.GetAdStates([]cid.Cid{goodAd, badAd})
+	states, err := te.ingester.GetAdStates(t.Context(), []cid.Cid{goodAd, badAd})
 	require.Error(t, err)
 	require.Nil(t, states)
 	require.Contains(t, err.Error(), badAd.String())
 }
-
-func (vs *errorValueStore) Get(_ multihash.Multihash) ([]indexer.Value, bool, error) {
-	return nil, false, vs.err
-}
-func (vs *errorValueStore) Put(_ indexer.Value, _ ...multihash.Multihash) error    { return vs.err }
-func (vs *errorValueStore) Remove(_ indexer.Value, _ ...multihash.Multihash) error { return vs.err }
-func (vs *errorValueStore) RemoveProvider(_ context.Context, _ peer.ID) error      { return vs.err }
-func (vs *errorValueStore) RemoveProviderContext(_ peer.ID, _ []byte) error        { return vs.err }
-func (vs *errorValueStore) Size() (int64, error)                                   { return 0, vs.err }
-func (vs *errorValueStore) Flush() error                                           { return vs.err }
-func (vs *errorValueStore) Close() error                                           { return vs.err }
-func (vs *errorValueStore) Stats() (*indexer.Stats, error)                         { return nil, vs.err }
 
 // blockingMirrorFilestore wraps a filestore and blocks Get for one CAR path.
 // Used to stall ad processing inside mirror.read without holding any dagsync mutex.

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -1230,7 +1230,7 @@ func TestPermanentErrorRoutesToSkippedMarker(t *testing.T) {
 	require.False(t, state.Indexed())
 
 	// Verify adAlreadyProcessed treats it as done (won't reprocess).
-	apState, err := i.adAlreadyProcessed(adCid)
+	apState, err := i.adAlreadyProcessed(t.Context(), adCid)
 	require.NoError(t, err)
 	require.True(t, apState.Known)
 	require.True(t, apState.Processed)
@@ -2525,7 +2525,7 @@ func TestAdStateByMarkerByte(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := te.ingester.adAlreadyProcessed(tt.ad)
+			got, err := te.ingester.adAlreadyProcessed(t.Context(), tt.ad)
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)
 		})
@@ -2593,7 +2593,7 @@ func TestAdStateEmptyValue(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "empty value")
 
-	_, err = te.ingester.adAlreadyProcessed(ad)
+	_, err = te.ingester.adAlreadyProcessed(t.Context(), ad)
 	require.Error(t, err)
 }
 
@@ -2635,7 +2635,7 @@ func TestSkippedAdNotReprocessed(t *testing.T) {
 
 	require.NoError(t, te.ingester.MarkAdSkipped(publisher, ad, "malformedErr", false))
 
-	adState, err := te.ingester.adAlreadyProcessed(ad)
+	adState, err := te.ingester.adAlreadyProcessed(t.Context(), ad)
 	require.NoError(t, err)
 	require.True(t, adState.Known)
 	require.True(t, adState.Processed)
@@ -2715,7 +2715,7 @@ func TestResyncMarkerNotDowngraded(t *testing.T) {
 	require.True(t, state.Resync)
 
 	// Simulate admission (what processRawAdChain does)
-	adState, err := te.ingester.adAlreadyProcessed(ad)
+	adState, err := te.ingester.adAlreadyProcessed(t.Context(), ad)
 	require.NoError(t, err)
 	require.True(t, adState.Known)
 
@@ -2888,6 +2888,111 @@ func newErrorValueStore() *errorValueStore {
 		err: errors.New("dead value store"),
 	}
 }
+
+func TestGetAdStates(t *testing.T) {
+	te := setupTestEnv(t, false)
+	publisher := te.pubHost.ID()
+
+	adProcessed := random.Cids(1)[0]
+	adSkipped := random.Cids(1)[0]
+	adResync := random.Cids(1)[0]
+	adUnknown := random.Cids(1)[0]
+
+	require.NoError(t, te.ingester.MarkAdProcessed(publisher, adProcessed))
+	require.NoError(t, te.ingester.MarkAdSkipped(publisher, adSkipped, "test skip reason", false))
+	require.NoError(t, te.ingester.markAdUnprocessed(adResync, true))
+
+	input := []cid.Cid{adProcessed, adSkipped, adResync, adUnknown}
+	states, err := te.ingester.GetAdStates(input)
+	require.NoError(t, err)
+	require.Len(t, states, 4)
+
+	for i, adCid := range input {
+		single, err := te.ingester.GetAdState(adCid)
+		require.NoError(t, err)
+		require.Equal(t, single, states[i], "batch[%d] for %s should equal GetAdState", i, adCid)
+	}
+}
+
+func TestGetAdStatesOrderAndDedup(t *testing.T) {
+	te := setupTestEnv(t, false)
+	publisher := te.pubHost.ID()
+
+	adA := random.Cids(1)[0]
+	adB := random.Cids(1)[0]
+	adC := random.Cids(1)[0]
+
+	require.NoError(t, te.ingester.MarkAdProcessed(publisher, adA))
+	require.NoError(t, te.ingester.MarkAdSkipped(publisher, adB, "skip B", false))
+	require.NoError(t, te.ingester.markAdUnprocessed(adC, true))
+
+	shuffled := []cid.Cid{adC, adA, adB, adA, adC}
+	states, err := te.ingester.GetAdStates(shuffled)
+	require.NoError(t, err)
+	require.Len(t, states, 5)
+
+	for i, adCid := range shuffled {
+		single, err := te.ingester.GetAdState(adCid)
+		require.NoError(t, err)
+		require.Equal(t, single, states[i])
+	}
+}
+
+func TestGetAdStatesFrozen(t *testing.T) {
+	te := setupTestEnv(t, false)
+	publisher := te.pubHost.ID()
+
+	ad := random.Cids(1)[0]
+	require.NoError(t, te.ingester.markAdProcessed(publisher, ad, true, false))
+
+	states, err := te.ingester.GetAdStates([]cid.Cid{ad})
+	require.NoError(t, err)
+	require.Len(t, states, 1)
+	require.True(t, states[0].Frozen)
+	require.False(t, states[0].Indexed())
+
+	single, err := te.ingester.GetAdState(ad)
+	require.NoError(t, err)
+	require.Equal(t, single, states[0])
+}
+
+func TestGetAdStatesEmpty(t *testing.T) {
+	te := setupTestEnv(t, false)
+
+	states, err := te.ingester.GetAdStates(nil)
+	require.NoError(t, err)
+	require.NotNil(t, states)
+	require.Len(t, states, 0)
+
+	states, err = te.ingester.GetAdStates([]cid.Cid{})
+	require.NoError(t, err)
+	require.NotNil(t, states)
+	require.Len(t, states, 0)
+}
+
+func TestGetAdStatesErrorNoPartial(t *testing.T) {
+	ds := dssync.MutexWrap(datastore.NewMapDatastore())
+	h := dstest.MkTestHost(t)
+	reg := mkRegistry(t)
+	core := mkIndexer(t, true)
+	i, err := NewIngester(defaultTestIngestConfig, h, core, reg, ds, ds)
+	require.NoError(t, err)
+	defer func() {
+		i.Close()
+		reg.Close()
+		core.Close()
+	}()
+
+	badAd := random.Cids(1)[0]
+	ds.Put(context.Background(), datastore.NewKey(adProcessedPrefix+badAd.String()), []byte{})
+
+	goodAd := random.Cids(1)[0]
+	states, err := i.GetAdStates([]cid.Cid{goodAd, badAd})
+	require.Error(t, err)
+	require.Nil(t, states)
+	require.Contains(t, err.Error(), badAd.String())
+}
+
 func (vs *errorValueStore) Get(_ multihash.Multihash) ([]indexer.Value, bool, error) {
 	return nil, false, vs.err
 }

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -2986,7 +2986,7 @@ func TestGetAdStatesErrorNoPartial(t *testing.T) {
 	te := setupTestEnv(t, false)
 
 	badAd := random.Cids(1)[0]
-	require.NoError(t, te.ingester.ds.Put(context.Background(), datastore.NewKey(adProcessedPrefix+badAd.String()), []byte{}))
+	require.NoError(t, te.ingester.ds.Put(t.Context(), datastore.NewKey(adProcessedPrefix+badAd.String()), []byte{}))
 
 	goodAd := random.Cids(1)[0]
 	states, err := te.ingester.GetAdStates(t.Context(), []cid.Cid{goodAd, badAd})

--- a/server/ingest/protocol_test.go
+++ b/server/ingest/protocol_test.go
@@ -425,8 +425,19 @@ func TestAdStatusBatch(t *testing.T) {
 	require.Equal(t, http.StatusOK, status)
 	require.Contains(t, body, `"Error"`)
 	require.Contains(t, body, `"Ad":"not-a-cid"`)
-	// Error entries omit State: Frozen immediately precedes Error (no State/SkipReason between them)
-	require.Contains(t, body, `"Frozen":false,"Error"`)
+
+	// Unmarshal to verify error entries omit State/SkipReason and raw-codec entry is correct
+	var batchResp map[string][]map[string]any
+	require.NoError(t, json.Unmarshal([]byte(body), &batchResp))
+	statuses := batchResp["Statuses"]
+	require.Len(t, statuses, 4)
+	// "not-a-cid" entry (index 2): no State key
+	require.False(t, func() bool { _, ok := statuses[2]["State"]; return ok }(), "error entry should not have State")
+	require.False(t, func() bool { _, ok := statuses[2]["SkipReason"]; return ok }(), "error entry should not have SkipReason")
+	// raw-codec entry (index 3): Ad is canonicalized, error mentions supported codecs
+	require.Equal(t, rawCid.String(), statuses[3]["Ad"])
+	require.Contains(t, statuses[3]["Error"].(string), "dag-json")
+	require.Contains(t, statuses[3]["Error"].(string), "dag-cbor")
 
 	// All-invalid batch still returns 200
 	status, _, body = postBatch(t, []string{"not-a-cid", "also-not-a-cid"})

--- a/server/ingest/protocol_test.go
+++ b/server/ingest/protocol_test.go
@@ -270,7 +270,9 @@ func TestAdStatus(t *testing.T) {
 	dagCBORCid := cid.NewCidV1(cid.DagCBOR, random.Multihashes(1)[0])
 	res, err = http.Get(s.URL() + "/sync/status/ad/" + dagCBORCid.String())
 	require.NoError(t, err)
+	bodyBytes, err = io.ReadAll(res.Body)
 	res.Body.Close()
+	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, res.StatusCode)
 	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"unknown","Frozen":false}`, dagCBORCid.String()), string(bodyBytes))
 

--- a/server/ingest/protocol_test.go
+++ b/server/ingest/protocol_test.go
@@ -456,7 +456,7 @@ func TestAdStatusBatch(t *testing.T) {
 	require.Contains(t, body, "128")
 
 	// Empty Ads returns 400
-	emptyBody, err := json.Marshal(map[string][]string{"Ads": []string{}})
+	emptyBody, err := json.Marshal(map[string][]string{"Ads": {}})
 	require.NoError(t, err)
 	res, err := http.Post(s.URL()+"/sync/status/ad", "application/json", bytes.NewReader(emptyBody))
 	require.NoError(t, err)
@@ -525,7 +525,7 @@ func TestAdStatusBatch(t *testing.T) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	batchBody, err := json.Marshal(map[string][]string{"Ads": []string{cids[0].String()}})
+	batchBody, err := json.Marshal(map[string][]string{"Ads": {cids[0].String()}})
 	require.NoError(t, err)
 	res, err = http.Post(nilServer.URL()+"/sync/status/ad", "application/json", bytes.NewReader(batchBody))
 	require.NoError(t, err)

--- a/server/ingest/protocol_test.go
+++ b/server/ingest/protocol_test.go
@@ -475,10 +475,11 @@ func TestAdStatusBatch(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, res.StatusCode)
 	require.Contains(t, string(data), "malformed")
 
-	// Body over 1 MiB returns 400 with distinct message
-	// Send valid-looking JSON prefix + padding so decoder reads past limit before failing
-	pad := bytes.Repeat([]byte("x"), 1024*1024)
+	// Body over limit returns 400 with distinct message
+	// Build valid JSON that exceeds the body size limit: {"Ads":["<cid>", " ", ...]}
+	pad := bytes.Repeat([]byte(" "), 1024*1024)
 	bigBody := append([]byte(`{"Ads":["`), pad...)
+	bigBody = append(bigBody, []byte(`"]}`)...)
 	res, err = http.Post(s.URL()+"/sync/status/ad", "application/json", bytes.NewReader(bigBody))
 	require.NoError(t, err)
 	data, err = io.ReadAll(res.Body)

--- a/server/ingest/protocol_test.go
+++ b/server/ingest/protocol_test.go
@@ -1,6 +1,7 @@
 package ingest_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -269,9 +270,7 @@ func TestAdStatus(t *testing.T) {
 	dagCBORCid := cid.NewCidV1(cid.DagCBOR, random.Multihashes(1)[0])
 	res, err = http.Get(s.URL() + "/sync/status/ad/" + dagCBORCid.String())
 	require.NoError(t, err)
-	bodyBytes, err = io.ReadAll(res.Body)
 	res.Body.Close()
-	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, res.StatusCode)
 	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"unknown","Frozen":false}`, dagCBORCid.String()), string(bodyBytes))
 
@@ -320,6 +319,211 @@ func TestAdStatus(t *testing.T) {
 	require.NoError(t, err)
 	req.Header.Set("Origin", "http://example.com")
 	req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+	res, err = http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	res.Body.Close()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Equal(t, "*", res.Header.Get("Access-Control-Allow-Origin"))
+}
+
+func TestAdStatusBatch(t *testing.T) {
+	ind := initIndex(t, true)
+	reg := initRegistry(t, providerIdent.PeerID)
+	ing, ds := initIngest(t, ind, reg)
+	s := setupServer(ind, ing, reg, t)
+	errChan := make(chan error, 1)
+	go func() {
+		err := s.Start()
+		if err != http.ErrServerClosed {
+			errChan <- err
+		}
+		close(errChan)
+	}()
+	t.Cleanup(func() {
+		require.NoError(t, s.Close())
+		require.NoError(t, <-errChan)
+	})
+
+	pubID, _, err := providerIdent.Decode()
+	require.NoError(t, err)
+
+	postBatch := func(t *testing.T, ads []string) (int, http.Header, string) {
+		t.Helper()
+		body, err := json.Marshal(map[string][]string{"Ads": ads})
+		require.NoError(t, err)
+		res, err := http.Post(s.URL()+"/sync/status/ad", "application/json", bytes.NewReader(body))
+		require.NoError(t, err)
+		data, err := io.ReadAll(res.Body)
+		res.Body.Close()
+		require.NoError(t, err)
+		return res.StatusCode, res.Header, string(data)
+	}
+
+	// Create test CIDs for each state
+	cids := random.Cids(6)
+	for i := range cids {
+		cids[i] = cid.NewCidV1(cid.DagJSON, cids[i].Hash())
+	}
+
+	// Set up states: unknown, pending, indexed, resyncing, skipped
+	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adProcessed/"+cids[1].String()), []byte{0}))
+	require.NoError(t, ing.MarkAdProcessed(pubID, cids[2]))
+	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adProcessed/"+cids[3].String()), []byte{2}))
+	require.NoError(t, ing.MarkAdSkipped(pubID, cids[4], "testSkip", false))
+
+	// All five states in one request, asserted positionally
+	status, hdr, body := postBatch(t, []string{
+		cids[0].String(), // unknown
+		cids[1].String(), // pending
+		cids[2].String(), // indexed
+		cids[3].String(), // resyncing
+		cids[4].String(), // skipped
+	})
+	require.Equal(t, http.StatusOK, status)
+	require.Equal(t, "*", hdr.Get("Access-Control-Allow-Origin"))
+	require.JSONEq(t, fmt.Sprintf(`{
+		"Statuses": [
+			{"Ad":%q,"Indexed":false,"State":"unknown","Frozen":false},
+			{"Ad":%q,"Indexed":false,"State":"pending","Frozen":false},
+			{"Ad":%q,"Indexed":true,"State":"indexed","Frozen":false},
+			{"Ad":%q,"Indexed":false,"State":"resyncing","Frozen":false},
+			{"Ad":%q,"Indexed":false,"State":"skipped","SkipReason":"testSkip","Frozen":false}
+		]
+	}`, cids[0].String(), cids[1].String(), cids[2].String(), cids[3].String(), cids[4].String()), body)
+
+	// Frozen-processed ad
+	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adF/"+cids[2].String()), []byte{1}))
+	status, _, body = postBatch(t, []string{cids[2].String()})
+	require.Equal(t, http.StatusOK, status)
+	require.JSONEq(t, fmt.Sprintf(`{"Statuses":[{"Ad":%q,"Indexed":false,"State":"indexed","Frozen":true}]}`, cids[2].String()), body)
+
+	// Reversed order with one duplicated CID stays positionally aligned
+	status, _, body = postBatch(t, []string{cids[4].String(), cids[2].String(), cids[4].String()})
+	require.Equal(t, http.StatusOK, status)
+	require.JSONEq(t, fmt.Sprintf(`{
+		"Statuses": [
+			{"Ad":%q,"Indexed":false,"State":"skipped","SkipReason":"testSkip","Frozen":false},
+			{"Ad":%q,"Indexed":false,"State":"indexed","Frozen":true},
+			{"Ad":%q,"Indexed":false,"State":"skipped","SkipReason":"testSkip","Frozen":false}
+		]
+	}`, cids[4].String(), cids[2].String(), cids[4].String()), body)
+
+	// Single-element batch returns one-entry Statuses array
+	status, _, body = postBatch(t, []string{cids[0].String()})
+	require.Equal(t, http.StatusOK, status)
+	require.JSONEq(t, fmt.Sprintf(`{"Statuses":[{"Ad":%q,"Indexed":false,"State":"unknown","Frozen":false}]}`, cids[0].String()), body)
+
+	// dag-cbor CID accepted like dag-json
+	dagCBORCid := cid.NewCidV1(cid.DagCBOR, random.Multihashes(1)[0])
+	status, _, body = postBatch(t, []string{dagCBORCid.String()})
+	require.Equal(t, http.StatusOK, status)
+	require.JSONEq(t, fmt.Sprintf(`{"Statuses":[{"Ad":%q,"Indexed":false,"State":"unknown","Frozen":false}]}`, dagCBORCid.String()), body)
+
+	// Mixed batch: two valid, "not-a-cid", raw-codec - all 200 with per-item errors
+	rawCid := cid.NewCidV1(cid.Raw, random.Multihashes(1)[0])
+	status, _, body = postBatch(t, []string{cids[0].String(), cids[1].String(), "not-a-cid", rawCid.String()})
+	require.Equal(t, http.StatusOK, status)
+	require.Contains(t, body, `"Error"`)
+	require.Contains(t, body, `"Ad":"not-a-cid"`)
+	// Error entries omit State: Frozen immediately precedes Error (no State/SkipReason between them)
+	require.Contains(t, body, `"Frozen":false,"Error"`)
+
+	// All-invalid batch still returns 200
+	status, _, body = postBatch(t, []string{"not-a-cid", "also-not-a-cid"})
+	require.Equal(t, http.StatusOK, status)
+	require.Contains(t, body, `"Statuses"`)
+
+	// 129 CIDs returns 400 with body containing 128
+	overLimit := make([]string, 129)
+	for i := range overLimit {
+		overLimit[i] = cids[0].String()
+	}
+	status, _, body = postBatch(t, overLimit)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Contains(t, body, "128")
+
+	// Empty Ads returns 400
+	emptyBody, err := json.Marshal(map[string][]string{"Ads": []string{}})
+	require.NoError(t, err)
+	res, err := http.Post(s.URL()+"/sync/status/ad", "application/json", bytes.NewReader(emptyBody))
+	require.NoError(t, err)
+	data, err := io.ReadAll(res.Body)
+	res.Body.Close()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, res.StatusCode)
+	require.Contains(t, string(data), "no advertisement CIDs")
+
+	// Malformed JSON returns 400
+	res, err = http.Post(s.URL()+"/sync/status/ad", "application/json", bytes.NewReader([]byte("not json")))
+	require.NoError(t, err)
+	data, err = io.ReadAll(res.Body)
+	res.Body.Close()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, res.StatusCode)
+	require.Contains(t, string(data), "malformed")
+
+	// Body over 1 MiB returns 400 with distinct message
+	// Send valid-looking JSON prefix + padding so decoder reads past limit before failing
+	pad := bytes.Repeat([]byte("x"), 1024*1024)
+	bigBody := append([]byte(`{"Ads":["`), pad...)
+	res, err = http.Post(s.URL()+"/sync/status/ad", "application/json", bytes.NewReader(bigBody))
+	require.NoError(t, err)
+	data, err = io.ReadAll(res.Body)
+	res.Body.Close()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, res.StatusCode)
+	require.Contains(t, string(data), "byte limit")
+	require.NotContains(t, string(data), "malformed")
+
+	// GET on /sync/status/ad returns 405 with Allow: POST header, no redirect
+	client := &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	req, err := http.NewRequest(http.MethodGet, s.URL()+"/sync/status/ad", nil)
+	require.NoError(t, err)
+	res, err = client.Do(req)
+	require.NoError(t, err)
+	res.Body.Close()
+	require.Equal(t, http.StatusMethodNotAllowed, res.StatusCode)
+	require.Equal(t, http.MethodPost, res.Header.Get("Allow"))
+
+	// Nil ingester returns 503
+	nilServer, err := httpserver.New("127.0.0.1:0", ind, nil, reg)
+	require.NoError(t, err)
+	errChan2 := make(chan error, 1)
+	go func() {
+		err := nilServer.Start()
+		if err != http.ErrServerClosed {
+			errChan2 <- err
+		}
+		close(errChan2)
+	}()
+	t.Cleanup(func() {
+		require.NoError(t, nilServer.Close())
+		require.NoError(t, <-errChan2)
+	})
+	for i := 0; i < 50; i++ {
+		res, err = http.Get(nilServer.URL() + "/health")
+		if err == nil {
+			res.Body.Close()
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	batchBody, err := json.Marshal(map[string][]string{"Ads": []string{cids[0].String()}})
+	require.NoError(t, err)
+	res, err = http.Post(nilServer.URL()+"/sync/status/ad", "application/json", bytes.NewReader(batchBody))
+	require.NoError(t, err)
+	res.Body.Close()
+	require.Equal(t, http.StatusServiceUnavailable, res.StatusCode)
+
+	// OPTIONS preflight returns 200 with Access-Control-Allow-Origin: *
+	req, err = http.NewRequest(http.MethodOptions, s.URL()+"/sync/status/ad", nil)
+	require.NoError(t, err)
+	req.Header.Set("Origin", "http://example.com")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
 	res, err = http.DefaultClient.Do(req)
 	require.NoError(t, err)
 	res.Body.Close()

--- a/server/ingest/protocol_test.go
+++ b/server/ingest/protocol_test.go
@@ -476,10 +476,10 @@ func TestAdStatusBatch(t *testing.T) {
 	require.Contains(t, string(data), "malformed")
 
 	// Body over limit returns 400 with distinct message
-	// Build valid JSON that exceeds the body size limit: {"Ads":["<cid>", " ", ...]}
-	pad := bytes.Repeat([]byte(" "), 1024*1024)
-	bigBody := append([]byte(`{"Ads":["`), pad...)
-	bigBody = append(bigBody, []byte(`"]}`)...)
+	// Build valid JSON that exceeds the body size limit with a real CID as first element.
+	// maxAdStatusBodySize = 128*128+64 = 16448; pad to that + 1024 to exceed.
+	pad := bytes.Repeat([]byte(" "), 16448+1024)
+	bigBody := []byte(`{"Ads":["` + cids[0].String() + `","` + string(pad) + `"]}`)
 	res, err = http.Post(s.URL()+"/sync/status/ad", "application/json", bytes.NewReader(bigBody))
 	require.NoError(t, err)
 	data, err = io.ReadAll(res.Body)

--- a/server/ingest/server.go
+++ b/server/ingest/server.go
@@ -30,6 +30,10 @@ var log = logging.Logger("indexer/ingest")
 // clearly in error.
 const maxBodySize = 1024 * 1024
 
+// maxAdStatusBatch is the maximum number of advertisement CIDs allowed in a
+// single batch ad-status request.
+const maxAdStatusBatch = 128
+
 type Server struct {
 	server          *http.Server
 	listener        net.Listener
@@ -80,6 +84,7 @@ func New(listen string, indexer indexer.Interface, ingester *ingest.Ingester, re
 	mux.HandleFunc("/register", s.postRegisterProvider)
 	mux.HandleFunc("/sync/status", s.listSyncStatus)
 	mux.HandleFunc("/sync/status/", s.getSyncStatus)
+	mux.HandleFunc("/sync/status/ad", s.batchAdStatus)
 	mux.HandleFunc("/sync/status/ad/", s.getAdStatus)
 
 	// Depricated
@@ -222,9 +227,34 @@ func (s *Server) getSyncStatus(w http.ResponseWriter, r *http.Request) {
 type adStatusResponse struct {
 	Ad         string `json:"Ad"`
 	Indexed    bool   `json:"Indexed"`
-	State      string `json:"State"`
+	State      string `json:"State,omitempty"`
 	SkipReason string `json:"SkipReason,omitempty"`
 	Frozen     bool   `json:"Frozen"`
+	Error      string `json:"Error,omitempty"`
+}
+
+func newAdStatusResponse(adCid cid.Cid, adState ingest.AdState) adStatusResponse {
+	resp := adStatusResponse{
+		Ad:      adCid.String(),
+		Indexed: adState.Indexed(),
+		Frozen:  adState.Frozen,
+	}
+
+	switch {
+	case !adState.Known:
+		resp.State = "unknown"
+	case adState.Resync:
+		resp.State = "resyncing"
+	case adState.Processed && adState.Skipped:
+		resp.State = "skipped"
+		resp.SkipReason = adState.SkipReason
+	case adState.Processed && !adState.Skipped:
+		resp.State = "indexed"
+	default:
+		resp.State = "pending"
+	}
+
+	return resp
 }
 
 func (s *Server) getAdStatus(w http.ResponseWriter, r *http.Request) {
@@ -265,29 +295,116 @@ func (s *Server) getAdStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp := adStatusResponse{
-		Ad:      adCid.String(),
-		Indexed: adState.Indexed(),
-		Frozen:  adState.Frozen,
-	}
-
-	switch {
-	case !adState.Known:
-		resp.State = "unknown"
-	case adState.Resync:
-		resp.State = "resyncing"
-	case adState.Processed && adState.Skipped:
-		resp.State = "skipped"
-		resp.SkipReason = adState.SkipReason
-	case adState.Processed && !adState.Skipped:
-		resp.State = "indexed"
-	default:
-		resp.State = "pending"
-	}
+	resp := newAdStatusResponse(adCid, adState)
 
 	data, err := json.Marshal(resp)
 	if err != nil {
 		log.Errorw("cannot marshal advertisement status", "err", err)
+		http.Error(w, "", http.StatusInternalServerError)
+		return
+	}
+
+	httpserver.WriteJsonResponse(w, http.StatusOK, data)
+}
+
+type batchAdStatusRequest struct {
+	Ads []string `json:"Ads"`
+}
+
+type batchAdStatusResponse struct {
+	Statuses []adStatusResponse `json:"Statuses"`
+}
+
+func (s *Server) batchAdStatus(w http.ResponseWriter, r *http.Request) {
+	httpserver.EnableCors(w)
+
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed; use POST for batch or GET /sync/status/ad/<cid> for single advertisement", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if _, ok := httpserver.AcceptsMediaType(w, r, false, httpserver.MediaTypeJson, httpserver.MediaTypeAny); !ok {
+		return
+	}
+
+	bodyReader := http.MaxBytesReader(w, r.Body, maxBodySize)
+	defer r.Body.Close()
+
+	var req batchAdStatusRequest
+	if err := json.NewDecoder(bodyReader).Decode(&req); err != nil {
+		http.Error(w, "malformed request body", http.StatusBadRequest)
+		return
+	}
+
+	if len(req.Ads) == 0 {
+		http.Error(w, "no advertisement CIDs provided", http.StatusBadRequest)
+		return
+	}
+
+	if len(req.Ads) > maxAdStatusBatch {
+		msg := fmt.Sprintf("batch size %d exceeds limit of %d", len(req.Ads), maxAdStatusBatch)
+		http.Error(w, msg, http.StatusBadRequest)
+		return
+	}
+
+	if s.ingester == nil {
+		http.Error(w, "ingester not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	results := make([]adStatusResponse, len(req.Ads))
+	var validCids []struct {
+		idx int
+		cid cid.Cid
+	}
+
+	for i, raw := range req.Ads {
+		adCid, err := cid.Decode(raw)
+		if err != nil {
+			results[i] = adStatusResponse{
+				Ad:    raw,
+				Error: "cannot decode advertisement cid",
+			}
+			continue
+		}
+
+		if adCid.Prefix().Codec != cid.DagJSON && adCid.Prefix().Codec != cid.DagCBOR {
+			results[i] = adStatusResponse{
+				Ad:    adCid.String(),
+				Error: fmt.Sprintf("this endpoint expects an advertisement CID (dag-json or dag-cbor codec), got %d; use /cid/%s for content lookups", adCid.Prefix().Codec, adCid.String()),
+			}
+			continue
+		}
+
+		validCids = append(validCids, struct {
+			idx int
+			cid cid.Cid
+		}{i, adCid})
+	}
+
+	if len(validCids) > 0 {
+		cids := make([]cid.Cid, len(validCids))
+		for i, v := range validCids {
+			cids[i] = v.cid
+		}
+
+		adStates, err := s.ingester.GetAdStates(r.Context(), cids)
+		if err != nil {
+			log.Errorw("Failed to read advertisement states", "err", err)
+			http.Error(w, "", http.StatusInternalServerError)
+			return
+		}
+
+		for i, st := range adStates {
+			results[validCids[i].idx] = newAdStatusResponse(validCids[i].cid, st)
+		}
+	}
+
+	resp := batchAdStatusResponse{Statuses: results}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		log.Errorw("cannot marshal batch advertisement status", "err", err)
 		http.Error(w, "", http.StatusInternalServerError)
 		return
 	}

--- a/server/ingest/server.go
+++ b/server/ingest/server.go
@@ -258,7 +258,7 @@ func (s *Server) getAdStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	adState, err := s.ingester.GetAdState(adCid)
+	adState, err := s.ingester.GetAdState(r.Context(), adCid)
 	if err != nil {
 		log.Errorw("Failed to read advertisement processed state", "adCid", adCid, "err", err)
 		http.Error(w, "", http.StatusInternalServerError)

--- a/server/ingest/server.go
+++ b/server/ingest/server.go
@@ -318,6 +318,8 @@ type batchAdStatusResponse struct {
 func (s *Server) batchAdStatus(w http.ResponseWriter, r *http.Request) {
 	httpserver.EnableCors(w)
 
+	// Hand-rolled method check (not httpserver.MethodOK) so we can set Allow
+	// header and give a message that directs single-CID callers to the GET endpoint.
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", http.MethodPost)
 		http.Error(w, "method not allowed; use POST for batch or GET /sync/status/ad/<cid> for single advertisement", http.StatusMethodNotAllowed)
@@ -333,6 +335,11 @@ func (s *Server) batchAdStatus(w http.ResponseWriter, r *http.Request) {
 
 	var req batchAdStatusRequest
 	if err := json.NewDecoder(bodyReader).Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			http.Error(w, fmt.Sprintf("request body exceeds %d byte limit", maxBodySize), http.StatusBadRequest)
+			return
+		}
 		http.Error(w, "malformed request body", http.StatusBadRequest)
 		return
 	}
@@ -354,14 +361,16 @@ func (s *Server) batchAdStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	results := make([]adStatusResponse, len(req.Ads))
-	var validCids []struct {
+	type indexedCid struct {
 		idx int
 		cid cid.Cid
 	}
+	var validCids []indexedCid
 
 	for i, raw := range req.Ads {
 		adCid, err := cid.Decode(raw)
 		if err != nil {
+			log.Debugw("cannot decode advertisement cid in batch", "raw", raw, "err", err)
 			results[i] = adStatusResponse{
 				Ad:    raw,
 				Error: "cannot decode advertisement cid",
@@ -377,10 +386,7 @@ func (s *Server) batchAdStatus(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		validCids = append(validCids, struct {
-			idx int
-			cid cid.Cid
-		}{i, adCid})
+		validCids = append(validCids, indexedCid{i, adCid})
 	}
 
 	if len(validCids) > 0 {

--- a/server/ingest/server.go
+++ b/server/ingest/server.go
@@ -322,6 +322,10 @@ func (s *Server) batchAdStatus(w http.ResponseWriter, r *http.Request) {
 	// header and give a message that directs single-CID callers to the GET endpoint.
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", http.MethodPost)
+		if r.Method == http.MethodOptions {
+			http.Error(w, "", http.StatusOK)
+			return
+		}
 		http.Error(w, "method not allowed; use POST for batch or GET /sync/status/ad/<cid> for single advertisement", http.StatusMethodNotAllowed)
 		return
 	}

--- a/server/ingest/server.go
+++ b/server/ingest/server.go
@@ -89,6 +89,10 @@ func New(listen string, indexer indexer.Interface, ingester *ingest.Ingester, re
 	mux.HandleFunc("/register", s.postRegisterProvider)
 	mux.HandleFunc("/sync/status", s.listSyncStatus)
 	mux.HandleFunc("/sync/status/", s.getSyncStatus)
+	// Registered as an exact path (not a method pattern) because the sibling subtree
+	// pattern on the next line causes ServeMux to respond to a method mismatch on the
+	// bare path with a 301 redirect to the subtree rather than a 405; clients follow
+	// that redirect by converting POST to GET and dropping the request body.
 	mux.HandleFunc("/sync/status/ad", s.batchAdStatus)
 	mux.HandleFunc("/sync/status/ad/", s.getAdStatus)
 
@@ -331,12 +335,9 @@ type batchAdStatusResponse struct {
 func (s *Server) batchAdStatus(w http.ResponseWriter, r *http.Request) {
 	httpserver.EnableCors(w)
 
-	// Hand-rolled method check (not httpserver.MethodOK) so we can set Allow
-	// header and give a message that directs single-CID callers to the GET endpoint.
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", http.MethodPost)
 		if r.Method == http.MethodOptions {
-			// Mirrors httpserver.MethodOK: respond 200 to CORS preflight.
 			http.Error(w, "", http.StatusOK)
 			return
 		}
@@ -353,8 +354,7 @@ func (s *Server) batchAdStatus(w http.ResponseWriter, r *http.Request) {
 
 	var req batchAdStatusRequest
 	if err := json.NewDecoder(bodyReader).Decode(&req); err != nil {
-		var maxErr *http.MaxBytesError
-		if errors.As(err, &maxErr) {
+		if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
 			http.Error(w, fmt.Sprintf("request body exceeds %d byte limit", maxAdStatusBodySize), http.StatusBadRequest)
 			return
 		}
@@ -379,7 +379,8 @@ func (s *Server) batchAdStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	results := make([]adStatusResponse, len(req.Ads))
-	validCids := make([]cid.Cid, len(req.Ads))
+	cids := make([]cid.Cid, 0, len(req.Ads))
+	idxs := make([]int, 0, len(req.Ads))
 
 	for i, raw := range req.Ads {
 		adCid, err := cid.Decode(raw)
@@ -400,17 +401,8 @@ func (s *Server) batchAdStatus(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		validCids[i] = adCid
-	}
-
-	// Collect valid CIDs and their indices, preserving request order.
-	cids := make([]cid.Cid, 0, len(req.Ads))
-	idxs := make([]int, 0, len(req.Ads))
-	for i, c := range validCids {
-		if c != cid.Undef {
-			idxs = append(idxs, i)
-			cids = append(cids, c)
-		}
+		cids = append(cids, adCid)
+		idxs = append(idxs, i)
 	}
 
 	if len(cids) > 0 {

--- a/server/ingest/server.go
+++ b/server/ingest/server.go
@@ -323,6 +323,7 @@ func (s *Server) batchAdStatus(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", http.MethodPost)
 		if r.Method == http.MethodOptions {
+			// Mirrors httpserver.MethodOK: respond 200 to CORS preflight.
 			http.Error(w, "", http.StatusOK)
 			return
 		}

--- a/server/ingest/server.go
+++ b/server/ingest/server.go
@@ -34,6 +34,11 @@ const maxBodySize = 1024 * 1024
 // single batch ad-status request.
 const maxAdStatusBatch = 128
 
+// maxAdStatusBodySize is the maximum request body size for the batch ad-status
+// endpoint. Sized as 128 bytes per CID (worst-case base32 encoding) plus JSON
+// overhead, so a full 128-CID batch fits comfortably.
+const maxAdStatusBodySize = 128*maxAdStatusBatch + 64
+
 type Server struct {
 	server          *http.Server
 	listener        net.Listener
@@ -224,6 +229,15 @@ func (s *Server) getSyncStatus(w http.ResponseWriter, r *http.Request) {
 	httpserver.WriteJsonResponse(w, http.StatusOK, data)
 }
 
+// adCidCodecError returns a non-empty error message when the CID's codec is not
+// dag-json or dag-cbor, or empty string when the codec is acceptable.
+func adCidCodecError(adCid cid.Cid) string {
+	if adCid.Prefix().Codec != cid.DagJSON && adCid.Prefix().Codec != cid.DagCBOR {
+		return fmt.Sprintf("this endpoint expects an advertisement CID (dag-json or dag-cbor codec), got %d; use /cid/%s for content lookups", adCid.Prefix().Codec, adCid.String())
+	}
+	return ""
+}
+
 type adStatusResponse struct {
 	Ad         string `json:"Ad"`
 	Indexed    bool   `json:"Indexed"`
@@ -276,8 +290,7 @@ func (s *Server) getAdStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if adCid.Prefix().Codec != cid.DagJSON && adCid.Prefix().Codec != cid.DagCBOR {
-		msg := fmt.Sprintf("this endpoint expects an advertisement CID (dag-json or dag-cbor codec), got %d; use /cid/%s for content lookups", adCid.Prefix().Codec, cidStr)
+	if msg := adCidCodecError(adCid); msg != "" {
 		log.Debugw(msg, "cid", cidStr)
 		http.Error(w, msg, http.StatusBadRequest)
 		return
@@ -335,14 +348,14 @@ func (s *Server) batchAdStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	bodyReader := http.MaxBytesReader(w, r.Body, maxBodySize)
+	bodyReader := http.MaxBytesReader(w, r.Body, maxAdStatusBodySize)
 	defer r.Body.Close()
 
 	var req batchAdStatusRequest
 	if err := json.NewDecoder(bodyReader).Decode(&req); err != nil {
 		var maxErr *http.MaxBytesError
 		if errors.As(err, &maxErr) {
-			http.Error(w, fmt.Sprintf("request body exceeds %d byte limit", maxBodySize), http.StatusBadRequest)
+			http.Error(w, fmt.Sprintf("request body exceeds %d byte limit", maxAdStatusBodySize), http.StatusBadRequest)
 			return
 		}
 		http.Error(w, "malformed request body", http.StatusBadRequest)
@@ -366,11 +379,7 @@ func (s *Server) batchAdStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	results := make([]adStatusResponse, len(req.Ads))
-	type indexedCid struct {
-		idx int
-		cid cid.Cid
-	}
-	var validCids []indexedCid
+	validCids := make([]cid.Cid, len(req.Ads))
 
 	for i, raw := range req.Ads {
 		adCid, err := cid.Decode(raw)
@@ -383,23 +392,28 @@ func (s *Server) batchAdStatus(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		if adCid.Prefix().Codec != cid.DagJSON && adCid.Prefix().Codec != cid.DagCBOR {
+		if msg := adCidCodecError(adCid); msg != "" {
 			results[i] = adStatusResponse{
 				Ad:    adCid.String(),
-				Error: fmt.Sprintf("this endpoint expects an advertisement CID (dag-json or dag-cbor codec), got %d; use /cid/%s for content lookups", adCid.Prefix().Codec, adCid.String()),
+				Error: msg,
 			}
 			continue
 		}
 
-		validCids = append(validCids, indexedCid{i, adCid})
+		validCids[i] = adCid
 	}
 
-	if len(validCids) > 0 {
-		cids := make([]cid.Cid, len(validCids))
-		for i, v := range validCids {
-			cids[i] = v.cid
+	// Collect valid CIDs and their indices, preserving request order.
+	cids := make([]cid.Cid, 0, len(req.Ads))
+	idxs := make([]int, 0, len(req.Ads))
+	for i, c := range validCids {
+		if c != cid.Undef {
+			idxs = append(idxs, i)
+			cids = append(cids, c)
 		}
+	}
 
+	if len(cids) > 0 {
 		adStates, err := s.ingester.GetAdStates(r.Context(), cids)
 		if err != nil {
 			log.Errorw("Failed to read advertisement states", "err", err)
@@ -408,7 +422,7 @@ func (s *Server) batchAdStatus(w http.ResponseWriter, r *http.Request) {
 		}
 
 		for i, st := range adStates {
-			results[validCids[i].idx] = newAdStatusResponse(validCids[i].cid, st)
+			results[idxs[i]] = newAdStatusResponse(cids[i], st)
 		}
 	}
 


### PR DESCRIPTION
## Context

The `/sync/status/ad/<cid>` endpoint only supports single-advertisement lookups. This closes #2881 which asks for the endpoint to accept multiple advertisement CIDs in a single call.

## Proposed Changes

- **New `POST /sync/status/ad` batch endpoint**: accepts `{"Ads": ["<cid>", ...]}` and returns `{"Statuses": [...]}` with one entry per submitted position, in request order, duplicates answered per position. Batch size is limited to 128 CIDs and the body to 1 MiB. 

- **Per-item validation**: an undecodable CID or an unsupported codec produces an entry carrying an `Error` field with `State` omitted, and the remaining entries are still answered. 

- **`GetAdStates` batch method on Ingester**: looks up state for multiple CIDs, sharing the single-ad read path exactly so the two cannot diverge, and deduplicating datastore reads for repeated CIDs.

- **Context threading**: `GetAdState`, `GetAdStates`, and `adAlreadyProcessed` now accept `context.Context`, and the HTTP handler passes the request context through, so a client disconnect cancels the datastore reads.

- **Updated `doc/ingestion.md`**: documented the batch endpoint, the limits, the per-item versus request-level error split, and the GET preference for single-ad checks.

## Tests

- `TestAdStatusBatch`: covers all five states in a single request asserted positionally against the whole response body, frozen ads, reversed order with a duplicated CID, a single-element batch, and dag-cbor accepted alongside dag-json. 

- `TestGetAdStates` and companions (`TestGetAdStatesOrderAndDedup`, `TestGetAdStatesFrozen`, `TestGetAdStatesEmpty`, `TestGetAdStatesErrorNoPartial`): prove that every batch entry equals the corresponding single `GetAdState` call, plus order preservation, duplicate handling, frozen state, empty input, and that a corrupt marker value returns an error with no partial results.

- Existing assertions in `TestAdStatus` are unchanged, which is the evidence that the single-CID endpoint behaves identically to before.

## Revert Strategy

Change is safe to revert.