### PR TITLE
Expose sf car mirror through CloudFront

### DIFF
--- a/deploy/infrastructure/prod/us-east-2/cloudfront.tf
+++ b/deploy/infrastructure/prod/us-east-2/cloudfront.tf
@@ -230,6 +230,33 @@ resource "aws_cloudfront_distribution" "cdn" {
     max_ttl                = 86400
   }
 
+  # Appended so existing ordered_cache_behavior indexes stay put.
+  # Origin is sf for now (writes happen there); switch target_origin_id
+  # when that changes. TTL matches default_cache_behavior: publisher .head
+  # files are overwritten as the chain advances, so this cannot be year-long.
+  # 404s still use the distribution custom_error_response (20m).
+  ordered_cache_behavior {
+    path_pattern     = "carmirror"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = local.direct_sf_cid_contact_origin_id
+    cache_policy_id  = aws_cloudfront_cache_policy.carmirror.id
+
+    compress               = false
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "carmirror/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = local.direct_sf_cid_contact_origin_id
+    cache_policy_id  = aws_cloudfront_cache_policy.carmirror.id
+
+    compress               = false
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
   restrictions {
     geo_restriction {
       restriction_type = "none"
@@ -279,6 +306,33 @@ resource "aws_cloudfront_cache_policy" "providers" {
 
     enable_accept_encoding_brotli = true
     enable_accept_encoding_gzip   = true
+  }
+}
+
+resource "aws_cloudfront_cache_policy" "carmirror" {
+  name        = "carmirror"
+  min_ttl     = 1200
+  default_ttl = 7200
+  max_ttl     = 86400
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {
+      cookie_behavior = "none"
+    }
+    headers_config {
+      header_behavior = "none"
+    }
+    query_strings_config {
+      # filestore HTTP list API (see filestore/http.go). Object GETs have none.
+      query_string_behavior = "whitelist"
+      query_strings {
+        items = ["list", "path", "recursive"]
+      }
+    }
+
+    # Objects are already gzip CARs; do not vary the cache on Accept-Encoding.
+    enable_accept_encoding_brotli = false
+    enable_accept_encoding_gzip   = false
   }
 }
 


### PR DESCRIPTION
## Summary
- Add dedicated `carmirror` / `carmirror/*` CloudFront behaviors on `cid.contact`, origin **sf** (`sf.cid.contact`), GET/HEAD/OPTIONS only.
- Cache policy matches the distribution default (20m / 2h / 24h). Publisher `.head` files are overwritten as the chain advances, so this cannot be a year-long TTL. 404s stay at the distribution 20m error cache.
- Do not recompress: objects are already gzip CARs. List API query keys (`list`, `path`, `recursive`) are in the cache key so they do not collide with object GETs.

## Test plan
- [x] `terraform plan` in `deploy/infrastructure/prod/us-east-2` shows the new cache policy and two behaviors, origin `direct_sf`.
- [x] After apply: `GET https://cid.contact/carmirror/...` is served from sf (not the default sf2 origin).
- [x] A repeated GET is a CloudFront hit; a 404 is not stuck for longer than ~20m.
- [x] Leave indexer External URLs on `https://sf.cid.contact/carmirror/` until this is applied — pointing them at `cid.contact/carmirror` first would hit the default origin (sf2) and loop.
