### PR TITLE
build: ship cross-announce in the published image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /ipnigc
 /storetheindex
+/cross-announce
 *~
 *.car
 *.out

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,13 @@ RUN go mod download
 COPY . .
 
 RUN CGO_ENABLED=1 go build
+# CGO_ENABLED differs from the line above, so this step shares no build cache and recompiles the dependency graph.
+RUN CGO_ENABLED=0 go build -o cross-announce ./scripts/cross_announce
 
 # Debug non-root image used as base in order to provide easier administration and debugging.
 FROM gcr.io/distroless/cc:debug-nonroot
 COPY --from=builder /storetheindex/storetheindex /usr/local/bin/
+COPY --from=builder /storetheindex/cross-announce /usr/local/bin/
 
 # Default port configuration:
 #  - 3000 Finder interface
@@ -19,5 +22,6 @@ COPY --from=builder /storetheindex/storetheindex /usr/local/bin/
 # Note: exposed ports below will have no effect if the default config is overridden.
 EXPOSE 3000-3003
 
+# The image also contains /usr/local/bin/cross-announce. Run it by overriding the entrypoint or command.
 ENTRYPOINT ["/usr/local/bin/storetheindex"]
 CMD ["daemon"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BIN := storetheindex
 
-.PHONY: all build clean test
+.PHONY: all build clean test cross-announce
 
 all: vet test build
 
@@ -24,3 +24,7 @@ vet:
 
 clean:
 	go clean
+	rm -f cross-announce
+
+cross-announce:
+	go build -o cross-announce ./scripts/cross_announce

--- a/scripts/cross_announce/README.md
+++ b/scripts/cross_announce/README.md
@@ -1,0 +1,48 @@
+# cross-announce
+
+Cross-announce propagates provider registrations from one IPNI indexer to another. It lists all providers on a source indexer, then sends an announce request for each to a target indexer. The tool only transfers advertisement pointers; it does not copy or sync index data. The target indexer fetches advertisement chains independently after receiving an announcement.
+
+## Flags
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `-source` | (empty) | Base URL of the source indexer. Must point to the find API (default port 3000). |
+| `-target` | (empty) | Base URL of the target indexer. Must point to the ingest API (default port 3001). |
+| `-pid` | (empty) | If set, only announce the provider with this peer ID. Omit to announce all providers. |
+| `-help` | `false` | Print usage text and exit. |
+
+## Port distinction
+
+The `-source` URL must target the **find** interface (port 3000 by default) because the tool reads provider listings through the find API. The `-target` URL must target the **ingest** interface (port 3001 by default) because announcements are submitted through the ingest API. The client constructors only parse these URLs, so a wrong port is not rejected up front; it fails later, when the provider listing or the announce request is made.
+
+## Container invocation
+
+The binary is included in the published `storetheindex` image. Override the default entrypoint to run it:
+
+```bash
+docker run --rm \
+  --entrypoint /usr/local/bin/cross-announce \
+  ghcr.io/ipni/storetheindex@sha256:abcd1234... \
+  -source http://source-indexer:3000 \
+  -target http://target-indexer:3001
+```
+
+Pin the image by digest rather than tag to ensure a reproducible binary.
+
+The usage text printed by `-help` shows a `go run ./scripts/cross_announce/main.go` invocation. That path does not exist inside the image; use the binary at `/usr/local/bin/cross-announce` as shown above.
+
+## Verification
+
+After a run, use `scripts/compare_providers` to verify that providers on the source and target are in sync:
+
+```bash
+go run ./scripts/compare_providers/main.go \
+  -source http://source-indexer:3000 \
+  -target http://target-indexer:3000
+```
+
+Note that compare_providers queries the find API (port 3000) on both indexers.
+
+## Warning
+
+This tool has previously triggered full advertisement chain resyncs on target indexers. Do not point it at a production indexer without first reading and understanding the current flag set and the state of both indexers. Use `-pid` to limit scope when testing.


### PR DESCRIPTION
Builds `scripts/cross_announce` in the Dockerfile builder stage and copies the binary into the runtime image alongside `storetheindex`, so deployed cronjobs can run it from the published image instead of cloning and compiling from source on every run.

`ENTRYPOINT` and `CMD` are unchanged; `cross-announce` is run by overriding the entrypoint. Also adds a `make cross-announce` target, a `.gitignore` entry so a local build is not swept into the image build context by `COPY . .`, and a README for the tool.

Packaging and docs only. No Go source changed.

### Notes

- The `cross-announce` build uses `CGO_ENABLED=0`, which differs from the `storetheindex` build above it, so the two steps share no build cache and the dependency graph is compiled twice. Verified the tool builds without cgo.
- `distroless/cc` ships libc, so either linking mode works in the runtime image.
- The README documents that this tool has previously triggered full advertisement chain resyncs on targets, and that it must not be pointed at a production indexer without first reading the current flag set.

### Verification

- `docker build .` succeeds.
- `docker run --rm --entrypoint /usr/local/bin/cross-announce <image> --help` prints the usage text, exit 0.
- Default entrypoint still starts `storetheindex daemon`.
- `make cross-announce` produces a working binary; `make clean` removes it.
- `git diff --stat` confirms no Go source changed.

The full `go test ./...` suite was not run; the diff is packaging and docs only and cannot affect it.

### Follow-up

The usage text in `scripts/cross_announce/main.go` still points at `go run ./scripts/cross_announce/main.go`, a path that does not exist inside the image. The README notes this; correcting the string itself needs a Go change and is left to the follow-up branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)