### PR TITLE
Limit jemalloc arenas so RSS can drop after cache evictions.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY --from=jemalloc \
     /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 \
     /usr/lib/x86_64-linux-gnu/
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
-ENV MALLOC_CONF=background_thread:true,dirty_decay_ms:5000,muzzy_decay_ms:5000
+ENV MALLOC_CONF=background_thread:true,narenas:2,dirty_decay_ms:0,muzzy_decay_ms
 
 # Default port configuration:
 #  - 3000 Finder interface


### PR DESCRIPTION
## Context

With the current jemalloc-based docker image the memory growth is much reduced but still observable on large-core-count machines. Production setups run docker image with customized env var that reduces that consumption even more by limiting number of arenas of the allocato to 2.

The small number of arenas does not harm our workloads as those are mostly large and rare allocations.

## Proposed Changes

Update the MALLOC_CONG env var to match currnet production ones.

## Tests

Already running on production

## Revert Strategy

Only config change