### PR TITLE
Store and report indexing time

### DIFF
--- a/doc/ingestion.md
+++ b/doc/ingestion.md
@@ -330,9 +330,14 @@ Ingestion markers (`ingest.go`):
 - `syncPrefix` (`/sync/<publisherID>`) -> CID bytes of the latest fully
   processed ad for a publisher (`GetLatestSync` / `getLastKnownSync`).
 - `adProcessedPrefix` (`/adProcessed/<adCid>`) -> marks an ad state
-  (used to stop chain walks and skip re-processing). Value is a single byte:
-  `0` = unprocessed, `1` = processed, `2` = marked for resync,
-  `3` = permanently skipped (will not be retried).
+  (used to stop chain walks and skip re-processing). Value starts with a
+  single marker byte: `0` = unprocessed, `1` = processed, `2` = marked for
+  resync, `3` = permanently skipped (will not be retried). Processed (`1`)
+  and skipped (`3`) markers written by current code are followed by 8
+  bytes holding little-endian microseconds since the Unix epoch recording
+  when the marker was written (9 bytes total). Legacy records are
+  marker-only (1 byte) and have no timestamp. Readers accept trailing
+  bytes after the timestamp.
 - `adSkipReasonPrefix` (`/adSkipReason/<adCid>`) -> sidecar string stored
   alongside the `3` marker, explaining why the ad was permanently skipped
   (e.g. decoding error, malformed, entry chunk error, content not found).
@@ -490,7 +495,11 @@ The response includes:
 - `Ad` - the requested advertisement CID
 - `Indexed` - true only when the ad was fully processed while the indexer was
   not frozen, and is not currently marked for resync
-  (`Processed && !Resync && !Frozen` from `AdState`)
+  (`Processed && !Skipped && !Resync && !Frozen` from `AdState`)
+- `IndexedTime` - UTC RFC3339 timestamp with microsecond precision of when
+  the ad was last marked processed, present only when `Indexed` is true and
+  the stored marker includes a timestamp. Ads processed before timestamps
+  were stored (legacy 1-byte markers) omit this field.
 - `State` - one of `"unknown"`, `"pending"`, `"indexed"`, `"skipped"`, or
   `"resyncing"`:
   - `"unknown"` - the ad is not known to the ingester
@@ -510,12 +519,12 @@ The response includes:
   multihashes were not indexed)
 - the ad is marked for resync (previous processing is treated as invalidated
   until the ad is processed again)
+- the ad was permanently skipped
 
-`Indexed` now distinguishes permanent skips from successful processing: ads
+`Indexed` distinguishes permanent skips from successful processing: ads
 that fail with a permanent error (malformed, decoding, content-not-found, etc.)
 are marked with the `3` (skipped) marker and report `Skipped: true`,
-`Indexed: false`. Timestamps and provider identity are not stored per ad and
-are not returned.
+`Indexed: false`. Provider identity is not stored per ad and is not returned.
 
 See [`internal/ingest/syncstatus.go`](../internal/ingest/syncstatus.go) for
 the tracker. The ingest HTTP handlers marshal tracker snapshots to JSON.

--- a/doc/ingestion.md
+++ b/doc/ingestion.md
@@ -510,6 +510,10 @@ The response includes:
   - `"skipped"` - the ad was permanently skipped (malformed, decode error, etc.)
   - `"resyncing"` - the ad is marked for resync (previous processing invalidated)
 - `SkipReason` - the skip reason string (truncated to 256 bytes), non-empty only when `State` is `"skipped"`
+- `SkippedTime` - UTC RFC3339 timestamp with microsecond precision of when
+  the ad was last marked skipped, present only when `State` is `"skipped"`
+  and the stored marker includes a timestamp. Legacy 1-byte skipped markers
+  omit this field.
 - `Frozen` - true when the ad was processed while the indexer was in frozen mode
 
 `Indexed` is false when:

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -618,6 +618,7 @@ type AdState struct {
 	Resync      bool
 	Frozen      bool
 	IndexedTime *time.Time
+	SkippedTime *time.Time
 }
 
 // Indexed reports whether the advertisement's content should be considered
