### PR TITLE
Fix legacy config migration

### DIFF
--- a/config/mirror.go
+++ b/config/mirror.go
@@ -126,19 +126,20 @@ func (c *Mirror) PopulateUnset() {
 // UnmarshalJSON loads Mirror config, accepting legacy Read/Write,
 // Retrieval/Storage, and top-level Compress fields and converting them to
 // MainMode/Main/External with per-store Compress.
-// FallbackRetrieval from unreleased configs is ignored.
 func (c *Mirror) UnmarshalJSON(data []byte) error {
-	aux := mirrorJSON{mirrorPlain: (*mirrorPlain)(c)}
+	aux := mirrorJSON{mirrorPlain: &mirrorPlain{}}
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
 	}
-	if err := c.convertLegacy(aux); err != nil {
+	m := (*Mirror)(aux.mirrorPlain)
+	if err := m.convertLegacy(aux); err != nil {
 		return err
 	}
-	if !c.MainMode.Valid() {
+	if !m.MainMode.Valid() {
 		return fmt.Errorf("invalid AdvertisementMirror.MainMode %q; want one of: %q, %q, %q, %q, %q",
-			c.MainMode, MainModeUnspecified, MainModeNone, MainModeRead, MainModeWrite, MainModeReadWrite)
+			m.MainMode, MainModeUnspecified, MainModeNone, MainModeRead, MainModeWrite, MainModeReadWrite)
 	}
+	*c = *m
 	return nil
 }
 

--- a/config/mirror_test.go
+++ b/config/mirror_test.go
@@ -262,6 +262,30 @@ func TestMirrorUnmarshalMixedCompressStylesError(t *testing.T) {
 	require.Contains(t, err.Error(), "mixes legacy top-level Compress")
 }
 
+// config.Load seeds AdvertisementMirror with NewMirror() before Decode. Legacy
+// configs with top-level Compress must still load against those defaults.
+func TestMirrorUnmarshalLegacyIntoNewMirrorDefaults(t *testing.T) {
+	m := config.NewMirror()
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"Read": true,
+		"Write": true,
+		"Compress": "gzip",
+		"Storage": {
+			"Type": "local",
+			"Local": {"BasePath": "/mirror", "DefaultPathSplit": [11, 2]}
+		},
+		"Retrieval": {
+			"Type": "local",
+			"Local": {"BasePath": "/mirror", "DefaultPathSplit": [11, 2]}
+		}
+	}`), &m))
+	require.Equal(t, config.MainModeReadWrite, m.MainMode)
+	require.Equal(t, "gzip", m.Main.Compress)
+	require.Equal(t, "local", m.Main.Type)
+	require.Equal(t, "/mirror", m.Main.Local.BasePath)
+	require.Empty(t, m.External)
+}
+
 func TestMirrorUnmarshalInvalidMainMode(t *testing.T) {
 	var m config.Mirror
 	err := json.Unmarshal([]byte(`{"MainMode": "nope"}`), &m)


### PR DESCRIPTION
## Context

Can't run storetheindex with existing configuration using carmirror.

## Proposed Changes

When unmarshaling from a JSON data, start with a clean structure before the unmarshal is done to avoid defaults messing up with the data.

## Tests

Dedicated unit test for loading the legacy configuration.

## Revert Strategy

Code revert.