### PR TITLE
Switch to jemalloc allocator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,20 @@ COPY . .
 
 RUN CGO_ENABLED=1 go build
 
+FROM debian:bookworm-slim AS jemalloc
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libjemalloc2 \
+    && rm -rf /var/lib/apt/lists/*
+
 # Debug non-root image used as base in order to provide easier administration and debugging.
+# distroless/cc includes libstdc++, which Debian jemalloc requires.
 FROM gcr.io/distroless/cc:debug-nonroot
 COPY --from=builder /storetheindex/storetheindex /usr/local/bin/
+COPY --from=jemalloc \
+    /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
+    /usr/lib/x86_64-linux-gnu/
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV MALLOC_CONF=background_thread:true,dirty_decay_ms:5000,muzzy_decay_ms:5000
 
 # Default port configuration:
 #  - 3000 Finder interface

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.26-bookworm as builder
+FROM golang:1.26-bookworm AS builder
 
 WORKDIR /storetheindex
 COPY go.* .
-RUN go mod download
+RUN go mod download -x
 COPY . .
 
 RUN CGO_ENABLED=1 go build


### PR DESCRIPTION
## Context

Avoid unbound memory growth by switching to jemalloc allocator when using pebble as keyvalue store.

## Proposed Changes

Alter Dockerfile to use jemalloc allocator.

## Tests

Manual tests

## Revert Strategy

Code revert