@@ -642,7 +643,9 @@ func (s AdState) Indexed() bool {
 // provider metadata but does not index entry multihashes. Known is false when
 // the ad has never been seen (datastore.ErrNotFound). IndexedTime is set only
 // when Indexed() is true and the stored marker includes a modification
-// timestamp; ads recorded before timestamps were stored have a nil IndexedTime.
+// timestamp. SkippedTime is set only when the ad is skipped and the stored
+// marker includes a modification timestamp. Ads recorded before timestamps
+// were stored have nil IndexedTime and SkippedTime.
 func (ing *Ingester) GetAdState(ctx context.Context, adCid cid.Cid) (state AdState, err error) {
 	adState, err := ing.adAlreadyProcessed(ctx, adCid)
 	if err != nil {
@@ -671,12 +674,17 @@ func (ing *Ingester) GetAdState(ctx context.Context, adCid cid.Cid) (state AdSta
 		state.Frozen = true
 	}
 
-	// IndexedTime is only reported for ads whose content is currently
-	// considered indexed. Frozen must be loaded first so Indexed() is
+	// IndexedTime and SkippedTime are reported from the same stored
+	// ModifiedAt value. Frozen must be loaded first so Indexed() is
 	// accurate. Legacy 1-byte markers have ModifiedAt == 0.
-	if state.Indexed() && adState.ModifiedAt != 0 {
+	if adState.ModifiedAt != 0 {
 		unixMicros := time.UnixMicro(int64(adState.ModifiedAt)).UTC()
-		state.IndexedTime = &unixMicros
+		switch {
+		case state.Indexed():
+			state.IndexedTime = &unixMicros
+		case state.Skipped:
+			state.SkippedTime = &unixMicros
+		}
 	}
 
 	return state, nil

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -2,6 +2,7 @@ package ingest
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -48,10 +49,20 @@ const (
 	adSkipReasonPrefix = "/adSkipReason/"
 	// Marker byte values for /adProcessed/<cid>.
 	// Explicit values; these are a persisted on-disk format.
+	//
+	// The stored value is the marker byte, optionally followed by 8
+	// bytes holding little-endian microseconds since the Unix epoch
+	// recording when the marker was last written. Legacy records are
+	// marker-only (1 byte); current writes of processed and skipped
+	// markers are 9 bytes. Readers accept trailing bytes after the
+	// timestamp.
 	adMarkerUnprocessed byte = 0 // unprocessed
 	adMarkerProcessed   byte = 1 // processed successfully
 	adMarkerResync      byte = 2 // marked for resync
 	adMarkerSkipped     byte = 3 // processed but permanently skipped
+	// adProcessedMarkerTimeLen is the size of the optional unix-microseconds
+	// suffix stored after the marker byte.
+	adProcessedMarkerTimeLen = 8
 	// metricsUpdateInterval determines how ofter to update ingestion metrics.
 	metricsUpdateInterval = time.Minute
 	// adsScannedLogInterval is how often to log ad-chain scanning progress.
@@ -567,10 +578,11 @@ func (ing *Ingester) markAdUnprocessed(adCid cid.Cid, forResync bool) error {
 }
 
 type adProcessedState struct {
-	Known     bool
-	Processed bool
-	Skipped   bool
-	Resync    bool
+	Known      bool
+	Processed  bool
+	Skipped    bool
+	Resync     bool
+	ModifiedAt uint64
 }
 
 func (ing *Ingester) adAlreadyProcessed(ctx context.Context, adCid cid.Cid) (adProcessedState, error) {
@@ -583,21 +595,29 @@ func (ing *Ingester) adAlreadyProcessed(ctx context.Context, adCid cid.Cid) (adP
 	if len(v) == 0 {
 		return adProcessedState{}, fmt.Errorf("empty value for ad processed marker %s", adCid)
 	}
-	return adProcessedState{
+
+	state := adProcessedState{
 		Known:     true,
 		Processed: v[0] == adMarkerProcessed || v[0] == adMarkerSkipped,
 		Skipped:   v[0] == adMarkerSkipped,
 		Resync:    v[0] == adMarkerResync,
-	}, nil
+	}
+
+	if len(v) >= 1+adProcessedMarkerTimeLen {
+		state.ModifiedAt = binary.LittleEndian.Uint64(v[1:])
+	}
+
+	return state, nil
 }
 
 type AdState struct {
-	Known      bool
-	Processed  bool
-	Skipped    bool
-	SkipReason string
-	Resync     bool
-	Frozen     bool
+	Known       bool
+	Processed   bool
+	Skipped     bool
+	SkipReason  string
+	Resync      bool
+	Frozen      bool
+	IndexedTime *time.Time
 }
 
 // Indexed reports whether the advertisement's content should be considered
@@ -620,7 +640,9 @@ func (s AdState) Indexed() bool {
 // marked for resync (value 2). Frozen is true when the ad was processed while
 // the indexer was in frozen mode (/adF/ key present); frozen processing updates
 // provider metadata but does not index entry multihashes. Known is false when
-// the ad has never been seen (datastore.ErrNotFound).
+// the ad has never been seen (datastore.ErrNotFound). IndexedTime is set only
+// when Indexed() is true and the stored marker includes a modification
+// timestamp; ads recorded before timestamps were stored have a nil IndexedTime.
 func (ing *Ingester) GetAdState(ctx context.Context, adCid cid.Cid) (state AdState, err error) {
 	adState, err := ing.adAlreadyProcessed(ctx, adCid)
 	if err != nil {
@@ -647,6 +669,14 @@ func (ing *Ingester) GetAdState(ctx context.Context, adCid cid.Cid) (state AdSta
 		return state, err
 	default:
 		state.Frozen = true
+	}
+
+	// IndexedTime is only reported for ads whose content is currently
+	// considered indexed. Frozen must be loaded first so Indexed() is
+	// accurate. Legacy 1-byte markers have ModifiedAt == 0.
+	if state.Indexed() && adState.ModifiedAt != 0 {
+		unixMicros := time.UnixMicro(int64(adState.ModifiedAt)).UTC()
+		state.IndexedTime = &unixMicros
 	}
 
 	return state, nil
@@ -702,6 +732,13 @@ func (ing *Ingester) MarkAdSkipped(publisher peer.ID, adCid cid.Cid, reason stri
 	return ing.writeAdMarker(publisher, adCid, adMarkerSkipped, frozen, false)
 }
 
+func encodeAdProcessedMarker(marker byte, modifiedAt time.Time) []byte {
+	var buf [1 + adProcessedMarkerTimeLen]byte
+	buf[0] = marker
+	binary.LittleEndian.PutUint64(buf[1:], uint64(modifiedAt.UnixMicro()))
+	return buf[:]
+}
+
 func (ing *Ingester) writeAdMarker(publisher peer.ID, adCid cid.Cid, marker byte, frozen, mirrored bool) error {
 	cidStr := adCid.String()
 	ctx := context.Background()
@@ -712,7 +749,11 @@ func (ing *Ingester) writeAdMarker(publisher peer.ID, adCid cid.Cid, marker byte
 		}
 	}
 
-	err := ing.ds.Put(ctx, datastore.NewKey(adProcessedPrefix+cidStr), []byte{marker})
+	err := ing.ds.Put(
+		ctx,
+		datastore.NewKey(adProcessedPrefix+cidStr),
+		encodeAdProcessedMarker(marker, time.Now()),
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -2395,14 +2395,14 @@ func requireIndexedEventually(t *testing.T, ix indexer.Interface, p peer.ID, mhs
 	}, testRetryTimeout, testRetryInterval, "Expected all multihashes from %s to have been indexed eventually", p.String())
 }
 
-func verifyIndexedTime(t *testing.T, got *time.Time, notBefore, notAfter time.Time) {
+func verifyStatusTime(t *testing.T, got *time.Time, notBefore, notAfter time.Time) {
 	t.Helper()
 	require.NotNil(t, got)
 	require.Equal(t, time.UTC, got.Location())
 	notBefore = notBefore.UTC().Truncate(time.Microsecond)
 	notAfter = notAfter.UTC().Truncate(time.Microsecond)
-	require.False(t, got.Before(notBefore), "IndexedTime %s is before %s", got.Format(time.RFC3339Nano), notBefore.Format(time.RFC3339Nano))
-	require.False(t, got.After(notAfter), "IndexedTime %s is after %s", got.Format(time.RFC3339Nano), notAfter.Format(time.RFC3339Nano))
+	require.False(t, got.Before(notBefore), "timestamp %s is before %s", got.Format(time.RFC3339Nano), notBefore.Format(time.RFC3339Nano))
+	require.False(t, got.After(notAfter), "timestamp %s is after %s", got.Format(time.RFC3339Nano), notAfter.Format(time.RFC3339Nano))
 }
 
 type testEnv struct {
@@ -2432,7 +2432,7 @@ func TestGetAdState(t *testing.T) {
 	after := time.Now()
 	state, err = te.ingester.GetAdState(t.Context(), ads[0])
 	require.NoError(t, err)
-	verifyIndexedTime(t, state.IndexedTime, before, after)
+	verifyStatusTime(t, state.IndexedTime, before, after)
 	state.IndexedTime = nil
 	require.Equal(t, AdState{Known: true, Processed: true}, state)
 	require.True(t, state.Indexed())
@@ -2476,7 +2476,7 @@ func TestIndexedTimeStoredAndRead(t *testing.T) {
 	state, err := te.ingester.GetAdState(t.Context(), ad)
 	require.NoError(t, err)
 	require.True(t, state.Indexed())
-	verifyIndexedTime(t, state.IndexedTime, before, after)
+	verifyStatusTime(t, state.IndexedTime, before, after)
 	require.Equal(t, storedMicros, uint64(state.IndexedTime.UnixMicro()))
 
 	marker, err := te.ingester.adAlreadyProcessed(t.Context(), ad)
@@ -2522,6 +2522,31 @@ func TestIndexedTimeExactRoundTrip(t *testing.T) {
 	require.True(t, state.IndexedTime.Equal(want))
 }
 
+func TestSkippedTimeExactRoundTrip(t *testing.T) {
+	te := setupTestEnv(t, false)
+	ad := random.Cids(1)[0]
+	want := time.Date(2024, 6, 15, 12, 30, 45, 123456000, time.UTC)
+
+	require.NoError(t, te.ingester.ds.Put(
+		t.Context(),
+		datastore.NewKey(adProcessedPrefix+ad.String()),
+		encodeAdProcessedMarker(adMarkerSkipped, want),
+	))
+	require.NoError(t, te.ingester.ds.Put(
+		t.Context(),
+		datastore.NewKey(adSkipReasonPrefix+ad.String()),
+		[]byte("decodeErr"),
+	))
+
+	state, err := te.ingester.GetAdState(t.Context(), ad)
+	require.NoError(t, err)
+	require.True(t, state.Skipped)
+	require.False(t, state.Indexed())
+	require.Nil(t, state.IndexedTime)
+	require.NotNil(t, state.SkippedTime)
+	require.True(t, state.SkippedTime.Equal(want))
+}
+
 func TestIndexedTimeTrailingBytesStillDecoded(t *testing.T) {
 	te := setupTestEnv(t, false)
 	ad := random.Cids(1)[0]
@@ -2542,14 +2567,18 @@ func TestIndexedTimeNotSetWhenNotIndexed(t *testing.T) {
 	publisher := te.pubHost.ID()
 	ads := random.Cids(3)
 
+	before := time.Now()
 	require.NoError(t, te.ingester.MarkAdSkipped(publisher, ads[0], "decodeErr", false))
+	after := time.Now()
 	state, err := te.ingester.GetAdState(t.Context(), ads[0])
 	require.NoError(t, err)
 	require.False(t, state.Indexed())
 	require.Nil(t, state.IndexedTime)
+	verifyStatusTime(t, state.SkippedTime, before, after)
 	marker, err := te.ingester.adAlreadyProcessed(t.Context(), ads[0])
 	require.NoError(t, err)
 	require.NotZero(t, marker.ModifiedAt)
+	require.Equal(t, marker.ModifiedAt, uint64(state.SkippedTime.UnixMicro()))
 
 	require.NoError(t, te.ingester.markAdProcessed(publisher, ads[1], true, false))
 	state, err = te.ingester.GetAdState(t.Context(), ads[1])
@@ -2557,6 +2586,7 @@ func TestIndexedTimeNotSetWhenNotIndexed(t *testing.T) {
 	require.True(t, state.Frozen)
 	require.False(t, state.Indexed())
 	require.Nil(t, state.IndexedTime)
+	require.Nil(t, state.SkippedTime)
 	marker, err = te.ingester.adAlreadyProcessed(t.Context(), ads[1])
 	require.NoError(t, err)
 	require.NotZero(t, marker.ModifiedAt)
@@ -2568,6 +2598,7 @@ func TestIndexedTimeNotSetWhenNotIndexed(t *testing.T) {
 	require.True(t, state.Resync)
 	require.False(t, state.Indexed())
 	require.Nil(t, state.IndexedTime)
+	require.Nil(t, state.SkippedTime)
 	marker, err = te.ingester.adAlreadyProcessed(t.Context(), ads[2])
 	require.NoError(t, err)
 	require.Zero(t, marker.ModifiedAt)
@@ -2643,7 +2674,7 @@ func TestAdStateByMarkerByte(t *testing.T) {
 	require.False(t, state.Skipped)
 	require.False(t, state.Resync)
 	require.True(t, state.Indexed())
-	verifyIndexedTime(t, state.IndexedTime, before, after)
+	verifyStatusTime(t, state.IndexedTime, before, after)
 
 	// Test marker byte 2 (resync) via markAdUnprocessed(forResync=true)
 	require.NoError(t, te.ingester.markAdUnprocessed(ads[2], true))
@@ -2656,7 +2687,9 @@ func TestAdStateByMarkerByte(t *testing.T) {
 	require.False(t, state.Indexed())
 
 	// Test marker byte 3 (skipped) via MarkAdSkipped
+	beforeSkip := time.Now()
 	require.NoError(t, te.ingester.MarkAdSkipped(publisher, ads[3], "malformedErr", false))
+	afterSkip := time.Now()
 	state, err = te.ingester.GetAdState(t.Context(), ads[3])
 	require.NoError(t, err)
 	require.True(t, state.Known)
@@ -2666,6 +2699,7 @@ func TestAdStateByMarkerByte(t *testing.T) {
 	require.Equal(t, "malformedErr", state.SkipReason)
 	require.False(t, state.Indexed())
 	require.Nil(t, state.IndexedTime)
+	verifyStatusTime(t, state.SkippedTime, beforeSkip, afterSkip)
 
 	// Test adAlreadyProcessed for each marker byte
 	tests := []struct {
@@ -2764,7 +2798,9 @@ func TestMarkAdSkipped(t *testing.T) {
 	publisher := te.pubHost.ID()
 	ad := random.Cids(1)[0]
 
+	before := time.Now()
 	require.NoError(t, te.ingester.MarkAdSkipped(publisher, ad, "decodeErr", false))
+	after := time.Now()
 
 	state, err := te.ingester.GetAdState(t.Context(), ad)
 	require.NoError(t, err)
@@ -2774,6 +2810,8 @@ func TestMarkAdSkipped(t *testing.T) {
 	require.Equal(t, "decodeErr", state.SkipReason)
 	require.False(t, state.Frozen)
 	require.False(t, state.Indexed())
+	require.Nil(t, state.IndexedTime)
+	verifyStatusTime(t, state.SkippedTime, before, after)
 
 	// Verify sync head updated
 	syncCid, ok := te.ingester.getLastKnownSync(publisher)

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -3,6 +3,7 @@ package ingest
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -2394,6 +2395,16 @@ func requireIndexedEventually(t *testing.T, ix indexer.Interface, p peer.ID, mhs
 	}, testRetryTimeout, testRetryInterval, "Expected all multihashes from %s to have been indexed eventually", p.String())
 }
 
+func verifyIndexedTime(t *testing.T, got *time.Time, notBefore, notAfter time.Time) {
+	t.Helper()
+	require.NotNil(t, got)
+	require.Equal(t, time.UTC, got.Location())
+	notBefore = notBefore.UTC().Truncate(time.Microsecond)
+	notAfter = notAfter.UTC().Truncate(time.Microsecond)
+	require.False(t, got.Before(notBefore), "IndexedTime %s is before %s", got.Format(time.RFC3339Nano), notBefore.Format(time.RFC3339Nano))
+	require.False(t, got.After(notAfter), "IndexedTime %s is after %s", got.Format(time.RFC3339Nano), notAfter.Format(time.RFC3339Nano))
+}
+
 type testEnv struct {
 	publisher        dagsync.Publisher
 	pubHost          host.Host
@@ -2416,9 +2427,13 @@ func TestGetAdState(t *testing.T) {
 	require.Equal(t, AdState{}, state)
 	require.False(t, state.Indexed())
 
+	before := time.Now()
 	require.NoError(t, te.ingester.MarkAdProcessed(publisher, ads[0]))
+	after := time.Now()
 	state, err = te.ingester.GetAdState(t.Context(), ads[0])
 	require.NoError(t, err)
+	verifyIndexedTime(t, state.IndexedTime, before, after)
+	state.IndexedTime = nil
 	require.Equal(t, AdState{Known: true, Processed: true}, state)
 	require.True(t, state.Indexed())
 
@@ -2437,8 +2452,146 @@ func TestGetAdState(t *testing.T) {
 	require.NoError(t, te.ingester.markAdProcessed(publisher, ads[3], true, false))
 	state, err = te.ingester.GetAdState(t.Context(), ads[3])
 	require.NoError(t, err)
+	require.Nil(t, state.IndexedTime)
 	require.Equal(t, AdState{Known: true, Processed: true, Frozen: true}, state)
 	require.False(t, state.Indexed())
+}
+
+func TestIndexedTimeStoredAndRead(t *testing.T) {
+	te := setupTestEnv(t, false)
+	publisher := te.pubHost.ID()
+	ad := random.Cids(1)[0]
+
+	before := time.Now()
+	require.NoError(t, te.ingester.MarkAdProcessed(publisher, ad))
+	after := time.Now()
+
+	raw, err := te.ingester.ds.Get(t.Context(), datastore.NewKey(adProcessedPrefix+ad.String()))
+	require.NoError(t, err)
+	require.Len(t, raw, 1+adProcessedMarkerTimeLen)
+	require.Equal(t, adMarkerProcessed, raw[0])
+	storedMicros := binary.LittleEndian.Uint64(raw[1:])
+	require.NotZero(t, storedMicros)
+
+	state, err := te.ingester.GetAdState(t.Context(), ad)
+	require.NoError(t, err)
+	require.True(t, state.Indexed())
+	verifyIndexedTime(t, state.IndexedTime, before, after)
+	require.Equal(t, storedMicros, uint64(state.IndexedTime.UnixMicro()))
+
+	marker, err := te.ingester.adAlreadyProcessed(t.Context(), ad)
+	require.NoError(t, err)
+	require.Equal(t, storedMicros, marker.ModifiedAt)
+}
+
+func TestIndexedTimeLegacyMarkerHasNoTimestamp(t *testing.T) {
+	te := setupTestEnv(t, false)
+	ad := random.Cids(1)[0]
+
+	require.NoError(t, te.ingester.ds.Put(
+		t.Context(),
+		datastore.NewKey(adProcessedPrefix+ad.String()),
+		[]byte{adMarkerProcessed},
+	))
+
+	state, err := te.ingester.GetAdState(t.Context(), ad)
+	require.NoError(t, err)
+	require.True(t, state.Indexed())
+	require.Nil(t, state.IndexedTime)
+
+	marker, err := te.ingester.adAlreadyProcessed(t.Context(), ad)
+	require.NoError(t, err)
+	require.Zero(t, marker.ModifiedAt)
+}
+
+func TestIndexedTimeExactRoundTrip(t *testing.T) {
+	te := setupTestEnv(t, false)
+	ad := random.Cids(1)[0]
+	want := time.Date(2024, 6, 15, 12, 30, 45, 123456000, time.UTC)
+
+	require.NoError(t, te.ingester.ds.Put(
+		t.Context(),
+		datastore.NewKey(adProcessedPrefix+ad.String()),
+		encodeAdProcessedMarker(adMarkerProcessed, want),
+	))
+
+	state, err := te.ingester.GetAdState(t.Context(), ad)
+	require.NoError(t, err)
+	require.True(t, state.Indexed())
+	require.NotNil(t, state.IndexedTime)
+	require.True(t, state.IndexedTime.Equal(want))
+}
+
+func TestIndexedTimeTrailingBytesStillDecoded(t *testing.T) {
+	te := setupTestEnv(t, false)
+	ad := random.Cids(1)[0]
+	want := time.Date(2024, 6, 15, 12, 30, 45, 123456000, time.UTC)
+	raw := append(encodeAdProcessedMarker(adMarkerProcessed, want), 0xFF, 0x00)
+
+	require.NoError(t, te.ingester.ds.Put(t.Context(), datastore.NewKey(adProcessedPrefix+ad.String()), raw))
+
+	state, err := te.ingester.GetAdState(t.Context(), ad)
+	require.NoError(t, err)
+	require.True(t, state.Indexed())
+	require.NotNil(t, state.IndexedTime)
+	require.True(t, state.IndexedTime.Equal(want))
+}
+
+func TestIndexedTimeNotSetWhenNotIndexed(t *testing.T) {
+	te := setupTestEnv(t, false)
+	publisher := te.pubHost.ID()
+	ads := random.Cids(3)
+
+	require.NoError(t, te.ingester.MarkAdSkipped(publisher, ads[0], "decodeErr", false))
+	state, err := te.ingester.GetAdState(t.Context(), ads[0])
+	require.NoError(t, err)
+	require.False(t, state.Indexed())
+	require.Nil(t, state.IndexedTime)
+	marker, err := te.ingester.adAlreadyProcessed(t.Context(), ads[0])
+	require.NoError(t, err)
+	require.NotZero(t, marker.ModifiedAt)
+
+	require.NoError(t, te.ingester.markAdProcessed(publisher, ads[1], true, false))
+	state, err = te.ingester.GetAdState(t.Context(), ads[1])
+	require.NoError(t, err)
+	require.True(t, state.Frozen)
+	require.False(t, state.Indexed())
+	require.Nil(t, state.IndexedTime)
+	marker, err = te.ingester.adAlreadyProcessed(t.Context(), ads[1])
+	require.NoError(t, err)
+	require.NotZero(t, marker.ModifiedAt)
+
+	require.NoError(t, te.ingester.MarkAdProcessed(publisher, ads[2]))
+	require.NoError(t, te.ingester.markAdUnprocessed(ads[2], true))
+	state, err = te.ingester.GetAdState(t.Context(), ads[2])
+	require.NoError(t, err)
+	require.True(t, state.Resync)
+	require.False(t, state.Indexed())
+	require.Nil(t, state.IndexedTime)
+	marker, err = te.ingester.adAlreadyProcessed(t.Context(), ads[2])
+	require.NoError(t, err)
+	require.Zero(t, marker.ModifiedAt)
+}
+
+func TestIndexedTimeUpdatedOnReprocess(t *testing.T) {
+	te := setupTestEnv(t, false)
+	publisher := te.pubHost.ID()
+	ad := random.Cids(1)[0]
+
+	require.NoError(t, te.ingester.MarkAdProcessed(publisher, ad))
+	first, err := te.ingester.adAlreadyProcessed(t.Context(), ad)
+	require.NoError(t, err)
+	require.NotZero(t, first.ModifiedAt)
+
+	time.Sleep(2 * time.Millisecond)
+	require.NoError(t, te.ingester.MarkAdProcessed(publisher, ad))
+	second, err := te.ingester.adAlreadyProcessed(t.Context(), ad)
+	require.NoError(t, err)
+	require.Greater(t, second.ModifiedAt, first.ModifiedAt)
+
+	state, err := te.ingester.GetAdState(t.Context(), ad)
+	require.NoError(t, err)
+	require.Equal(t, second.ModifiedAt, uint64(state.IndexedTime.UnixMicro()))
 }
 
 func TestAdStateIndexed(t *testing.T) {
@@ -2480,7 +2633,9 @@ func TestAdStateByMarkerByte(t *testing.T) {
 	require.False(t, state.Indexed())
 
 	// Test marker byte 1 (processed) via MarkAdProcessed
+	before := time.Now()
 	require.NoError(t, te.ingester.MarkAdProcessed(publisher, ads[1]))
+	after := time.Now()
 	state, err = te.ingester.GetAdState(t.Context(), ads[1])
 	require.NoError(t, err)
 	require.True(t, state.Known)
@@ -2488,6 +2643,7 @@ func TestAdStateByMarkerByte(t *testing.T) {
 	require.False(t, state.Skipped)
 	require.False(t, state.Resync)
 	require.True(t, state.Indexed())
+	verifyIndexedTime(t, state.IndexedTime, before, after)
 
 	// Test marker byte 2 (resync) via markAdUnprocessed(forResync=true)
 	require.NoError(t, te.ingester.markAdUnprocessed(ads[2], true))
@@ -2509,22 +2665,30 @@ func TestAdStateByMarkerByte(t *testing.T) {
 	require.False(t, state.Resync)
 	require.Equal(t, "malformedErr", state.SkipReason)
 	require.False(t, state.Indexed())
+	require.Nil(t, state.IndexedTime)
 
 	// Test adAlreadyProcessed for each marker byte
 	tests := []struct {
-		name string
-		ad   cid.Cid
-		want adProcessedState
+		name           string
+		ad             cid.Cid
+		want           adProcessedState
+		wantModifiedAt bool
 	}{
 		{name: "unprocessed", ad: ads[0], want: adProcessedState{Known: true}},
-		{name: "processed", ad: ads[1], want: adProcessedState{Known: true, Processed: true}},
+		{name: "processed", ad: ads[1], want: adProcessedState{Known: true, Processed: true}, wantModifiedAt: true},
 		{name: "resync", ad: ads[2], want: adProcessedState{Known: true, Resync: true}},
-		{name: "skipped", ad: ads[3], want: adProcessedState{Known: true, Processed: true, Skipped: true}},
+		{name: "skipped", ad: ads[3], want: adProcessedState{Known: true, Processed: true, Skipped: true}, wantModifiedAt: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := te.ingester.adAlreadyProcessed(t.Context(), tt.ad)
 			require.NoError(t, err)
+			if tt.wantModifiedAt {
+				require.NotZero(t, got.ModifiedAt)
+				got.ModifiedAt = 0
+			} else {
+				require.Zero(t, got.ModifiedAt)
+			}
 			require.Equal(t, tt.want, got)
 		})
 	}

--- a/server/ingest/protocol_test.go
+++ b/server/ingest/protocol_test.go
@@ -211,7 +211,15 @@ func TestAdStatus(t *testing.T) {
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, "*", hdr.Get("Access-Control-Allow-Origin"))
 	require.Equal(t, "application/json; charset=utf-8", hdr.Get("Content-Type"))
-	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"unknown","Frozen":false}`, dagJSONAds[0].String()), body)
+	require.JSONEq(t, fmt.Sprintf(`
+		{
+			"Ad": %[1]q,
+			"Indexed": false,
+			"State": "unknown",
+			"Frozen": false
+		}`,
+		dagJSONAds[0].String(), // [1]
+	), body)
 
 	// Fully processed ad is indexed and reports IndexedTime.
 	before := time.Now()
@@ -221,7 +229,17 @@ func TestAdStatus(t *testing.T) {
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, "*", hdr.Get("Access-Control-Allow-Origin"))
 	indexedTime := getVerifiedStatusTime(t, body, "IndexedTime", -1, before, after)
-	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":true,"IndexedTime":%q,"State":"indexed","Frozen":false}`, dagJSONAds[0].String(), indexedTime), body)
+	require.JSONEq(t, fmt.Sprintf(`
+		{
+			"Ad": %[1]q,
+			"Indexed": true,
+			"IndexedTime": %[2]q,
+			"State": "indexed",
+			"Frozen": false
+		}`,
+		dagJSONAds[0].String(), // [1]
+		indexedTime,            // [2]
+	), body)
 
 	// Exact stored timestamp is returned as UTC IndexedTime.
 	timedAd := cid.NewCidV1(cid.DagJSON, random.Multihashes(1)[0])
@@ -232,7 +250,17 @@ func TestAdStatus(t *testing.T) {
 	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adProcessed/"+timedAd.String()), timedMarker))
 	status, _, body = getAdStatus(t, timedAd)
 	require.Equal(t, http.StatusOK, status)
-	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":true,"IndexedTime":%q,"State":"indexed","Frozen":false}`, timedAd.String(), wantTime.Format(time.RFC3339Nano)), body)
+	require.JSONEq(t, fmt.Sprintf(`
+		{
+			"Ad": %[1]q,
+			"Indexed": true,
+			"IndexedTime": %[2]q,
+			"State": "indexed",
+			"Frozen": false
+		}`,
+		timedAd.String(),                  // [1]
+		wantTime.Format(time.RFC3339Nano), // [2]
+	), body)
 
 	// Skipped ad returns state "skipped" with reason, Indexed false, and SkippedTime.
 	skipBefore := time.Now()
@@ -241,7 +269,18 @@ func TestAdStatus(t *testing.T) {
 	status, _, body = getAdStatus(t, dagJSONAds[1])
 	require.Equal(t, http.StatusOK, status)
 	skippedTime := getVerifiedStatusTime(t, body, "SkippedTime", -1, skipBefore, skipAfter)
-	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"skipped","SkipReason":"decodeErr","SkippedTime":%q,"Frozen":false}`, dagJSONAds[1].String(), skippedTime), body)
+	require.JSONEq(t, fmt.Sprintf(`
+		{
+			"Ad": %[1]q,
+			"Indexed": false,
+			"State": "skipped",
+			"SkipReason": "decodeErr",
+			"SkippedTime": %[2]q,
+			"Frozen": false
+		}`,
+		dagJSONAds[1].String(), // [1]
+		skippedTime,            // [2]
+	), body)
 
 	// Exact stored timestamp is returned as UTC SkippedTime.
 	timedSkipAd := cid.NewCidV1(cid.DagJSON, random.Multihashes(1)[0])
@@ -252,33 +291,76 @@ func TestAdStatus(t *testing.T) {
 	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adSkipReason/"+timedSkipAd.String()), []byte("decodeErr")))
 	status, _, body = getAdStatus(t, timedSkipAd)
 	require.Equal(t, http.StatusOK, status)
-	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"skipped","SkipReason":"decodeErr","SkippedTime":%q,"Frozen":false}`, timedSkipAd.String(), wantTime.Format(time.RFC3339Nano)), body)
+	require.JSONEq(t, fmt.Sprintf(`
+		{
+			"Ad": %[1]q,
+			"Indexed": false,
+			"State": "skipped",
+			"SkipReason": "decodeErr",
+			"SkippedTime": %[2]q,
+			"Frozen": false
+		}`,
+		timedSkipAd.String(),              // [1]
+		wantTime.Format(time.RFC3339Nano), // [2]
+	), body)
 
 	// Pending ad (marker byte 0 written directly).
 	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adProcessed/"+dagJSONAds[2].String()), []byte{0}))
 	status, _, body = getAdStatus(t, dagJSONAds[2])
 	require.Equal(t, http.StatusOK, status)
-	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"pending","Frozen":false}`, dagJSONAds[2].String()), body)
+	require.JSONEq(t, fmt.Sprintf(`
+		{
+			"Ad": %[1]q,
+			"Indexed": false,
+			"State": "pending",
+			"Frozen": false
+		}`,
+		dagJSONAds[2].String(), // [1]
+	), body)
 
 	// Resyncing ad (marker byte 2 written directly).
 	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adProcessed/"+dagJSONAds[3].String()), []byte{2}))
 	status, _, body = getAdStatus(t, dagJSONAds[3])
 	require.Equal(t, http.StatusOK, status)
-	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"resyncing","Frozen":false}`, dagJSONAds[3].String()), body)
+	require.JSONEq(t, fmt.Sprintf(`
+		{
+			"Ad": %[1]q,
+			"Indexed": false,
+			"State": "resyncing",
+			"Frozen": false
+		}`,
+		dagJSONAds[3].String(), // [1]
+	), body)
 
 	// Frozen ad (processed + frozen key set) omits IndexedTime.
 	require.NoError(t, ing.MarkAdProcessed(pubID, dagJSONAds[4]))
 	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adF/"+dagJSONAds[4].String()), []byte{1}))
 	status, _, body = getAdStatus(t, dagJSONAds[4])
 	require.Equal(t, http.StatusOK, status)
-	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"indexed","Frozen":true}`, dagJSONAds[4].String()), body)
+	require.JSONEq(t, fmt.Sprintf(`
+		{
+			"Ad": %[1]q,
+			"Indexed": false,
+			"State": "indexed",
+			"Frozen": true
+		}`,
+		dagJSONAds[4].String(), // [1]
+	), body)
 
 	// Legacy 1-byte processed marker is indexed but has no IndexedTime.
 	legacyAd := cid.NewCidV1(cid.DagJSON, random.Multihashes(1)[0])
 	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adProcessed/"+legacyAd.String()), []byte{1}))
 	status, _, body = getAdStatus(t, legacyAd)
 	require.Equal(t, http.StatusOK, status)
-	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":true,"State":"indexed","Frozen":false}`, legacyAd.String()), body)
+	require.JSONEq(t, fmt.Sprintf(`
+		{
+			"Ad": %[1]q,
+			"Indexed": true,
+			"State": "indexed",
+			"Frozen": false
+		}`,
+		legacyAd.String(), // [1]
+	), body)
 
 	// Legacy 1-byte skipped marker has no SkippedTime.
 	legacySkip := cid.NewCidV1(cid.DagJSON, random.Multihashes(1)[0])
@@ -286,7 +368,16 @@ func TestAdStatus(t *testing.T) {
 	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adSkipReason/"+legacySkip.String()), []byte("decodeErr")))
 	status, _, body = getAdStatus(t, legacySkip)
 	require.Equal(t, http.StatusOK, status)
-	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"skipped","SkipReason":"decodeErr","Frozen":false}`, legacySkip.String()), body)
+	require.JSONEq(t, fmt.Sprintf(`
+		{
+			"Ad": %[1]q,
+			"Indexed": false,
+			"State": "skipped",
+			"SkipReason": "decodeErr",
+			"Frozen": false
+		}`,
+		legacySkip.String(), // [1]
+	), body)
 
 	// Codec guard: raw CID returns 400.
 	rawCid := cid.NewCidV1(cid.Raw, random.Multihashes(1)[0])
@@ -318,7 +409,15 @@ func TestAdStatus(t *testing.T) {
 	res.Body.Close()
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, res.StatusCode)
-	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"unknown","Frozen":false}`, dagCBORCid.String()), string(bodyBytes))
+	require.JSONEq(t, fmt.Sprintf(`
+		{
+			"Ad": %[1]q,
+			"Indexed": false,
+			"State": "unknown",
+			"Frozen": false
+		}`,
+		dagCBORCid.String(), // [1]
+	), string(bodyBytes))
 
 	// Bad CID format returns 400.
 	res, err = http.Get(s.URL() + "/sync/status/ad/not-a-cid")
@@ -431,44 +530,142 @@ func TestAdStatusBatch(t *testing.T) {
 	})
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, "*", hdr.Get("Access-Control-Allow-Origin"))
-	indexedTime := getVerifiedIndexedTime(t, body, 2, before, after)
-	require.JSONEq(t, fmt.Sprintf(`{
-		"Statuses": [
-			{"Ad":%q,"Indexed":false,"State":"unknown","Frozen":false},
-			{"Ad":%q,"Indexed":false,"State":"pending","Frozen":false},
-			{"Ad":%q,"Indexed":true,"IndexedTime":%q,"State":"indexed","Frozen":false},
-			{"Ad":%q,"Indexed":false,"State":"resyncing","Frozen":false},
-			{"Ad":%q,"Indexed":false,"State":"skipped","SkipReason":"testSkip","Frozen":false}
-		]
-	}`, cids[0].String(), cids[1].String(), cids[2].String(), indexedTime, cids[3].String(), cids[4].String()), body)
+	indexedTime := getVerifiedStatusTime(t, body, "IndexedTime", 2, before, after)
+	skippedTime := getVerifiedStatusTime(t, body, "SkippedTime", 4, skipBefore, skipAfter)
+	require.JSONEq(t, fmt.Sprintf(`
+		{
+			"Statuses": [
+				{
+					"Ad": %[1]q,
+					"Indexed": false,
+					"State": "unknown",
+					"Frozen": false
+				},
+				{
+					"Ad": %[2]q,
+					"Indexed": false,
+					"State": "pending",
+					"Frozen": false
+				},
+				{
+					"Ad": %[3]q,
+					"Indexed": true,
+					"IndexedTime": %[4]q,
+					"State": "indexed",
+					"Frozen": false
+				},
+				{
+					"Ad": %[5]q,
+					"Indexed": false,
+					"State": "resyncing",
+					"Frozen": false
+				},
+				{
+					"Ad": %[6]q,
+					"Indexed": false,
+					"State": "skipped",
+					"SkipReason": "testSkip",
+					"SkippedTime": %[7]q,
+					"Frozen": false
+				}
+			]
+		}`,
+		cids[0].String(), // [1]
+		cids[1].String(), // [2]
+		cids[2].String(), // [3]
+		indexedTime,      // [4]
+		cids[3].String(), // [5]
+		cids[4].String(), // [6]
+		skippedTime,      // [7]
+	), body)
 
 	// Frozen-processed ad
 	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adF/"+cids[2].String()), []byte{1}))
 	status, _, body = postBatch(t, []string{cids[2].String()})
 	require.Equal(t, http.StatusOK, status)
-	require.JSONEq(t, fmt.Sprintf(`{"Statuses":[{"Ad":%q,"Indexed":false,"State":"indexed","Frozen":true}]}`, cids[2].String()), body)
+	require.JSONEq(t, fmt.Sprintf(`
+		{
+			"Statuses": [
+				{
+					"Ad": %[1]q,
+					"Indexed": false,
+					"State": "indexed",
+					"Frozen": true
+				}
+			]
+		}`,
+		cids[2].String(), // [1]
+	), body)
 
 	// Reversed order with one duplicated CID stays positionally aligned
 	status, _, body = postBatch(t, []string{cids[4].String(), cids[2].String(), cids[4].String()})
 	require.Equal(t, http.StatusOK, status)
-	require.JSONEq(t, fmt.Sprintf(`{
-		"Statuses": [
-			{"Ad":%q,"Indexed":false,"State":"skipped","SkipReason":"testSkip","Frozen":false},
-			{"Ad":%q,"Indexed":false,"State":"indexed","Frozen":true},
-			{"Ad":%q,"Indexed":false,"State":"skipped","SkipReason":"testSkip","Frozen":false}
-		]
-	}`, cids[4].String(), cids[2].String(), cids[4].String()), body)
+	require.JSONEq(t, fmt.Sprintf(`
+		{
+			"Statuses": [
+				{
+					"Ad": %[1]q,
+					"Indexed": false,
+					"State": "skipped",
+					"SkipReason": "testSkip",
+					"SkippedTime": %[2]q,
+					"Frozen": false
+				},
+				{
+					"Ad": %[3]q,
+					"Indexed": false,
+					"State": "indexed",
+					"Frozen": true
+				},
+				{
+					"Ad": %[1]q,
+					"Indexed": false,
+					"State": "skipped",
+					"SkipReason": "testSkip",
+					"SkippedTime": %[2]q,
+					"Frozen": false
+				}
+			]
+		}`,
+		cids[4].String(), // [1]
+		skippedTime,      // [2]
+		cids[2].String(), // [3]
+	), body)
 
 	// Single-element batch returns one-entry Statuses array
 	status, _, body = postBatch(t, []string{cids[0].String()})
 	require.Equal(t, http.StatusOK, status)
-	require.JSONEq(t, fmt.Sprintf(`{"Statuses":[{"Ad":%q,"Indexed":false,"State":"unknown","Frozen":false}]}`, cids[0].String()), body)
+	require.JSONEq(t, fmt.Sprintf(`
+		{
+			"Statuses": [
+				{
+					"Ad": %[1]q,
+					"Indexed": false,
+					"State": "unknown",
+					"Frozen": false
+				}
+			]
+		}`,
+		cids[0].String(), // [1]
+	), body)
 
 	// dag-cbor CID accepted like dag-json
 	dagCBORCid := cid.NewCidV1(cid.DagCBOR, random.Multihashes(1)[0])
 	status, _, body = postBatch(t, []string{dagCBORCid.String()})
 	require.Equal(t, http.StatusOK, status)
-	require.JSONEq(t, fmt.Sprintf(`{"Statuses":[{"Ad":%q,"Indexed":false,"State":"unknown","Frozen":false}]}`, dagCBORCid.String()), body)
+	require.JSONEq(t, fmt.Sprintf(`
+		{
+			"Statuses": [
+				{
+					"Ad": %[1]q,
+					"Indexed": false,
+					"State": "unknown",
+					"Frozen": false
+				}
+			]
+		}`,
+		dagCBORCid.String(), // [1]
+	), body)
 
 	// Mixed batch: two valid, "not-a-cid", raw-codec - all 200 with per-item errors
 	rawCid := cid.NewCidV1(cid.Raw, random.Multihashes(1)[0])

--- a/server/ingest/protocol_test.go
+++ b/server/ingest/protocol_test.go
@@ -220,7 +220,7 @@ func TestAdStatus(t *testing.T) {
 	status, hdr, body = getAdStatus(t, dagJSONAds[0])
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, "*", hdr.Get("Access-Control-Allow-Origin"))
-	indexedTime := getVerifiedIndexedTime(t, body, -1, before, after)
+	indexedTime := getVerifiedStatusTime(t, body, "IndexedTime", -1, before, after)
 	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":true,"IndexedTime":%q,"State":"indexed","Frozen":false}`, dagJSONAds[0].String(), indexedTime), body)
 
 	// Exact stored timestamp is returned as UTC IndexedTime.
@@ -234,11 +234,25 @@ func TestAdStatus(t *testing.T) {
 	require.Equal(t, http.StatusOK, status)
 	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":true,"IndexedTime":%q,"State":"indexed","Frozen":false}`, timedAd.String(), wantTime.Format(time.RFC3339Nano)), body)
 
-	// Skipped ad returns state "skipped" with reason, Indexed false.
+	// Skipped ad returns state "skipped" with reason, Indexed false, and SkippedTime.
+	skipBefore := time.Now()
 	require.NoError(t, ing.MarkAdSkipped(pubID, dagJSONAds[1], "decodeErr", false))
+	skipAfter := time.Now()
 	status, _, body = getAdStatus(t, dagJSONAds[1])
 	require.Equal(t, http.StatusOK, status)
-	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"skipped","SkipReason":"decodeErr","Frozen":false}`, dagJSONAds[1].String()), body)
+	skippedTime := getVerifiedStatusTime(t, body, "SkippedTime", -1, skipBefore, skipAfter)
+	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"skipped","SkipReason":"decodeErr","SkippedTime":%q,"Frozen":false}`, dagJSONAds[1].String(), skippedTime), body)
+
+	// Exact stored timestamp is returned as UTC SkippedTime.
+	timedSkipAd := cid.NewCidV1(cid.DagJSON, random.Multihashes(1)[0])
+	timedSkipMarker := make([]byte, 9)
+	timedSkipMarker[0] = 3
+	binary.LittleEndian.PutUint64(timedSkipMarker[1:], uint64(wantTime.UnixMicro()))
+	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adProcessed/"+timedSkipAd.String()), timedSkipMarker))
+	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adSkipReason/"+timedSkipAd.String()), []byte("decodeErr")))
+	status, _, body = getAdStatus(t, timedSkipAd)
+	require.Equal(t, http.StatusOK, status)
+	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"skipped","SkipReason":"decodeErr","SkippedTime":%q,"Frozen":false}`, timedSkipAd.String(), wantTime.Format(time.RFC3339Nano)), body)
 
 	// Pending ad (marker byte 0 written directly).
 	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adProcessed/"+dagJSONAds[2].String()), []byte{0}))
@@ -265,6 +279,14 @@ func TestAdStatus(t *testing.T) {
 	status, _, body = getAdStatus(t, legacyAd)
 	require.Equal(t, http.StatusOK, status)
 	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":true,"State":"indexed","Frozen":false}`, legacyAd.String()), body)
+
+	// Legacy 1-byte skipped marker has no SkippedTime.
+	legacySkip := cid.NewCidV1(cid.DagJSON, random.Multihashes(1)[0])
+	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adProcessed/"+legacySkip.String()), []byte{3}))
+	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adSkipReason/"+legacySkip.String()), []byte("decodeErr")))
+	status, _, body = getAdStatus(t, legacySkip)
+	require.Equal(t, http.StatusOK, status)
+	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"skipped","SkipReason":"decodeErr","Frozen":false}`, legacySkip.String()), body)
 
 	// Codec guard: raw CID returns 400.
 	rawCid := cid.NewCidV1(cid.Raw, random.Multihashes(1)[0])
@@ -395,7 +417,9 @@ func TestAdStatusBatch(t *testing.T) {
 	require.NoError(t, ing.MarkAdProcessed(pubID, cids[2]))
 	after := time.Now()
 	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adProcessed/"+cids[3].String()), []byte{2}))
+	skipBefore := time.Now()
 	require.NoError(t, ing.MarkAdSkipped(pubID, cids[4], "testSkip", false))
+	skipAfter := time.Now()
 
 	// All five states in one request, asserted positionally
 	status, hdr, body := postBatch(t, []string{
@@ -656,33 +680,29 @@ func mustJSONMap(t *testing.T, m map[string]json.RawMessage) []byte {
 	return data
 }
 
-func getVerifiedIndexedTime(t *testing.T, body string, statusIdx int, notBefore, notAfter time.Time) string {
+func getVerifiedStatusTime(t *testing.T, body, field string, statusIdx int, notBefore, notAfter time.Time) string {
 	t.Helper()
-	var ts string
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal([]byte(body), &raw))
+	var obj map[string]any
 	if statusIdx < 0 {
-		var parsed struct {
-			IndexedTime string `json:"IndexedTime"`
-		}
-		require.NoError(t, json.Unmarshal([]byte(body), &parsed))
-		ts = parsed.IndexedTime
+		obj = raw
 	} else {
-		var parsed struct {
-			Statuses []struct {
-				IndexedTime string `json:"IndexedTime"`
-			} `json:"Statuses"`
-		}
-		require.NoError(t, json.Unmarshal([]byte(body), &parsed))
-		require.Greater(t, len(parsed.Statuses), statusIdx)
-		ts = parsed.Statuses[statusIdx].IndexedTime
+		statuses, ok := raw["Statuses"].([]any)
+		require.True(t, ok)
+		require.Greater(t, len(statuses), statusIdx)
+		obj, ok = statuses[statusIdx].(map[string]any)
+		require.True(t, ok)
 	}
+	ts, _ := obj[field].(string)
 	require.NotEmpty(t, ts)
 	parsedTime, err := time.Parse(time.RFC3339Nano, ts)
 	require.NoError(t, err)
 	require.Equal(t, time.UTC, parsedTime.Location())
 	notBefore = notBefore.UTC().Truncate(time.Microsecond)
 	notAfter = notAfter.UTC().Truncate(time.Microsecond)
-	require.False(t, parsedTime.Before(notBefore), "IndexedTime %s is before %s", ts, notBefore.Format(time.RFC3339Nano))
-	require.False(t, parsedTime.After(notAfter), "IndexedTime %s is after %s", ts, notAfter.Format(time.RFC3339Nano))
+	require.False(t, parsedTime.Before(notBefore), "%s %s is before %s", field, ts, notBefore.Format(time.RFC3339Nano))
+	require.False(t, parsedTime.After(notAfter), "%s %s is after %s", field, ts, notAfter.Format(time.RFC3339Nano))
 	return ts
 }
 

--- a/server/ingest/protocol_test.go
+++ b/server/ingest/protocol_test.go
@@ -3,6 +3,7 @@ package ingest_test
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -212,12 +213,26 @@ func TestAdStatus(t *testing.T) {
 	require.Equal(t, "application/json; charset=utf-8", hdr.Get("Content-Type"))
 	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"unknown","Frozen":false}`, dagJSONAds[0].String()), body)
 
-	// Fully processed ad is indexed.
+	// Fully processed ad is indexed and reports IndexedTime.
+	before := time.Now()
 	require.NoError(t, ing.MarkAdProcessed(pubID, dagJSONAds[0]))
+	after := time.Now()
 	status, hdr, body = getAdStatus(t, dagJSONAds[0])
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, "*", hdr.Get("Access-Control-Allow-Origin"))
-	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":true,"State":"indexed","Frozen":false}`, dagJSONAds[0].String()), body)
+	indexedTime := getVerifiedIndexedTime(t, body, -1, before, after)
+	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":true,"IndexedTime":%q,"State":"indexed","Frozen":false}`, dagJSONAds[0].String(), indexedTime), body)
+
+	// Exact stored timestamp is returned as UTC IndexedTime.
+	timedAd := cid.NewCidV1(cid.DagJSON, random.Multihashes(1)[0])
+	wantTime := time.Date(2024, 6, 15, 12, 30, 45, 123456000, time.UTC)
+	timedMarker := make([]byte, 9)
+	timedMarker[0] = 1
+	binary.LittleEndian.PutUint64(timedMarker[1:], uint64(wantTime.UnixMicro()))
+	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adProcessed/"+timedAd.String()), timedMarker))
+	status, _, body = getAdStatus(t, timedAd)
+	require.Equal(t, http.StatusOK, status)
+	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":true,"IndexedTime":%q,"State":"indexed","Frozen":false}`, timedAd.String(), wantTime.Format(time.RFC3339Nano)), body)
 
 	// Skipped ad returns state "skipped" with reason, Indexed false.
 	require.NoError(t, ing.MarkAdSkipped(pubID, dagJSONAds[1], "decodeErr", false))
@@ -237,12 +252,19 @@ func TestAdStatus(t *testing.T) {
 	require.Equal(t, http.StatusOK, status)
 	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"resyncing","Frozen":false}`, dagJSONAds[3].String()), body)
 
-	// Frozen ad (processed + frozen key set).
+	// Frozen ad (processed + frozen key set) omits IndexedTime.
 	require.NoError(t, ing.MarkAdProcessed(pubID, dagJSONAds[4]))
 	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adF/"+dagJSONAds[4].String()), []byte{1}))
 	status, _, body = getAdStatus(t, dagJSONAds[4])
 	require.Equal(t, http.StatusOK, status)
 	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":false,"State":"indexed","Frozen":true}`, dagJSONAds[4].String()), body)
+
+	// Legacy 1-byte processed marker is indexed but has no IndexedTime.
+	legacyAd := cid.NewCidV1(cid.DagJSON, random.Multihashes(1)[0])
+	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adProcessed/"+legacyAd.String()), []byte{1}))
+	status, _, body = getAdStatus(t, legacyAd)
+	require.Equal(t, http.StatusOK, status)
+	require.JSONEq(t, fmt.Sprintf(`{"Ad":%q,"Indexed":true,"State":"indexed","Frozen":false}`, legacyAd.String()), body)
 
 	// Codec guard: raw CID returns 400.
 	rawCid := cid.NewCidV1(cid.Raw, random.Multihashes(1)[0])
@@ -369,7 +391,9 @@ func TestAdStatusBatch(t *testing.T) {
 
 	// Set up states: unknown, pending, indexed, resyncing, skipped
 	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adProcessed/"+cids[1].String()), []byte{0}))
+	before := time.Now()
 	require.NoError(t, ing.MarkAdProcessed(pubID, cids[2]))
+	after := time.Now()
 	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adProcessed/"+cids[3].String()), []byte{2}))
 	require.NoError(t, ing.MarkAdSkipped(pubID, cids[4], "testSkip", false))
 
@@ -383,15 +407,16 @@ func TestAdStatusBatch(t *testing.T) {
 	})
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, "*", hdr.Get("Access-Control-Allow-Origin"))
+	indexedTime := getVerifiedIndexedTime(t, body, 2, before, after)
 	require.JSONEq(t, fmt.Sprintf(`{
 		"Statuses": [
 			{"Ad":%q,"Indexed":false,"State":"unknown","Frozen":false},
 			{"Ad":%q,"Indexed":false,"State":"pending","Frozen":false},
-			{"Ad":%q,"Indexed":true,"State":"indexed","Frozen":false},
+			{"Ad":%q,"Indexed":true,"IndexedTime":%q,"State":"indexed","Frozen":false},
 			{"Ad":%q,"Indexed":false,"State":"resyncing","Frozen":false},
 			{"Ad":%q,"Indexed":false,"State":"skipped","SkipReason":"testSkip","Frozen":false}
 		]
-	}`, cids[0].String(), cids[1].String(), cids[2].String(), cids[3].String(), cids[4].String()), body)
+	}`, cids[0].String(), cids[1].String(), cids[2].String(), indexedTime, cids[3].String(), cids[4].String()), body)
 
 	// Frozen-processed ad
 	require.NoError(t, ds.Put(context.Background(), datastore.NewKey("/adF/"+cids[2].String()), []byte{1}))
@@ -629,6 +654,36 @@ func mustJSONMap(t *testing.T, m map[string]json.RawMessage) []byte {
 	data, err := json.Marshal(m)
 	require.NoError(t, err)
 	return data
+}
+
+func getVerifiedIndexedTime(t *testing.T, body string, statusIdx int, notBefore, notAfter time.Time) string {
+	t.Helper()
+	var ts string
+	if statusIdx < 0 {
+		var parsed struct {
+			IndexedTime string `json:"IndexedTime"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(body), &parsed))
+		ts = parsed.IndexedTime
+	} else {
+		var parsed struct {
+			Statuses []struct {
+				IndexedTime string `json:"IndexedTime"`
+			} `json:"Statuses"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(body), &parsed))
+		require.Greater(t, len(parsed.Statuses), statusIdx)
+		ts = parsed.Statuses[statusIdx].IndexedTime
+	}
+	require.NotEmpty(t, ts)
+	parsedTime, err := time.Parse(time.RFC3339Nano, ts)
+	require.NoError(t, err)
+	require.Equal(t, time.UTC, parsedTime.Location())
+	notBefore = notBefore.UTC().Truncate(time.Microsecond)
+	notAfter = notAfter.UTC().Truncate(time.Microsecond)
+	require.False(t, parsedTime.Before(notBefore), "IndexedTime %s is before %s", ts, notBefore.Format(time.RFC3339Nano))
+	require.False(t, parsedTime.After(notAfter), "IndexedTime %s is after %s", ts, notAfter.Format(time.RFC3339Nano))
+	return ts
 }
 
 func registerProviderTest(t *testing.T, cl client.Interface, providerID peer.ID, privateKey crypto.PrivKey, addr string, reg *registry.Registry) {

--- a/server/ingest/server.go
+++ b/server/ingest/server.go
@@ -243,19 +243,21 @@ func adCidCodecError(adCid cid.Cid) string {
 }
 
 type adStatusResponse struct {
-	Ad         string `json:"Ad"`
-	Indexed    bool   `json:"Indexed"`
-	State      string `json:"State,omitempty"`
-	SkipReason string `json:"SkipReason,omitempty"`
-	Frozen     bool   `json:"Frozen"`
-	Error      string `json:"Error,omitempty"`
+	Ad          string     `json:"Ad"`
+	Indexed     bool       `json:"Indexed"`
+	IndexedTime *time.Time `json:"IndexedTime,omitempty"`
+	State       string     `json:"State,omitempty"`
+	SkipReason  string     `json:"SkipReason,omitempty"`
+	Frozen      bool       `json:"Frozen"`
+	Error       string     `json:"Error,omitempty"`
 }
 
 func newAdStatusResponse(adCid cid.Cid, adState ingest.AdState) adStatusResponse {
 	resp := adStatusResponse{
-		Ad:      adCid.String(),
-		Indexed: adState.Indexed(),
-		Frozen:  adState.Frozen,
+		Ad:          adCid.String(),
+		Indexed:     adState.Indexed(),
+		IndexedTime: adState.IndexedTime,
+		Frozen:      adState.Frozen,
 	}
 
 	switch {

--- a/server/ingest/server.go
+++ b/server/ingest/server.go
@@ -248,6 +248,7 @@ type adStatusResponse struct {
 	IndexedTime *time.Time `json:"IndexedTime,omitempty"`
 	State       string     `json:"State,omitempty"`
 	SkipReason  string     `json:"SkipReason,omitempty"`
+	SkippedTime *time.Time `json:"SkippedTime,omitempty"`
 	Frozen      bool       `json:"Frozen"`
 	Error       string     `json:"Error,omitempty"`
 }
@@ -257,6 +258,7 @@ func newAdStatusResponse(adCid cid.Cid, adState ingest.AdState) adStatusResponse
 		Ad:          adCid.String(),
 		Indexed:     adState.Indexed(),
 		IndexedTime: adState.IndexedTime,
+		SkippedTime: adState.SkippedTime,
 		Frozen:      adState.Frozen,
 	}
 


### PR DESCRIPTION
## Context

It would be good for the ad status API to return the time when the ad was considered indexed.

## Proposed Changes

Store the timestamp in the datastore in a compact form next to the ad processing status within the same database key.

## Tests

Dedicated unit tests for this feature, including backwards-compatibility ones.

## Revert Strategy

Just code revert, database format is backwards-compatible, the old code only checks the first byte of the datastore value.