### PR TITLE
Add fill_carmirror to backfill advertisement CAR files

### DIFF
--- a/scripts/fill_carmirror/fill.go
+++ b/scripts/fill_carmirror/fill.go
@@ -1,0 +1,681 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"sync/atomic"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	dssync "github.com/ipfs/go-datastore/sync"
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipld/go-ipld-prime/multicodec"
+	"github.com/ipld/go-ipld-prime/node/basicnode"
+	"github.com/ipni/go-libipni/dagsync"
+	"github.com/ipni/go-libipni/ingest/schema"
+	"github.com/ipni/storetheindex/carstore"
+	"github.com/ipni/storetheindex/config"
+	"github.com/ipni/storetheindex/filestore"
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+
+	_ "github.com/ipld/go-ipld-prime/codec/dagcbor"
+	_ "github.com/ipld/go-ipld-prime/codec/dagjson"
+)
+
+const (
+	stopGenesis    = "genesis"
+	stopDepth      = "depth"
+	stopInvalidCar = "invalid_car"
+	stopCanceled   = "canceled"
+	stopError      = "error"
+)
+
+type source int
+
+const (
+	sourceNone source = iota
+	sourceMain
+	sourceExternal
+	sourceProvider
+)
+
+func (s source) String() string {
+	switch s {
+	case sourceMain:
+		return "main"
+	case sourceExternal:
+		return "external"
+	case sourceProvider:
+		return "provider"
+	default:
+		return "none"
+	}
+}
+
+// Options configures a fill run. Mirror must have MainMode readwrite.
+type Options struct {
+	Mirror            config.Mirror
+	HttpTimeout       time.Duration
+	HttpRetryMax      int
+	HttpRetryWaitMin  time.Duration
+	HttpRetryWaitMax  time.Duration
+	EntriesDepthLimit int64
+
+	Provider  peer.ID
+	StartAd   cid.Cid
+	Publisher peer.AddrInfo
+	Depth     int // 0 means unlimited
+
+	// Progress is called with a copy of the running stats. Optional.
+	Progress func(Stats)
+}
+
+// Stats is the running / final summary of a fill run.
+type Stats struct {
+	Scanned         int
+	AlreadyPresent  int
+	CopiedExternal  int
+	Downloaded      int
+	SkippedHAMT     int
+	SkippedNoEnts   int
+	EntryChunks     int
+	Multihashes     int
+	BytesDownloaded int64
+	BytesWritten    int64
+	StopReason      string
+	LastAd          cid.Cid
+}
+
+func (s Stats) print() {
+	fmt.Println("Stats:")
+	fmt.Printf("  scanned:           %d\n", s.Scanned)
+	fmt.Printf("  already present:   %d\n", s.AlreadyPresent)
+	fmt.Printf("  copied (external): %d\n", s.CopiedExternal)
+	fmt.Printf("  downloaded:        %d\n", s.Downloaded)
+	fmt.Printf("  skipped HAMT:      %d\n", s.SkippedHAMT)
+	fmt.Printf("  skipped no ents:   %d\n", s.SkippedNoEnts)
+	fmt.Printf("  entry chunks:      %d\n", s.EntryChunks)
+	fmt.Printf("  multihashes:       %d\n", s.Multihashes)
+	fmt.Printf("  bytes downloaded:  %d\n", s.BytesDownloaded)
+	fmt.Printf("  bytes written:     %d\n", s.BytesWritten)
+	if s.LastAd != cid.Undef {
+		fmt.Printf("  last ad:           %s\n", s.LastAd)
+	}
+	if s.StopReason != "" {
+		fmt.Printf("  stop reason:       %s\n", s.StopReason)
+	}
+}
+
+type carData struct {
+	ad      schema.Advertisement
+	adData  []byte
+	entries []carstore.EntryBlock
+	hamt    bool
+	chunks  int
+	mhs     int
+	size    int64
+}
+
+type filler struct {
+	opts       Options
+	ds         datastore.Batching
+	mainReader *carstore.CarReader
+	mainWriter *carstore.CarWriter
+	externals  []*carstore.CarReader
+	downloaded atomic.Int64
+
+	host host.Host
+	sub  *dagsync.Subscriber
+}
+
+// Fill walks a provider's advertisement chain and writes missing CAR files to
+// the main advertisement mirror. It never opens the indexer value store.
+func Fill(ctx context.Context, opts Options) (*Stats, error) {
+	f, err := newFiller(opts)
+	if err != nil {
+		return nil, err
+	}
+	defer f.close()
+	return f.run(ctx)
+}
+
+func newFiller(opts Options) (*filler, error) {
+	opts.Mirror.PopulateUnset()
+	if !opts.Mirror.MainMode.CanRead() || !opts.Mirror.MainMode.CanWrite() {
+		return nil, fmt.Errorf("main car mirror must be readwrite (got MainMode %q)", opts.Mirror.MainMode)
+	}
+	if opts.Mirror.Main.Type == "" || opts.Mirror.Main.Type == "none" {
+		return nil, errors.New("main car mirror has no storage backend")
+	}
+
+	ds := dssync.MutexWrap(datastore.NewMapDatastore())
+	mainStore, err := filestore.MakeFilestore(opts.Mirror.Main.Config)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create main car file store: %w", err)
+	}
+	if mainStore == nil {
+		return nil, errors.New("main car mirror storage backend is disabled")
+	}
+
+	mainWriter, err := carstore.NewWriter(ds, mainStore, carstore.WithCompress(opts.Mirror.Main.Compress))
+	if err != nil {
+		return nil, fmt.Errorf("cannot create main car writer: %w", err)
+	}
+	mainReader, err := carstore.NewReader(mainStore, carstore.WithCompress(opts.Mirror.Main.Compress))
+	if err != nil {
+		return nil, fmt.Errorf("cannot create main car reader: %w", err)
+	}
+
+	var externals []*carstore.CarReader
+	for i, ext := range opts.Mirror.External {
+		if ext.Type == "" || ext.Type == "none" {
+			continue
+		}
+		extStore, err := filestore.MakeFilestore(ext.Config)
+		if err != nil {
+			return nil, fmt.Errorf("cannot create external[%d] car store: %w", i, err)
+		}
+		if extStore == nil {
+			continue
+		}
+		reader, err := carstore.NewReader(extStore, carstore.WithCompress(ext.Compress))
+		if err != nil {
+			return nil, fmt.Errorf("cannot create external[%d] car reader: %w", i, err)
+		}
+		externals = append(externals, reader)
+	}
+
+	return &filler{
+		opts:       opts,
+		ds:         ds,
+		mainReader: mainReader,
+		mainWriter: mainWriter,
+		externals:  externals,
+	}, nil
+}
+
+func (f *filler) close() {
+	if f.sub != nil {
+		_ = f.sub.Close()
+	}
+	if f.host != nil {
+		_ = f.host.Close()
+	}
+}
+
+func (f *filler) run(ctx context.Context) (*Stats, error) {
+	st := &Stats{}
+	adCid := f.opts.StartAd
+	if adCid == cid.Undef {
+		return st, errors.New("no start advertisement: pass --cid or --indexer so LastAdvertisement can be read from provider info")
+	}
+
+	for adCid != cid.Undef {
+		if err := ctx.Err(); err != nil {
+			st.StopReason = stopCanceled
+			return st, err
+		}
+		if f.opts.Depth > 0 && st.Scanned >= f.opts.Depth {
+			st.StopReason = stopDepth
+			return st, nil
+		}
+
+		prev, err := f.processAd(ctx, adCid, st)
+		st.Scanned++
+		st.LastAd = adCid
+		if f.opts.Progress != nil {
+			f.opts.Progress(*st)
+		}
+		if err != nil {
+			if st.StopReason == "" {
+				st.StopReason = stopError
+			}
+			return st, err
+		}
+		adCid = prev
+	}
+
+	st.StopReason = stopGenesis
+	return st, nil
+}
+
+func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.Cid, error) {
+	data, src, err := f.loadExisting(ctx, adCid)
+	switch {
+	case err == nil && src == sourceMain:
+		st.AlreadyPresent++
+		st.EntryChunks += data.chunks
+		st.Multihashes += data.mhs
+		if data.hamt {
+			st.SkippedHAMT++
+			fmt.Printf("%s  present (HAMT entries skipped)\n", adCid)
+		}
+		return data.ad.PreviousCid(), nil
+
+	case err != nil && src == sourceMain:
+		st.StopReason = stopInvalidCar
+		return cid.Undef, fmt.Errorf("invalid CAR already on main for %s: %w", adCid, err)
+
+	case err == nil && src == sourceExternal:
+		skipEnts := data.hamt || !hasEntries(data.ad)
+		if skipEnts {
+			data.entries = nil
+		}
+		written, err := f.writeFromData(ctx, adCid, data)
+		if err != nil {
+			return cid.Undef, fmt.Errorf("cannot copy %s from external to main: %w", adCid, err)
+		}
+		st.CopiedExternal++
+		st.BytesWritten += written
+		if data.hamt {
+			st.SkippedHAMT++
+			fmt.Printf("%s  copied from external (ad only, HAMT skipped)  bytes=%d\n", adCid, written)
+		} else if !hasEntries(data.ad) {
+			st.SkippedNoEnts++
+			fmt.Printf("%s  copied from external (no entries)  bytes=%d\n", adCid, written)
+		} else {
+			st.EntryChunks += data.chunks
+			st.Multihashes += data.mhs
+			fmt.Printf("%s  copied from external  chunks=%d mhs=%d bytes=%d\n", adCid, data.chunks, data.mhs, written)
+		}
+		return data.ad.PreviousCid(), nil
+
+	case err != nil && !errors.Is(err, fs.ErrNotExist):
+		return cid.Undef, err
+	}
+
+	ad, err := f.fetchFromProvider(ctx, adCid)
+	if err != nil {
+		return cid.Undef, fmt.Errorf("cannot fetch %s from provider: %w", adCid, err)
+	}
+
+	if !hasEntries(ad) {
+		written, err := f.writeAdOnly(ctx, adCid)
+		if err != nil {
+			return cid.Undef, fmt.Errorf("cannot write ad-only CAR for %s: %w", adCid, err)
+		}
+		st.SkippedNoEnts++
+		st.Downloaded++
+		st.BytesWritten += written
+		st.BytesDownloaded = f.downloaded.Load()
+		fmt.Printf("%s  downloaded (no entries)  bytes=%d\n", adCid, written)
+		return ad.PreviousCid(), nil
+	}
+
+	entsCid := ad.Entries.(cidlink.Link).Cid
+	if err = f.syncOneEntry(ctx, entsCid); err != nil {
+		return cid.Undef, fmt.Errorf("cannot sync first entries block for %s: %w", adCid, err)
+	}
+	hamt, err := f.entryIsHAMT(ctx, entsCid)
+	if err != nil {
+		return cid.Undef, err
+	}
+	if hamt {
+		_ = f.ds.Delete(ctx, datastore.NewKey(entsCid.String()))
+		written, err := f.writeAdOnly(ctx, adCid)
+		if err != nil {
+			return cid.Undef, fmt.Errorf("cannot write ad-only CAR for HAMT ad %s: %w", adCid, err)
+		}
+		st.SkippedHAMT++
+		st.Downloaded++
+		st.BytesWritten += written
+		st.BytesDownloaded = f.downloaded.Load()
+		fmt.Printf("%s  downloaded (ad only, HAMT skipped)  bytes=%d\n", adCid, written)
+		return ad.PreviousCid(), nil
+	}
+
+	chunks, mhs, err := f.syncRemainingEntries(ctx, entsCid)
+	if err != nil {
+		return cid.Undef, fmt.Errorf("cannot sync entries for %s: %w", adCid, err)
+	}
+
+	info, err := f.mainWriter.Write(ctx, adCid, false, false)
+	if err != nil {
+		return cid.Undef, fmt.Errorf("cannot write CAR for %s: %w", adCid, err)
+	}
+	st.Downloaded++
+	st.EntryChunks += chunks
+	st.Multihashes += mhs
+	st.BytesDownloaded = f.downloaded.Load()
+	var written int64
+	if info != nil {
+		written = info.Size
+		st.BytesWritten += written
+	}
+	fmt.Printf("%s  downloaded  chunks=%d mhs=%d bytes=%d\n", adCid, chunks, mhs, written)
+	return ad.PreviousCid(), nil
+}
+
+func (f *filler) loadExisting(ctx context.Context, adCid cid.Cid) (*carData, source, error) {
+	block, err := f.mainReader.Read(ctx, adCid, false)
+	if err == nil {
+		data, vErr := inspectCar(adCid, block)
+		if vErr != nil {
+			return nil, sourceMain, vErr
+		}
+		return data, sourceMain, nil
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		return nil, sourceMain, err
+	}
+
+	for i, reader := range f.externals {
+		block, err = reader.Read(ctx, adCid, false)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) || errors.Is(err, context.Canceled) {
+				continue
+			}
+			fmt.Printf("external[%d] read error for %s: %s\n", i, adCid, err)
+			continue
+		}
+		data, vErr := inspectCar(adCid, block)
+		if vErr != nil {
+			fmt.Printf("external[%d] invalid CAR for %s: %s\n", i, adCid, vErr)
+			continue
+		}
+		return data, sourceExternal, nil
+	}
+
+	return nil, sourceNone, fs.ErrNotExist
+}
+
+func inspectCar(adCid cid.Cid, block *carstore.AdBlock) (*carData, error) {
+	defer func() { _ = block.Close() }()
+
+	if err := verifyCID(adCid, block.Data); err != nil {
+		return nil, fmt.Errorf("advertisement blob: %w", err)
+	}
+	ad, err := block.Advertisement()
+	if err != nil {
+		return nil, fmt.Errorf("cannot decode advertisement: %w", err)
+	}
+
+	out := &carData{
+		ad:     ad,
+		adData: block.Data,
+		size:   int64(len(block.Data)),
+	}
+
+	if !hasEntries(ad) {
+		if block.Entries == nil {
+			return out, nil
+		}
+		var extra int
+		for range block.Entries {
+			extra++
+		}
+		if extra > 0 {
+			return nil, fmt.Errorf("CAR has %d extra blocks but advertisement has no entries", extra)
+		}
+		return out, nil
+	}
+
+	expected := ad.Entries.(cidlink.Link).Cid
+	for entry := range block.Entries {
+		if entry.Err != nil {
+			return nil, entry.Err
+		}
+		if expected == cid.Undef {
+			return nil, errors.New("CAR has extra entry blocks beyond the entries chain")
+		}
+		if entry.Cid != expected {
+			return nil, fmt.Errorf("entry CID mismatch: car has %s, chain wants %s", entry.Cid, expected)
+		}
+		if err := verifyCID(entry.Cid, entry.Data); err != nil {
+			return nil, fmt.Errorf("entry blob %s: %w", entry.Cid, err)
+		}
+
+		chunk, err := entry.EntryChunk()
+		if err != nil {
+			if errors.Is(err, carstore.ErrHAMT) {
+				out.hamt = true
+				for range block.Entries {
+				}
+				return out, nil
+			}
+			return nil, fmt.Errorf("cannot decode entry chunk %s: %w", entry.Cid, err)
+		}
+
+		out.entries = append(out.entries, carstore.EntryBlock{Cid: entry.Cid, Data: entry.Data})
+		out.chunks++
+		out.mhs += len(chunk.Entries)
+		out.size += int64(len(entry.Data))
+		if chunk.Next == nil {
+			expected = cid.Undef
+		} else {
+			expected = chunk.Next.(cidlink.Link).Cid
+		}
+	}
+	if expected != cid.Undef {
+		return nil, fmt.Errorf("CAR is missing remaining entries starting at %s", expected)
+	}
+	return out, nil
+}
+
+func (f *filler) writeFromData(ctx context.Context, adCid cid.Cid, data *carData) (int64, error) {
+	if err := f.ds.Put(ctx, datastore.NewKey(adCid.String()), data.adData); err != nil {
+		return 0, err
+	}
+	skipEnts := data.hamt || !hasEntries(data.ad)
+	if !skipEnts {
+		for _, e := range data.entries {
+			if err := f.ds.Put(ctx, datastore.NewKey(e.Cid.String()), e.Data); err != nil {
+				return 0, err
+			}
+		}
+	}
+	info, err := f.mainWriter.Write(ctx, adCid, skipEnts, false)
+	if err != nil {
+		return 0, err
+	}
+	if info == nil {
+		return 0, nil
+	}
+	return info.Size, nil
+}
+
+func (f *filler) writeAdOnly(ctx context.Context, adCid cid.Cid) (int64, error) {
+	info, err := f.mainWriter.Write(ctx, adCid, true, false)
+	if err != nil {
+		return 0, err
+	}
+	if info == nil {
+		return 0, nil
+	}
+	return info.Size, nil
+}
+
+func (f *filler) fetchFromProvider(ctx context.Context, adCid cid.Cid) (schema.Advertisement, error) {
+	if err := f.ensurePublisher(ctx); err != nil {
+		return schema.Advertisement{}, err
+	}
+	_, err := f.sub.SyncAdChain(ctx, f.opts.Publisher, dagsync.WithHeadAdCid(adCid), dagsync.ScopedDepthLimit(1))
+	if err != nil {
+		return schema.Advertisement{}, err
+	}
+	raw, err := f.ds.Get(ctx, datastore.NewKey(adCid.String()))
+	if err != nil {
+		return schema.Advertisement{}, err
+	}
+	return schema.BytesToAdvertisement(adCid, raw)
+}
+
+func (f *filler) syncOneEntry(ctx context.Context, entsCid cid.Cid) error {
+	if err := f.ensurePublisher(ctx); err != nil {
+		return err
+	}
+	return f.sub.SyncOneEntry(ctx, f.opts.Publisher, entsCid)
+}
+
+func (f *filler) syncRemainingEntries(ctx context.Context, first cid.Cid) (chunks, mhs int, err error) {
+	raw, err := f.ds.Get(ctx, datastore.NewKey(first.String()))
+	if err != nil {
+		return 0, 0, err
+	}
+	chunk, err := decodeEntryChunk(first, raw)
+	if err != nil {
+		return 0, 0, err
+	}
+	chunks = 1
+	mhs = len(chunk.Entries)
+	if chunk.Next == nil {
+		return chunks, mhs, nil
+	}
+
+	next := chunk.Next.(cidlink.Link).Cid
+	hook := func(_ peer.ID, c cid.Cid, actions dagsync.SegmentSyncActions) {
+		raw, err := f.ds.Get(ctx, datastore.NewKey(c.String()))
+		if err != nil {
+			actions.FailSync(err)
+			return
+		}
+		ch, err := decodeEntryChunk(c, raw)
+		if err != nil {
+			actions.FailSync(err)
+			return
+		}
+		chunks++
+		mhs += len(ch.Entries)
+		if ch.Next == nil {
+			actions.SetNextSyncCid(cid.Undef)
+			return
+		}
+		actions.SetNextSyncCid(ch.Next.(cidlink.Link).Cid)
+	}
+	opts := []dagsync.SyncOption{dagsync.ScopedBlockHook(hook)}
+	if f.opts.EntriesDepthLimit != 0 {
+		opts = append(opts, dagsync.ScopedDepthLimit(f.opts.EntriesDepthLimit))
+	}
+	if err = f.sub.SyncEntries(ctx, f.opts.Publisher, next, opts...); err != nil {
+		return chunks, mhs, err
+	}
+	return chunks, mhs, nil
+}
+
+func (f *filler) entryIsHAMT(ctx context.Context, entsCid cid.Cid) (bool, error) {
+	raw, err := f.ds.Get(ctx, datastore.NewKey(entsCid.String()))
+	if err != nil {
+		return false, err
+	}
+	node, err := decodeNode(entsCid, raw)
+	if err != nil {
+		return false, err
+	}
+	return isHAMT(node), nil
+}
+
+func (f *filler) ensurePublisher(ctx context.Context) error {
+	if f.sub != nil {
+		return nil
+	}
+	if f.opts.Publisher.ID == "" && len(f.opts.Publisher.Addrs) == 0 {
+		return errors.New("no publisher address: pass --addr-info or --indexer")
+	}
+
+	h, err := libp2p.New()
+	if err != nil {
+		return fmt.Errorf("cannot create libp2p host: %w", err)
+	}
+	if f.opts.Publisher.ID != "" && len(f.opts.Publisher.Addrs) > 0 {
+		h.Peerstore().AddAddrs(f.opts.Publisher.ID, f.opts.Publisher.Addrs, time.Hour)
+	}
+
+	lsys := cidlink.DefaultLinkSystem()
+	lsys.StorageReadOpener = func(lctx ipld.LinkContext, lnk ipld.Link) (io.Reader, error) {
+		c := lnk.(cidlink.Link).Cid
+		val, err := f.ds.Get(lctx.Ctx, datastore.NewKey(c.String()))
+		if err != nil {
+			return nil, err
+		}
+		return bytes.NewBuffer(val), nil
+	}
+	lsys.StorageWriteOpener = func(lctx ipld.LinkContext) (io.Writer, ipld.BlockWriteCommitter, error) {
+		buf := bytes.NewBuffer(nil)
+		return buf, func(lnk ipld.Link) error {
+			c := lnk.(cidlink.Link).Cid
+			b := buf.Bytes()
+			f.downloaded.Add(int64(len(b)))
+			return f.ds.Put(lctx.Ctx, datastore.NewKey(c.String()), b)
+		}, nil
+	}
+
+	subOpts := []dagsync.Option{
+		dagsync.HttpTimeout(f.opts.HttpTimeout),
+		dagsync.RetryableHTTPClient(f.opts.HttpRetryMax, f.opts.HttpRetryWaitMin, f.opts.HttpRetryWaitMax),
+	}
+	if f.opts.EntriesDepthLimit != 0 {
+		subOpts = append(subOpts, dagsync.EntriesDepthLimit(f.opts.EntriesDepthLimit))
+	}
+	sub, err := dagsync.NewSubscriber(h, lsys, subOpts...)
+	if err != nil {
+		_ = h.Close()
+		return fmt.Errorf("cannot create dagsync subscriber: %w", err)
+	}
+
+	f.host = h
+	f.sub = sub
+	return nil
+}
+
+func hasEntries(ad schema.Advertisement) bool {
+	if ad.Entries == nil || ad.Entries == schema.NoEntries {
+		return false
+	}
+	c, ok := ad.Entries.(cidlink.Link)
+	if !ok {
+		return false
+	}
+	return c.Cid != cid.Undef
+}
+
+func verifyCID(c cid.Cid, data []byte) error {
+	got, err := c.Prefix().Sum(data)
+	if err != nil {
+		return err
+	}
+	if !got.Equals(c) {
+		return fmt.Errorf("cid does not match data (got %s want %s)", got, c)
+	}
+	return nil
+}
+
+func decodeEntryChunk(c cid.Cid, data []byte) (*schema.EntryChunk, error) {
+	node, err := decodeNodeWithPrototype(c, data, schema.EntryChunkPrototype)
+	if err != nil {
+		return nil, err
+	}
+	chunk, err := schema.UnwrapEntryChunk(node)
+	if err != nil {
+		return nil, err
+	}
+	return chunk, nil
+}
+
+func decodeNode(c cid.Cid, data []byte) (ipld.Node, error) {
+	return decodeNodeWithPrototype(c, data, basicnode.Prototype.Any)
+}
+
+func decodeNodeWithPrototype(c cid.Cid, data []byte, proto ipld.NodePrototype) (ipld.Node, error) {
+	nb := proto.NewBuilder()
+	decoder, err := multicodec.LookupDecoder(c.Prefix().Codec)
+	if err != nil {
+		return nil, err
+	}
+	if err = decoder(nb, bytes.NewBuffer(data)); err != nil {
+		return nil, err
+	}
+	return nb.Build(), nil
+}
+
+func isHAMT(n ipld.Node) bool {
+	h, _ := n.LookupByString("hamt")
+	return h != nil
+}

--- a/scripts/fill_carmirror/fill.go
+++ b/scripts/fill_carmirror/fill.go
@@ -86,6 +86,7 @@ type Stats struct {
 	Recreated       int
 	SkippedHAMT     int
 	SkippedNoEnts   int
+	SkippedRm       int
 	EntryChunks     int
 	Multihashes     int
 	BytesDownloaded int64
@@ -103,6 +104,7 @@ func (s Stats) print() {
 	fmt.Printf("  recreated:         %d\n", s.Recreated)
 	fmt.Printf("  skipped HAMT:      %d\n", s.SkippedHAMT)
 	fmt.Printf("  skipped no ents:   %d\n", s.SkippedNoEnts)
+	fmt.Printf("  skipped IsRm:      %d\n", s.SkippedRm)
 	fmt.Printf("  entry chunks:      %d\n", s.EntryChunks)
 	fmt.Printf("  multihashes:       %d\n", s.Multihashes)
 	fmt.Printf("  bytes downloaded:  %d\n", s.BytesDownloaded)
@@ -138,8 +140,9 @@ type filler struct {
 }
 
 // Fill walks a provider's advertisement chain and writes missing or invalid
-// CAR files to the main advertisement mirror. It never opens the indexer
-// value store.
+// CAR files to the main advertisement mirror. Removal (IsRm) and no-entries
+// ads are not stored. An IsRm ad is reported (whether a CAR already exists on
+// main) and otherwise left untouched. It never opens the indexer value store.
 func Fill(ctx context.Context, opts Options) (*Stats, error) {
 	f, err := newFiller(opts)
 	if err != nil {
@@ -253,8 +256,35 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 	n := st.Scanned + 1
 	fmt.Printf("[%d] %s  checking main\n", n, adCid)
 	data, src, mainBroken, err := f.loadExisting(ctx, n, adCid)
-	switch {
-	case err == nil && src == sourceMain:
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return cid.Undef, err
+	}
+
+	var ad schema.Advertisement
+	if err == nil {
+		ad = data.ad
+		fmt.Printf("[%d] %s  loaded from %s  %s\n", n, adCid, src, formatCarData(data))
+	} else {
+		if mainBroken {
+			fmt.Printf("[%d] %s  main CAR unusable, fetching from publisher %s\n", n, adCid, f.opts.Publisher.ID)
+		} else {
+			fmt.Printf("[%d] %s  not in mirrors, fetching from publisher %s\n", n, adCid, f.opts.Publisher.ID)
+		}
+		ad, err = f.fetchFromProvider(ctx, adCid)
+		if err != nil {
+			return cid.Undef, fmt.Errorf("cannot fetch %s from provider: %w", adCid, err)
+		}
+		src = sourceProvider
+		st.BytesDownloaded = f.downloaded.Load()
+		fmt.Printf("[%d] %s  fetched ad  %s\n", n, adCid, formatAd(ad))
+	}
+
+	if skipUnstored(n, adCid, ad, src, mainBroken, st) {
+		return ad.PreviousCid(), nil
+	}
+
+	switch src {
+	case sourceMain:
 		st.AlreadyPresent++
 		st.EntryChunks += data.chunks
 		st.Multihashes += data.mhs
@@ -262,10 +292,10 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 			st.SkippedHAMT++
 		}
 		fmt.Printf("[%d] %s  present on main  %s\n", n, adCid, formatCarData(data))
-		return data.ad.PreviousCid(), nil
+		return ad.PreviousCid(), nil
 
-	case err == nil && src == sourceExternal:
-		skipEnts := data.hamt || !hasEntries(data.ad)
+	case sourceExternal:
+		skipEnts := data.hamt || !hasEntries(ad)
 		if skipEnts {
 			data.entries = nil
 		}
@@ -280,8 +310,6 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 		}
 		if data.hamt {
 			st.SkippedHAMT++
-		} else if !hasEntries(data.ad) {
-			st.SkippedNoEnts++
 		} else {
 			st.EntryChunks += data.chunks
 			st.Multihashes += data.mhs
@@ -291,33 +319,6 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 			action = "recreated from external"
 		}
 		fmt.Printf("[%d] %s  %s  %s  written=%d\n", n, adCid, action, formatCarData(data), written)
-		return data.ad.PreviousCid(), nil
-
-	case err != nil && !errors.Is(err, fs.ErrNotExist):
-		return cid.Undef, err
-	}
-
-	if mainBroken {
-		fmt.Printf("[%d] %s  main CAR unusable, fetching from publisher %s\n", n, adCid, f.opts.Publisher.ID)
-	} else {
-		fmt.Printf("[%d] %s  not in mirrors, fetching from publisher %s\n", n, adCid, f.opts.Publisher.ID)
-	}
-	ad, err := f.fetchFromProvider(ctx, adCid)
-	if err != nil {
-		return cid.Undef, fmt.Errorf("cannot fetch %s from provider: %w", adCid, err)
-	}
-	fmt.Printf("[%d] %s  fetched ad  %s\n", n, adCid, formatAd(ad))
-
-	if !hasEntries(ad) {
-		written, err := f.writeAdOnly(ctx, adCid)
-		if err != nil {
-			return cid.Undef, fmt.Errorf("cannot write ad-only CAR for %s: %w", adCid, err)
-		}
-		st.SkippedNoEnts++
-		noteWrittenFromPublisher(st, mainBroken)
-		st.BytesWritten += written
-		st.BytesDownloaded = f.downloaded.Load()
-		fmt.Printf("[%d] %s  %s (no entries)  written=%d down_bytes=%d\n", n, adCid, publisherAction(mainBroken), written, st.BytesDownloaded)
 		return ad.PreviousCid(), nil
 	}
 
@@ -366,6 +367,21 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 	}
 	fmt.Printf("[%d] %s  %s  %s  chunks=%d mhs=%d written=%d down_bytes=%d\n", n, adCid, publisherAction(mainBroken), formatAd(ad), chunks, mhs, written, st.BytesDownloaded)
 	return ad.PreviousCid(), nil
+}
+
+func skipUnstored(n int, adCid cid.Cid, ad schema.Advertisement, src source, mainBroken bool, st *Stats) bool {
+	if ad.IsRm {
+		onMain := src == sourceMain || mainBroken
+		st.SkippedRm++
+		fmt.Printf("[%d] %s  skip IsRm  car_on_main=%t  %s\n", n, adCid, onMain, formatAd(ad))
+		return true
+	}
+	if !hasEntries(ad) {
+		st.SkippedNoEnts++
+		fmt.Printf("[%d] %s  skip no-entries  %s\n", n, adCid, formatAd(ad))
+		return true
+	}
+	return false
 }
 
 func noteWrittenFromPublisher(st *Stats, mainBroken bool) {

--- a/scripts/fill_carmirror/fill.go
+++ b/scripts/fill_carmirror/fill.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log/slog"
 	"sync/atomic"
 	"time"
 
@@ -93,28 +94,6 @@ type Stats struct {
 	BytesWritten    int64
 	StopReason      string
 	LastAd          cid.Cid
-}
-
-func (s Stats) print() {
-	fmt.Println("Stats:")
-	fmt.Printf("  scanned:           %d\n", s.Scanned)
-	fmt.Printf("  already present:   %d\n", s.AlreadyPresent)
-	fmt.Printf("  copied (external): %d\n", s.CopiedExternal)
-	fmt.Printf("  downloaded:        %d\n", s.Downloaded)
-	fmt.Printf("  recreated:         %d\n", s.Recreated)
-	fmt.Printf("  skipped HAMT:      %d\n", s.SkippedHAMT)
-	fmt.Printf("  skipped no ents:   %d\n", s.SkippedNoEnts)
-	fmt.Printf("  skipped IsRm:      %d\n", s.SkippedRm)
-	fmt.Printf("  entry chunks:      %d\n", s.EntryChunks)
-	fmt.Printf("  multihashes:       %d\n", s.Multihashes)
-	fmt.Printf("  bytes downloaded:  %d\n", s.BytesDownloaded)
-	fmt.Printf("  bytes written:     %d\n", s.BytesWritten)
-	if s.LastAd != cid.Undef {
-		fmt.Printf("  last ad:           %s\n", s.LastAd)
-	}
-	if s.StopReason != "" {
-		fmt.Printf("  stop reason:       %s\n", s.StopReason)
-	}
 }
 
 type carData struct {
@@ -254,8 +233,9 @@ func (f *filler) run(ctx context.Context) (*Stats, error) {
 
 func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.Cid, error) {
 	n := st.Scanned + 1
-	fmt.Printf("[%d] %s  checking main\n", n, adCid)
-	data, src, mainBroken, err := f.loadExisting(ctx, n, adCid)
+	log := log.With("n", n, "ad", adCid)
+	log.Debug("checking main")
+	data, src, mainBroken, err := f.loadExisting(ctx, log, adCid)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return cid.Undef, err
 	}
@@ -263,12 +243,13 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 	var ad schema.Advertisement
 	if err == nil {
 		ad = data.ad
-		fmt.Printf("[%d] %s  loaded from %s  %s\n", n, adCid, src, formatCarData(data))
+		log = logAdFields(log, ad)
+		logCarFields(log, data).Info("loaded advertisement", "source", src.String())
 	} else {
 		if mainBroken {
-			fmt.Printf("[%d] %s  main CAR unusable, fetching from publisher %s\n", n, adCid, f.opts.Publisher.ID)
+			log.Info("main CAR unusable, fetching from publisher", "publisher", f.opts.Publisher.ID)
 		} else {
-			fmt.Printf("[%d] %s  not in mirrors, fetching from publisher %s\n", n, adCid, f.opts.Publisher.ID)
+			log.Info("not in mirrors, fetching from publisher", "publisher", f.opts.Publisher.ID)
 		}
 		ad, err = f.fetchFromProvider(ctx, adCid)
 		if err != nil {
@@ -276,10 +257,11 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 		}
 		src = sourceProvider
 		st.BytesDownloaded = f.downloaded.Load()
-		fmt.Printf("[%d] %s  fetched ad  %s\n", n, adCid, formatAd(ad))
+		log = logAdFields(log, ad)
+		log.Info("fetched advertisement")
 	}
 
-	if skipUnstored(n, adCid, ad, src, mainBroken, st) {
+	if skipUnstored(log, ad, src, mainBroken, st) {
 		return ad.PreviousCid(), nil
 	}
 
@@ -291,7 +273,7 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 		if data.hamt {
 			st.SkippedHAMT++
 		}
-		fmt.Printf("[%d] %s  present on main  %s\n", n, adCid, formatCarData(data))
+		logCarFields(log, data).Info("present on main")
 		return ad.PreviousCid(), nil
 
 	case sourceExternal:
@@ -314,16 +296,16 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 			st.EntryChunks += data.chunks
 			st.Multihashes += data.mhs
 		}
-		action := "copied from external"
 		if mainBroken {
-			action = "recreated from external"
+			logCarFields(log, data).Info("recreated from external", "written", written)
+		} else {
+			logCarFields(log, data).Info("copied from external", "written", written)
 		}
-		fmt.Printf("[%d] %s  %s  %s  written=%d\n", n, adCid, action, formatCarData(data), written)
 		return ad.PreviousCid(), nil
 	}
 
 	entsCid := ad.Entries.(cidlink.Link).Cid
-	fmt.Printf("[%d] %s  syncing first entries block %s\n", n, adCid, entsCid)
+	log.Info("syncing first entries block", "entries", entsCid)
 	if err = f.syncOneEntry(ctx, entsCid); err != nil {
 		return cid.Undef, fmt.Errorf("cannot sync first entries block for %s: %w", adCid, err)
 	}
@@ -332,7 +314,7 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 		return cid.Undef, err
 	}
 	if hamt {
-		fmt.Printf("[%d] %s  entries are HAMT, writing ad only\n", n, adCid)
+		log.Info("entries are HAMT, writing ad only")
 		_ = f.ds.Delete(ctx, datastore.NewKey(entsCid.String()))
 		written, err := f.writeAdOnly(ctx, adCid)
 		if err != nil {
@@ -342,11 +324,11 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 		noteWrittenFromPublisher(st, mainBroken)
 		st.BytesWritten += written
 		st.BytesDownloaded = f.downloaded.Load()
-		fmt.Printf("[%d] %s  %s (HAMT skipped)  written=%d down_bytes=%d\n", n, adCid, publisherAction(mainBroken), written, st.BytesDownloaded)
+		log.Info(publisherAction(mainBroken), "hamt", true, "written", written, "bytesDownloaded", st.BytesDownloaded)
 		return ad.PreviousCid(), nil
 	}
 
-	fmt.Printf("[%d] %s  syncing remaining entry chunks from %s\n", n, adCid, entsCid)
+	log.Info("syncing remaining entry chunks", "entries", entsCid)
 	chunks, mhs, err := f.syncRemainingEntries(ctx, entsCid)
 	if err != nil {
 		return cid.Undef, fmt.Errorf("cannot sync entries for %s: %w", adCid, err)
@@ -365,20 +347,20 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 		written = info.Size
 		st.BytesWritten += written
 	}
-	fmt.Printf("[%d] %s  %s  %s  chunks=%d mhs=%d written=%d down_bytes=%d\n", n, adCid, publisherAction(mainBroken), formatAd(ad), chunks, mhs, written, st.BytesDownloaded)
+	log.Info(publisherAction(mainBroken), "chunks", chunks, "multihashes", mhs, "written", written, "bytesDownloaded", st.BytesDownloaded)
 	return ad.PreviousCid(), nil
 }
 
-func skipUnstored(n int, adCid cid.Cid, ad schema.Advertisement, src source, mainBroken bool, st *Stats) bool {
+func skipUnstored(log *slog.Logger, ad schema.Advertisement, src source, mainBroken bool, st *Stats) bool {
 	if ad.IsRm {
 		onMain := src == sourceMain || mainBroken
 		st.SkippedRm++
-		fmt.Printf("[%d] %s  skip IsRm  car_on_main=%t  %s\n", n, adCid, onMain, formatAd(ad))
+		log.Info("skip IsRm", "carOnMain", onMain)
 		return true
 	}
 	if !hasEntries(ad) {
 		st.SkippedNoEnts++
-		fmt.Printf("[%d] %s  skip no-entries  %s\n", n, adCid, formatAd(ad))
+		log.Info("skip no-entries")
 		return true
 	}
 	return false
@@ -398,7 +380,7 @@ func publisherAction(mainBroken bool) string {
 	return "downloaded"
 }
 
-func (f *filler) loadExisting(ctx context.Context, n int, adCid cid.Cid) (*carData, source, bool, error) {
+func (f *filler) loadExisting(ctx context.Context, log *slog.Logger, adCid cid.Cid) (*carData, source, bool, error) {
 	mainBroken := false
 	block, err := f.mainReader.Read(ctx, adCid, false)
 	switch {
@@ -410,29 +392,29 @@ func (f *filler) loadExisting(ctx context.Context, n int, adCid cid.Cid) (*carDa
 		if isCanceled(vErr) {
 			return nil, sourceNone, false, vErr
 		}
-		fmt.Printf("[%d] %s  main CAR invalid, will recreate: %s\n", n, adCid, vErr)
+		log.Info("main CAR invalid, will recreate", "err", vErr)
 		mainBroken = true
 	case isCanceled(err):
 		return nil, sourceNone, false, err
 	case errors.Is(err, fs.ErrNotExist):
-		fmt.Printf("[%d] %s  main miss\n", n, adCid)
+		log.Debug("main miss")
 	default:
-		fmt.Printf("[%d] %s  main read error, will recreate: %s\n", n, adCid, err)
+		log.Info("main read error, will recreate", "err", err)
 		mainBroken = true
 	}
 
 	for i, reader := range f.externals {
-		fmt.Printf("[%d] %s  checking external[%d] %s\n", n, adCid, i, reader.Location())
+		log.Debug("checking external", "external", i, "location", reader.Location())
 		block, err = reader.Read(ctx, adCid, false)
 		if err != nil {
 			if isCanceled(err) {
 				return nil, sourceNone, mainBroken, err
 			}
 			if errors.Is(err, fs.ErrNotExist) {
-				fmt.Printf("[%d] %s  external[%d] miss\n", n, adCid, i)
+				log.Debug("external miss", "external", i)
 				continue
 			}
-			fmt.Printf("[%d] %s  external[%d] read error: %s\n", n, adCid, i, err)
+			log.Info("external read error", "external", i, "err", err)
 			continue
 		}
 		data, vErr := inspectCar(adCid, block)
@@ -440,10 +422,10 @@ func (f *filler) loadExisting(ctx context.Context, n int, adCid cid.Cid) (*carDa
 			if isCanceled(vErr) {
 				return nil, sourceNone, mainBroken, vErr
 			}
-			fmt.Printf("[%d] %s  external[%d] invalid CAR: %s\n", n, adCid, i, vErr)
+			log.Info("external invalid CAR", "external", i, "err", vErr)
 			continue
 		}
-		fmt.Printf("[%d] %s  external[%d] hit\n", n, adCid, i)
+		log.Info("external hit", "external", i)
 		return data, sourceExternal, mainBroken, nil
 	}
 
@@ -701,32 +683,6 @@ func hasEntries(ad schema.Advertisement) bool {
 		return false
 	}
 	return c.Cid != cid.Undef
-}
-
-func formatAd(ad schema.Advertisement) string {
-	prev := "nil"
-	if p := ad.PreviousCid(); p != cid.Undef {
-		prev = p.String()
-	}
-	ents := "none"
-	if hasEntries(ad) {
-		ents = ad.Entries.(cidlink.Link).Cid.String()
-	}
-	rm := ""
-	if ad.IsRm {
-		rm = " rm=true"
-	}
-	return fmt.Sprintf("prev=%s entries=%s provider=%s%s", prev, ents, ad.Provider, rm)
-}
-
-func formatCarData(data *carData) string {
-	kind := "entries"
-	if data.hamt {
-		kind = "HAMT"
-	} else if !hasEntries(data.ad) {
-		kind = "no-entries"
-	}
-	return fmt.Sprintf("%s  %s  chunks=%d mhs=%d car_bytes=%d", formatAd(data.ad), kind, data.chunks, data.mhs, data.size)
 }
 
 func verifyCID(c cid.Cid, data []byte) error {

--- a/scripts/fill_carmirror/fill.go
+++ b/scripts/fill_carmirror/fill.go
@@ -31,11 +31,10 @@ import (
 )
 
 const (
-	stopGenesis    = "genesis"
-	stopDepth      = "depth"
-	stopInvalidCar = "invalid_car"
-	stopCanceled   = "canceled"
-	stopError      = "error"
+	stopGenesis  = "genesis"
+	stopDepth    = "depth"
+	stopCanceled = "canceled"
+	stopError    = "error"
 )
 
 type source int
@@ -84,6 +83,7 @@ type Stats struct {
 	AlreadyPresent  int
 	CopiedExternal  int
 	Downloaded      int
+	Recreated       int
 	SkippedHAMT     int
 	SkippedNoEnts   int
 	EntryChunks     int
@@ -100,6 +100,7 @@ func (s Stats) print() {
 	fmt.Printf("  already present:   %d\n", s.AlreadyPresent)
 	fmt.Printf("  copied (external): %d\n", s.CopiedExternal)
 	fmt.Printf("  downloaded:        %d\n", s.Downloaded)
+	fmt.Printf("  recreated:         %d\n", s.Recreated)
 	fmt.Printf("  skipped HAMT:      %d\n", s.SkippedHAMT)
 	fmt.Printf("  skipped no ents:   %d\n", s.SkippedNoEnts)
 	fmt.Printf("  entry chunks:      %d\n", s.EntryChunks)
@@ -136,8 +137,9 @@ type filler struct {
 	sub  *dagsync.Subscriber
 }
 
-// Fill walks a provider's advertisement chain and writes missing CAR files to
-// the main advertisement mirror. It never opens the indexer value store.
+// Fill walks a provider's advertisement chain and writes missing or invalid
+// CAR files to the main advertisement mirror. It never opens the indexer
+// value store.
 func Fill(ctx context.Context, opts Options) (*Stats, error) {
 	f, err := newFiller(opts)
 	if err != nil {
@@ -248,7 +250,9 @@ func (f *filler) run(ctx context.Context) (*Stats, error) {
 }
 
 func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.Cid, error) {
-	data, src, err := f.loadExisting(ctx, adCid)
+	n := st.Scanned + 1
+	fmt.Printf("[%d] %s  checking main\n", n, adCid)
+	data, src, mainBroken, err := f.loadExisting(ctx, n, adCid)
 	switch {
 	case err == nil && src == sourceMain:
 		st.AlreadyPresent++
@@ -256,13 +260,9 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 		st.Multihashes += data.mhs
 		if data.hamt {
 			st.SkippedHAMT++
-			fmt.Printf("%s  present (HAMT entries skipped)\n", adCid)
 		}
+		fmt.Printf("[%d] %s  present on main  %s\n", n, adCid, formatCarData(data))
 		return data.ad.PreviousCid(), nil
-
-	case err != nil && src == sourceMain:
-		st.StopReason = stopInvalidCar
-		return cid.Undef, fmt.Errorf("invalid CAR already on main for %s: %w", adCid, err)
 
 	case err == nil && src == sourceExternal:
 		skipEnts := data.hamt || !hasEntries(data.ad)
@@ -275,27 +275,38 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 		}
 		st.CopiedExternal++
 		st.BytesWritten += written
+		if mainBroken {
+			st.Recreated++
+		}
 		if data.hamt {
 			st.SkippedHAMT++
-			fmt.Printf("%s  copied from external (ad only, HAMT skipped)  bytes=%d\n", adCid, written)
 		} else if !hasEntries(data.ad) {
 			st.SkippedNoEnts++
-			fmt.Printf("%s  copied from external (no entries)  bytes=%d\n", adCid, written)
 		} else {
 			st.EntryChunks += data.chunks
 			st.Multihashes += data.mhs
-			fmt.Printf("%s  copied from external  chunks=%d mhs=%d bytes=%d\n", adCid, data.chunks, data.mhs, written)
 		}
+		action := "copied from external"
+		if mainBroken {
+			action = "recreated from external"
+		}
+		fmt.Printf("[%d] %s  %s  %s  written=%d\n", n, adCid, action, formatCarData(data), written)
 		return data.ad.PreviousCid(), nil
 
 	case err != nil && !errors.Is(err, fs.ErrNotExist):
 		return cid.Undef, err
 	}
 
+	if mainBroken {
+		fmt.Printf("[%d] %s  main CAR unusable, fetching from publisher %s\n", n, adCid, f.opts.Publisher.ID)
+	} else {
+		fmt.Printf("[%d] %s  not in mirrors, fetching from publisher %s\n", n, adCid, f.opts.Publisher.ID)
+	}
 	ad, err := f.fetchFromProvider(ctx, adCid)
 	if err != nil {
 		return cid.Undef, fmt.Errorf("cannot fetch %s from provider: %w", adCid, err)
 	}
+	fmt.Printf("[%d] %s  fetched ad  %s\n", n, adCid, formatAd(ad))
 
 	if !hasEntries(ad) {
 		written, err := f.writeAdOnly(ctx, adCid)
@@ -303,14 +314,15 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 			return cid.Undef, fmt.Errorf("cannot write ad-only CAR for %s: %w", adCid, err)
 		}
 		st.SkippedNoEnts++
-		st.Downloaded++
+		noteWrittenFromPublisher(st, mainBroken)
 		st.BytesWritten += written
 		st.BytesDownloaded = f.downloaded.Load()
-		fmt.Printf("%s  downloaded (no entries)  bytes=%d\n", adCid, written)
+		fmt.Printf("[%d] %s  %s (no entries)  written=%d down_bytes=%d\n", n, adCid, publisherAction(mainBroken), written, st.BytesDownloaded)
 		return ad.PreviousCid(), nil
 	}
 
 	entsCid := ad.Entries.(cidlink.Link).Cid
+	fmt.Printf("[%d] %s  syncing first entries block %s\n", n, adCid, entsCid)
 	if err = f.syncOneEntry(ctx, entsCid); err != nil {
 		return cid.Undef, fmt.Errorf("cannot sync first entries block for %s: %w", adCid, err)
 	}
@@ -319,19 +331,21 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 		return cid.Undef, err
 	}
 	if hamt {
+		fmt.Printf("[%d] %s  entries are HAMT, writing ad only\n", n, adCid)
 		_ = f.ds.Delete(ctx, datastore.NewKey(entsCid.String()))
 		written, err := f.writeAdOnly(ctx, adCid)
 		if err != nil {
 			return cid.Undef, fmt.Errorf("cannot write ad-only CAR for HAMT ad %s: %w", adCid, err)
 		}
 		st.SkippedHAMT++
-		st.Downloaded++
+		noteWrittenFromPublisher(st, mainBroken)
 		st.BytesWritten += written
 		st.BytesDownloaded = f.downloaded.Load()
-		fmt.Printf("%s  downloaded (ad only, HAMT skipped)  bytes=%d\n", adCid, written)
+		fmt.Printf("[%d] %s  %s (HAMT skipped)  written=%d down_bytes=%d\n", n, adCid, publisherAction(mainBroken), written, st.BytesDownloaded)
 		return ad.PreviousCid(), nil
 	}
 
+	fmt.Printf("[%d] %s  syncing remaining entry chunks from %s\n", n, adCid, entsCid)
 	chunks, mhs, err := f.syncRemainingEntries(ctx, entsCid)
 	if err != nil {
 		return cid.Undef, fmt.Errorf("cannot sync entries for %s: %w", adCid, err)
@@ -341,7 +355,7 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 	if err != nil {
 		return cid.Undef, fmt.Errorf("cannot write CAR for %s: %w", adCid, err)
 	}
-	st.Downloaded++
+	noteWrittenFromPublisher(st, mainBroken)
 	st.EntryChunks += chunks
 	st.Multihashes += mhs
 	st.BytesDownloaded = f.downloaded.Load()
@@ -350,41 +364,78 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 		written = info.Size
 		st.BytesWritten += written
 	}
-	fmt.Printf("%s  downloaded  chunks=%d mhs=%d bytes=%d\n", adCid, chunks, mhs, written)
+	fmt.Printf("[%d] %s  %s  %s  chunks=%d mhs=%d written=%d down_bytes=%d\n", n, adCid, publisherAction(mainBroken), formatAd(ad), chunks, mhs, written, st.BytesDownloaded)
 	return ad.PreviousCid(), nil
 }
 
-func (f *filler) loadExisting(ctx context.Context, adCid cid.Cid) (*carData, source, error) {
-	block, err := f.mainReader.Read(ctx, adCid, false)
-	if err == nil {
-		data, vErr := inspectCar(adCid, block)
-		if vErr != nil {
-			return nil, sourceMain, vErr
-		}
-		return data, sourceMain, nil
+func noteWrittenFromPublisher(st *Stats, mainBroken bool) {
+	st.Downloaded++
+	if mainBroken {
+		st.Recreated++
 	}
-	if !errors.Is(err, fs.ErrNotExist) {
-		return nil, sourceMain, err
+}
+
+func publisherAction(mainBroken bool) string {
+	if mainBroken {
+		return "recreated from publisher"
+	}
+	return "downloaded"
+}
+
+func (f *filler) loadExisting(ctx context.Context, n int, adCid cid.Cid) (*carData, source, bool, error) {
+	mainBroken := false
+	block, err := f.mainReader.Read(ctx, adCid, false)
+	switch {
+	case err == nil:
+		data, vErr := inspectCar(adCid, block)
+		if vErr == nil {
+			return data, sourceMain, false, nil
+		}
+		if isCanceled(vErr) {
+			return nil, sourceNone, false, vErr
+		}
+		fmt.Printf("[%d] %s  main CAR invalid, will recreate: %s\n", n, adCid, vErr)
+		mainBroken = true
+	case isCanceled(err):
+		return nil, sourceNone, false, err
+	case errors.Is(err, fs.ErrNotExist):
+		fmt.Printf("[%d] %s  main miss\n", n, adCid)
+	default:
+		fmt.Printf("[%d] %s  main read error, will recreate: %s\n", n, adCid, err)
+		mainBroken = true
 	}
 
 	for i, reader := range f.externals {
+		fmt.Printf("[%d] %s  checking external[%d] %s\n", n, adCid, i, reader.Location())
 		block, err = reader.Read(ctx, adCid, false)
 		if err != nil {
-			if errors.Is(err, fs.ErrNotExist) || errors.Is(err, context.Canceled) {
+			if isCanceled(err) {
+				return nil, sourceNone, mainBroken, err
+			}
+			if errors.Is(err, fs.ErrNotExist) {
+				fmt.Printf("[%d] %s  external[%d] miss\n", n, adCid, i)
 				continue
 			}
-			fmt.Printf("external[%d] read error for %s: %s\n", i, adCid, err)
+			fmt.Printf("[%d] %s  external[%d] read error: %s\n", n, adCid, i, err)
 			continue
 		}
 		data, vErr := inspectCar(adCid, block)
 		if vErr != nil {
-			fmt.Printf("external[%d] invalid CAR for %s: %s\n", i, adCid, vErr)
+			if isCanceled(vErr) {
+				return nil, sourceNone, mainBroken, vErr
+			}
+			fmt.Printf("[%d] %s  external[%d] invalid CAR: %s\n", n, adCid, i, vErr)
 			continue
 		}
-		return data, sourceExternal, nil
+		fmt.Printf("[%d] %s  external[%d] hit\n", n, adCid, i)
+		return data, sourceExternal, mainBroken, nil
 	}
 
-	return nil, sourceNone, fs.ErrNotExist
+	return nil, sourceNone, mainBroken, fs.ErrNotExist
+}
+
+func isCanceled(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }
 
 func inspectCar(adCid cid.Cid, block *carstore.AdBlock) (*carData, error) {
@@ -634,6 +685,32 @@ func hasEntries(ad schema.Advertisement) bool {
 		return false
 	}
 	return c.Cid != cid.Undef
+}
+
+func formatAd(ad schema.Advertisement) string {
+	prev := "nil"
+	if p := ad.PreviousCid(); p != cid.Undef {
+		prev = p.String()
+	}
+	ents := "none"
+	if hasEntries(ad) {
+		ents = ad.Entries.(cidlink.Link).Cid.String()
+	}
+	rm := ""
+	if ad.IsRm {
+		rm = " rm=true"
+	}
+	return fmt.Sprintf("prev=%s entries=%s provider=%s%s", prev, ents, ad.Provider, rm)
+}
+
+func formatCarData(data *carData) string {
+	kind := "entries"
+	if data.hamt {
+		kind = "HAMT"
+	} else if !hasEntries(data.ad) {
+		kind = "no-entries"
+	}
+	return fmt.Sprintf("%s  %s  chunks=%d mhs=%d car_bytes=%d", formatAd(data.ad), kind, data.chunks, data.mhs, data.size)
 }
 
 func verifyCID(c cid.Cid, data []byte) error {

--- a/scripts/fill_carmirror/fill_test.go
+++ b/scripts/fill_carmirror/fill_test.go
@@ -164,25 +164,75 @@ func TestFillCopiesFromExternal(t *testing.T) {
 	}
 }
 
-func TestFillStopsOnInvalidMainCAR(t *testing.T) {
+func TestFillRecreatesInvalidMainCARFromExternal(t *testing.T) {
 	ctx := context.Background()
 	main := localStore(t)
+	ext := localStore(t)
 	ds := datastore.NewMapDatastore()
 	ad2, ad1 := storeAdChain(t, ds, 2)
 	writeCAR(t, cloneDS(t, ds), main, ad1.cid)
-
-	fs, err := filestore.MakeFilestore(main.Config)
-	require.NoError(t, err)
-	_, err = fs.Put(ctx, ad2.cid.String()+carstore.CarFileSuffix+carstore.GzipFileSuffix, bytes.NewReader([]byte("not-a-car")))
-	require.NoError(t, err)
+	writeJunkCAR(t, main, ad2.cid)
+	writeCAR(t, cloneDS(t, ds), ext, ad2.cid)
+	writeCAR(t, cloneDS(t, ds), ext, ad1.cid)
 
 	st, err := Fill(ctx, Options{
-		Mirror:  rwMirror(main),
+		Mirror:  rwMirror(main, ext),
 		StartAd: ad2.cid,
 	})
-	require.Error(t, err)
-	require.Equal(t, stopInvalidCar, st.StopReason)
-	require.Equal(t, 1, st.Scanned)
+	require.NoError(t, err)
+	require.Equal(t, 2, st.Scanned)
+	require.Equal(t, 1, st.AlreadyPresent)
+	require.Equal(t, 1, st.CopiedExternal)
+	require.Equal(t, 1, st.Recreated)
+	require.Zero(t, st.Downloaded)
+	require.Equal(t, stopGenesis, st.StopReason)
+
+	reader, err := carstore.NewReader(mustStore(t, main), carstore.WithCompress(main.Compress))
+	require.NoError(t, err)
+	block, err := reader.Read(ctx, ad2.cid, false)
+	require.NoError(t, err)
+	_, err = inspectCar(ad2.cid, block)
+	require.NoError(t, err)
+}
+
+func TestFillRecreatesInvalidMainCARFromPublisher(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	pubDS := dssync.MutexWrap(datastore.NewMapDatastore())
+	ad2, ad1 := storeAdChain(t, pubDS, 2)
+
+	priv, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	require.NoError(t, err)
+	pub, err := ipnisync.NewPublisher(mkLinkSystem(pubDS), priv, ipnisync.WithHTTPListenAddrs("127.0.0.1:0"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pub.Close() })
+	pub.SetRoot(ad2.cid)
+
+	main := localStore(t)
+	writeCAR(t, cloneDS(t, pubDS), main, ad1.cid)
+	writeJunkCAR(t, main, ad2.cid)
+
+	st, err := Fill(ctx, Options{
+		Mirror:      rwMirror(main),
+		StartAd:     ad2.cid,
+		Publisher:   peer.AddrInfo{ID: pub.ID(), Addrs: pub.Addrs()},
+		HttpTimeout: 10 * time.Second,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, st.Scanned)
+	require.Equal(t, 1, st.AlreadyPresent)
+	require.Equal(t, 1, st.Downloaded)
+	require.Equal(t, 1, st.Recreated)
+	require.Equal(t, stopGenesis, st.StopReason)
+
+	reader, err := carstore.NewReader(mustStore(t, main), carstore.WithCompress(main.Compress))
+	require.NoError(t, err)
+	block, err := reader.Read(ctx, ad2.cid, false)
+	require.NoError(t, err)
+	data, err := inspectCar(ad2.cid, block)
+	require.NoError(t, err)
+	require.NotZero(t, data.chunks)
 }
 
 func TestFillDepthLimit(t *testing.T) {
@@ -346,6 +396,17 @@ func writeCAR(t *testing.T, ds datastore.Batching, storeCfg config.StoreConfig, 
 	w, err := carstore.NewWriter(ds, fs, carstore.WithCompress(storeCfg.Compress))
 	require.NoError(t, err)
 	_, err = w.Write(context.Background(), adCid, false, false)
+	require.NoError(t, err)
+}
+
+func writeJunkCAR(t *testing.T, storeCfg config.StoreConfig, adCid cid.Cid) {
+	t.Helper()
+	fs := mustStore(t, storeCfg)
+	path := adCid.String() + carstore.CarFileSuffix
+	if storeCfg.Compress == carstore.Gzip {
+		path += carstore.GzipFileSuffix
+	}
+	_, err := fs.Put(context.Background(), path, bytes.NewReader([]byte("not-a-car")))
 	require.NoError(t, err)
 }
 

--- a/scripts/fill_carmirror/fill_test.go
+++ b/scripts/fill_carmirror/fill_test.go
@@ -1,0 +1,440 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/query"
+	dssync "github.com/ipfs/go-datastore/sync"
+	"github.com/ipfs/go-test/random"
+	ipld "github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipni/go-libipni/dagsync/ipnisync"
+	"github.com/ipni/go-libipni/find/model"
+	"github.com/ipni/go-libipni/ingest/schema"
+	"github.com/ipni/storetheindex/carstore"
+	"github.com/ipni/storetheindex/config"
+	"github.com/ipni/storetheindex/filestore"
+	crypto "github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multihash"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewFillerRequiresReadWrite(t *testing.T) {
+	main := localStore(t)
+	_, err := newFiller(Options{Mirror: config.Mirror{MainMode: config.MainModeRead, Main: main}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "readwrite")
+
+	_, err = newFiller(Options{Mirror: config.Mirror{MainMode: config.MainModeWrite, Main: main}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "readwrite")
+}
+
+func TestFillRequiresStartAd(t *testing.T) {
+	_, err := Fill(context.Background(), Options{Mirror: rwMirror(localStore(t))})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "LastAdvertisement")
+}
+
+func TestApplyIndexerUsesLastAdvertisement(t *testing.T) {
+	provider, _, _ := random.Identity()
+	publisher, _, _ := random.Identity()
+	lastAd := random.Cids(1)[0]
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/providers/"+provider.String(), r.URL.Path)
+		require.NoError(t, json.NewEncoder(w).Encode(model.ProviderInfo{
+			AddrInfo:          peer.AddrInfo{ID: provider},
+			LastAdvertisement: lastAd,
+			Publisher:         &peer.AddrInfo{ID: publisher},
+		}))
+	}))
+	t.Cleanup(srv.Close)
+
+	var opts Options
+	require.NoError(t, applyIndexer(context.Background(), srv.URL, provider, &opts))
+	require.Equal(t, lastAd, opts.StartAd)
+	require.Equal(t, publisher, opts.Publisher.ID)
+}
+
+func TestLocalConfigResolvesMirrorDir(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.json")
+	require.NoError(t, os.WriteFile(cfgFile, []byte(`{
+  "Version": 2,
+  "Ingest": {
+    "AdvertisementMirror": {
+      "MainMode": "readwrite",
+      "Main": {
+        "Type": "local",
+        "Compress": "gzip",
+        "Local": {
+          "BasePath": "mirror",
+          "DefaultPathSplit": [11, 2]
+        }
+      },
+      "External": [
+        {
+          "Type": "http",
+          "Compress": "gzip",
+          "HTTP": {
+            "BaseURL": "https://sf.cid.contact/carmirror/"
+          }
+        }
+      ]
+    }
+  }
+}`), 0o644))
+
+	cfg, err := config.Load(cfgFile)
+	require.NoError(t, err)
+	require.Equal(t, config.MainModeReadWrite, cfg.Ingest.AdvertisementMirror.MainMode)
+	require.Equal(t, "https://sf.cid.contact/carmirror/", cfg.Ingest.AdvertisementMirror.External[0].HTTP.BaseURL)
+
+	require.NoError(t, resolveRelativeMirrorPaths(cfg, cfgFile))
+	require.True(t, filepath.IsAbs(cfg.Ingest.AdvertisementMirror.Main.Local.BasePath))
+	require.Equal(t, "mirror", filepath.Base(cfg.Ingest.AdvertisementMirror.Main.Local.BasePath))
+	st, err := os.Stat(cfg.Ingest.AdvertisementMirror.Main.Local.BasePath)
+	require.NoError(t, err)
+	require.True(t, st.IsDir())
+}
+
+func TestFillAlreadyOnMain(t *testing.T) {
+	ctx := context.Background()
+	main := localStore(t)
+	ds := datastore.NewMapDatastore()
+	ad2, ad1 := storeAdChain(t, ds, 2)
+
+	writeCAR(t, ds, main, ad2.cid)
+	writeCAR(t, cloneDS(t, ds), main, ad1.cid)
+
+	st, err := Fill(ctx, Options{
+		Mirror:   rwMirror(main),
+		Provider: ad2.provider,
+		StartAd:  ad2.cid,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, st.Scanned)
+	require.Equal(t, 2, st.AlreadyPresent)
+	require.Zero(t, st.Downloaded)
+	require.Zero(t, st.CopiedExternal)
+	require.Equal(t, stopGenesis, st.StopReason)
+}
+
+func TestFillCopiesFromExternal(t *testing.T) {
+	ctx := context.Background()
+	main := localStore(t)
+	ext := localStore(t)
+	ds := datastore.NewMapDatastore()
+	ad2, ad1 := storeAdChain(t, ds, 2)
+
+	writeCAR(t, cloneDS(t, ds), ext, ad2.cid)
+	writeCAR(t, cloneDS(t, ds), ext, ad1.cid)
+
+	st, err := Fill(ctx, Options{
+		Mirror:  rwMirror(main, ext),
+		StartAd: ad2.cid,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, st.CopiedExternal)
+	require.Zero(t, st.AlreadyPresent)
+	require.Zero(t, st.Downloaded)
+	require.Equal(t, stopGenesis, st.StopReason)
+
+	reader, err := carstore.NewReader(mustStore(t, main), carstore.WithCompress(main.Compress))
+	require.NoError(t, err)
+	for _, c := range []cid.Cid{ad2.cid, ad1.cid} {
+		block, err := reader.Read(ctx, c, false)
+		require.NoError(t, err)
+		_, err = inspectCar(c, block)
+		require.NoError(t, err)
+	}
+}
+
+func TestFillStopsOnInvalidMainCAR(t *testing.T) {
+	ctx := context.Background()
+	main := localStore(t)
+	ds := datastore.NewMapDatastore()
+	ad2, ad1 := storeAdChain(t, ds, 2)
+	writeCAR(t, cloneDS(t, ds), main, ad1.cid)
+
+	fs, err := filestore.MakeFilestore(main.Config)
+	require.NoError(t, err)
+	_, err = fs.Put(ctx, ad2.cid.String()+carstore.CarFileSuffix+carstore.GzipFileSuffix, bytes.NewReader([]byte("not-a-car")))
+	require.NoError(t, err)
+
+	st, err := Fill(ctx, Options{
+		Mirror:  rwMirror(main),
+		StartAd: ad2.cid,
+	})
+	require.Error(t, err)
+	require.Equal(t, stopInvalidCar, st.StopReason)
+	require.Equal(t, 1, st.Scanned)
+}
+
+func TestFillDepthLimit(t *testing.T) {
+	ctx := context.Background()
+	main := localStore(t)
+	ds := datastore.NewMapDatastore()
+	ad3, ad2, ad1 := storeAdChain3(t, ds)
+	for _, ad := range []testAd{ad3, ad2, ad1} {
+		writeCAR(t, cloneDS(t, ds), main, ad.cid)
+	}
+
+	st, err := Fill(ctx, Options{
+		Mirror:  rwMirror(main),
+		StartAd: ad3.cid,
+		Depth:   2,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, st.Scanned)
+	require.Equal(t, 2, st.AlreadyPresent)
+	require.Equal(t, stopDepth, st.StopReason)
+}
+
+func TestFillWritesAdOnlyForNoEntries(t *testing.T) {
+	ctx := context.Background()
+	main := localStore(t)
+	ext := localStore(t)
+	ds := datastore.NewMapDatastore()
+
+	empty := storeAd(t, ds, 0, nil)
+	withEnts := storeAd(t, ds, 2, cidlink.Link{Cid: empty.cid})
+	writeCAR(t, cloneDS(t, ds), ext, withEnts.cid)
+	writeCAR(t, cloneDS(t, ds), ext, empty.cid)
+
+	st, err := Fill(ctx, Options{
+		Mirror:  rwMirror(main, ext),
+		StartAd: withEnts.cid,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, st.CopiedExternal)
+	require.Equal(t, 1, st.SkippedNoEnts)
+	require.Equal(t, 2, st.Scanned)
+	require.Equal(t, stopGenesis, st.StopReason)
+
+	reader, err := carstore.NewReader(mustStore(t, main), carstore.WithCompress(main.Compress))
+	require.NoError(t, err)
+	block, err := reader.Read(ctx, empty.cid, true)
+	require.NoError(t, err)
+	require.NoError(t, block.Close())
+}
+
+func TestFillDownloadsFromProvider(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	pubDS := dssync.MutexWrap(datastore.NewMapDatastore())
+	ad2, ad1 := storeAdChain(t, pubDS, 2)
+
+	priv, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	require.NoError(t, err)
+	lsys := mkLinkSystem(pubDS)
+	pub, err := ipnisync.NewPublisher(lsys, priv, ipnisync.WithHTTPListenAddrs("127.0.0.1:0"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pub.Close() })
+	pub.SetRoot(ad2.cid)
+
+	main := localStore(t)
+	st, err := Fill(ctx, Options{
+		Mirror:      rwMirror(main),
+		StartAd:     ad2.cid,
+		Publisher:   peer.AddrInfo{ID: pub.ID(), Addrs: pub.Addrs()},
+		HttpTimeout: 10 * time.Second,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, st.Downloaded)
+	require.Zero(t, st.AlreadyPresent)
+	require.Equal(t, stopGenesis, st.StopReason)
+	require.Positive(t, st.BytesWritten)
+	require.Positive(t, st.BytesDownloaded)
+
+	reader, err := carstore.NewReader(mustStore(t, main), carstore.WithCompress(main.Compress))
+	require.NoError(t, err)
+	for _, c := range []cid.Cid{ad2.cid, ad1.cid} {
+		block, err := reader.Read(ctx, c, false)
+		require.NoError(t, err)
+		data, err := inspectCar(c, block)
+		require.NoError(t, err)
+		require.False(t, data.hamt)
+		require.NotZero(t, data.chunks)
+	}
+}
+
+func TestFillUsesEachSourceOnce(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	pubDS := dssync.MutexWrap(datastore.NewMapDatastore())
+	ad3, ad2, _ := storeAdChain3(t, pubDS)
+
+	main := localStore(t)
+	ext := localStore(t)
+	writeCAR(t, cloneDS(t, pubDS), main, ad3.cid)
+	writeCAR(t, cloneDS(t, pubDS), ext, ad2.cid)
+
+	priv, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	require.NoError(t, err)
+	pub, err := ipnisync.NewPublisher(mkLinkSystem(pubDS), priv, ipnisync.WithHTTPListenAddrs("127.0.0.1:0"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pub.Close() })
+	pub.SetRoot(ad3.cid)
+
+	st, err := Fill(ctx, Options{
+		Mirror:      rwMirror(main, ext),
+		StartAd:     ad3.cid,
+		Publisher:   peer.AddrInfo{ID: pub.ID(), Addrs: pub.Addrs()},
+		HttpTimeout: 10 * time.Second,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, st.AlreadyPresent)
+	require.Equal(t, 1, st.CopiedExternal)
+	require.Equal(t, 1, st.Downloaded)
+	require.Equal(t, 3, st.Scanned)
+	require.Equal(t, stopGenesis, st.StopReason)
+}
+
+type testAd struct {
+	cid      cid.Cid
+	provider peer.ID
+}
+
+func localStore(t *testing.T) config.StoreConfig {
+	t.Helper()
+	return config.StoreConfig{
+		Compress: carstore.Gzip,
+		Config: filestore.Config{
+			Type: "local",
+			Local: filestore.LocalConfig{
+				BasePath: t.TempDir(),
+			},
+		},
+	}
+}
+
+func rwMirror(main config.StoreConfig, ext ...config.StoreConfig) config.Mirror {
+	return config.Mirror{
+		MainMode: config.MainModeReadWrite,
+		Main:     main,
+		External: ext,
+	}
+}
+
+func mustStore(t *testing.T, cfg config.StoreConfig) filestore.Interface {
+	t.Helper()
+	s, err := filestore.MakeFilestore(cfg.Config)
+	require.NoError(t, err)
+	return s
+}
+
+func writeCAR(t *testing.T, ds datastore.Batching, storeCfg config.StoreConfig, adCid cid.Cid) {
+	t.Helper()
+	fs := mustStore(t, storeCfg)
+	w, err := carstore.NewWriter(ds, fs, carstore.WithCompress(storeCfg.Compress))
+	require.NoError(t, err)
+	_, err = w.Write(context.Background(), adCid, false, false)
+	require.NoError(t, err)
+}
+
+func storeAdChain(t *testing.T, ds datastore.Datastore, chunksPerAd int) (latest, prev testAd) {
+	t.Helper()
+	a1 := storeAd(t, ds, chunksPerAd, nil)
+	a2 := storeAd(t, ds, chunksPerAd, cidlink.Link{Cid: a1.cid})
+	return a2, a1
+}
+
+func storeAdChain3(t *testing.T, ds datastore.Datastore) (ad3, ad2, ad1 testAd) {
+	t.Helper()
+	ad1 = storeAd(t, ds, 2, nil)
+	ad2 = storeAd(t, ds, 2, cidlink.Link{Cid: ad1.cid})
+	ad3 = storeAd(t, ds, 2, cidlink.Link{Cid: ad2.cid})
+	return ad3, ad2, ad1
+}
+
+func storeAd(t *testing.T, ds datastore.Datastore, chunkCount int, prev ipld.Link) testAd {
+	t.Helper()
+	lsys := mkLinkSystem(ds)
+	p, priv, _ := random.Identity()
+	adv := &schema.Advertisement{
+		Provider:   p.String(),
+		Addresses:  []string{"/ip4/127.0.0.1/tcp/9999"},
+		ContextID:  []byte("test-context-id"),
+		Metadata:   []byte("test-metadata"),
+		PreviousID: prev,
+	}
+	if chunkCount == 0 {
+		adv.Entries = schema.NoEntries
+	} else {
+		adv.Entries, _ = newEntryList(t, lsys, chunkCount)
+	}
+	require.NoError(t, adv.Sign(priv))
+	node, err := adv.ToNode()
+	require.NoError(t, err)
+	lnk, err := lsys.Store(ipld.LinkContext{}, schema.Linkproto, node)
+	require.NoError(t, err)
+	return testAd{cid: lnk.(cidlink.Link).Cid, provider: p}
+}
+
+func newEntryList(t *testing.T, lsys ipld.LinkSystem, size int) (ipld.Link, []multihash.Multihash) {
+	t.Helper()
+	var out []multihash.Multihash
+	var next ipld.Link
+	rnd := random.New()
+	for range size {
+		mhs := rnd.Multihashes(4)
+		chunk := &schema.EntryChunk{Entries: mhs, Next: next}
+		node, err := chunk.ToNode()
+		require.NoError(t, err)
+		lnk, err := lsys.Store(ipld.LinkContext{}, schema.Linkproto, node)
+		require.NoError(t, err)
+		out = append(out, mhs...)
+		next = lnk
+	}
+	return next, out
+}
+
+func mkLinkSystem(ds datastore.Datastore) ipld.LinkSystem {
+	lsys := cidlink.DefaultLinkSystem()
+	lsys.StorageReadOpener = func(lctx ipld.LinkContext, lnk ipld.Link) (io.Reader, error) {
+		c := lnk.(cidlink.Link).Cid
+		val, err := ds.Get(lctx.Ctx, datastore.NewKey(c.String()))
+		if err != nil {
+			return nil, err
+		}
+		return bytes.NewBuffer(val), nil
+	}
+	lsys.StorageWriteOpener = func(lctx ipld.LinkContext) (io.Writer, ipld.BlockWriteCommitter, error) {
+		buf := bytes.NewBuffer(nil)
+		return buf, func(lnk ipld.Link) error {
+			c := lnk.(cidlink.Link).Cid
+			return ds.Put(lctx.Ctx, datastore.NewKey(c.String()), buf.Bytes())
+		}, nil
+	}
+	return lsys
+}
+
+func cloneDS(t *testing.T, src datastore.Datastore) datastore.Batching {
+	t.Helper()
+	dst := dssync.MutexWrap(datastore.NewMapDatastore())
+	res, err := src.Query(context.Background(), query.Query{})
+	require.NoError(t, err)
+	defer func() { _ = res.Close() }()
+	for r := range res.Next() {
+		require.NoError(t, r.Error)
+		require.NoError(t, dst.Put(context.Background(), datastore.NewKey(r.Key), r.Value))
+	}
+	return dst
+}

--- a/scripts/fill_carmirror/fill_test.go
+++ b/scripts/fill_carmirror/fill_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"io"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -255,7 +256,7 @@ func TestFillDepthLimit(t *testing.T) {
 	require.Equal(t, stopDepth, st.StopReason)
 }
 
-func TestFillWritesAdOnlyForNoEntries(t *testing.T) {
+func TestFillSkipsNoEntries(t *testing.T) {
 	ctx := context.Background()
 	main := localStore(t)
 	ext := localStore(t)
@@ -271,16 +272,69 @@ func TestFillWritesAdOnlyForNoEntries(t *testing.T) {
 		StartAd: withEnts.cid,
 	})
 	require.NoError(t, err)
-	require.Equal(t, 2, st.CopiedExternal)
+	require.Equal(t, 1, st.CopiedExternal)
 	require.Equal(t, 1, st.SkippedNoEnts)
 	require.Equal(t, 2, st.Scanned)
 	require.Equal(t, stopGenesis, st.StopReason)
+	require.True(t, carExists(t, main, withEnts.cid))
+	require.False(t, carExists(t, main, empty.cid))
+}
 
-	reader, err := carstore.NewReader(mustStore(t, main), carstore.WithCompress(main.Compress))
+func TestFillSkipsIsRmWithoutWritingOrDeleting(t *testing.T) {
+	ctx := context.Background()
+	main := localStore(t)
+	ds := datastore.NewMapDatastore()
+	ctxID := []byte("removed-context")
+
+	content := storeAdWith(t, ds, 2, nil, false, ctxID)
+	rm := storeAdWith(t, ds, 0, cidlink.Link{Cid: content.cid}, true, ctxID)
+	writeCAR(t, cloneDS(t, ds), main, content.cid)
+	writeCAR(t, cloneDS(t, ds), main, rm.cid)
+	require.True(t, carExists(t, main, content.cid))
+	require.True(t, carExists(t, main, rm.cid))
+
+	st, err := Fill(ctx, Options{
+		Mirror:  rwMirror(main),
+		StartAd: rm.cid,
+	})
 	require.NoError(t, err)
-	block, err := reader.Read(ctx, empty.cid, true)
+	require.Equal(t, 2, st.Scanned)
+	require.Equal(t, 1, st.SkippedRm)
+	require.Equal(t, 1, st.AlreadyPresent)
+	require.Equal(t, stopGenesis, st.StopReason)
+	require.True(t, carExists(t, main, rm.cid))
+	require.True(t, carExists(t, main, content.cid))
+}
+
+func TestFillSkipsIsRmFromPublisher(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	pubDS := dssync.MutexWrap(datastore.NewMapDatastore())
+	content := storeAdWith(t, pubDS, 2, nil, false, []byte("keep-ctx"))
+	rm := storeAdWith(t, pubDS, 0, cidlink.Link{Cid: content.cid}, true, []byte("other-ctx"))
+
+	priv, _, err := crypto.GenerateEd25519Key(rand.Reader)
 	require.NoError(t, err)
-	require.NoError(t, block.Close())
+	pub, err := ipnisync.NewPublisher(mkLinkSystem(pubDS), priv, ipnisync.WithHTTPListenAddrs("127.0.0.1:0"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pub.Close() })
+	pub.SetRoot(rm.cid)
+
+	main := localStore(t)
+	st, err := Fill(ctx, Options{
+		Mirror:      rwMirror(main),
+		StartAd:     rm.cid,
+		Publisher:   peer.AddrInfo{ID: pub.ID(), Addrs: pub.Addrs()},
+		HttpTimeout: 10 * time.Second,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, st.Scanned)
+	require.Equal(t, 1, st.SkippedRm)
+	require.Equal(t, 1, st.Downloaded)
+	require.Equal(t, stopGenesis, st.StopReason)
+	require.False(t, carExists(t, main, rm.cid))
+	require.True(t, carExists(t, main, content.cid))
 }
 
 func TestFillDownloadsFromProvider(t *testing.T) {
@@ -410,6 +464,21 @@ func writeJunkCAR(t *testing.T, storeCfg config.StoreConfig, adCid cid.Cid) {
 	require.NoError(t, err)
 }
 
+func carExists(t *testing.T, storeCfg config.StoreConfig, adCid cid.Cid) bool {
+	t.Helper()
+	store := mustStore(t, storeCfg)
+	path := adCid.String() + carstore.CarFileSuffix
+	if storeCfg.Compress == carstore.Gzip {
+		path += carstore.GzipFileSuffix
+	}
+	_, err := store.Head(context.Background(), path)
+	if err != nil {
+		require.ErrorIs(t, err, fs.ErrNotExist)
+		return false
+	}
+	return true
+}
+
 func storeAdChain(t *testing.T, ds datastore.Datastore, chunksPerAd int) (latest, prev testAd) {
 	t.Helper()
 	a1 := storeAd(t, ds, chunksPerAd, nil)
@@ -427,16 +496,22 @@ func storeAdChain3(t *testing.T, ds datastore.Datastore) (ad3, ad2, ad1 testAd) 
 
 func storeAd(t *testing.T, ds datastore.Datastore, chunkCount int, prev ipld.Link) testAd {
 	t.Helper()
+	return storeAdWith(t, ds, chunkCount, prev, false, []byte("test-context-id"))
+}
+
+func storeAdWith(t *testing.T, ds datastore.Datastore, chunkCount int, prev ipld.Link, isRm bool, ctxID []byte) testAd {
+	t.Helper()
 	lsys := mkLinkSystem(ds)
 	p, priv, _ := random.Identity()
 	adv := &schema.Advertisement{
 		Provider:   p.String(),
 		Addresses:  []string{"/ip4/127.0.0.1/tcp/9999"},
-		ContextID:  []byte("test-context-id"),
+		ContextID:  ctxID,
 		Metadata:   []byte("test-metadata"),
 		PreviousID: prev,
+		IsRm:       isRm,
 	}
-	if chunkCount == 0 {
+	if isRm || chunkCount == 0 {
 		adv.Entries = schema.NoEntries
 	} else {
 		adv.Entries, _ = newEntryList(t, lsys, chunkCount)

--- a/scripts/fill_carmirror/log.go
+++ b/scripts/fill_carmirror/log.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/ipfs/go-cid"
+	logging "github.com/ipfs/go-log/v2"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipni/go-libipni/ingest/schema"
+	"github.com/libp2p/go-libp2p/gologshim"
+)
+
+const loggerName = "fill_carmirror"
+
+// Discard until setupLogger wires slog through go-log, so tests stay quiet.
+var log = slog.New(slog.DiscardHandler)
+
+func setupLogger() error {
+	cfg := logging.GetConfig()
+	format, err := resolveLogFormat()
+	if err != nil {
+		return err
+	}
+	cfg.Format = format
+	if !cfg.Stdout && !cfg.Stderr && cfg.File == "" && cfg.URL == "" {
+		cfg.Stderr = true
+	}
+	logging.SetupLogging(cfg)
+	if os.Getenv("GOLOG_LOG_LEVEL") == "" && os.Getenv("IPFS_LOGGING") == "" {
+		if err := logging.SetLogLevel(loggerName, "info"); err != nil {
+			return err
+		}
+	}
+
+	handler := logging.SlogHandler()
+	slog.SetDefault(slog.New(handler))
+	gologshim.SetDefaultHandler(handler)
+	log = slog.New(handler.WithAttrs([]slog.Attr{slog.String("logger", loggerName)}))
+	return nil
+}
+
+func resolveLogFormat() (logging.LogFormat, error) {
+	if v := os.Getenv("GOLOG_LOG_FMT"); v != "" {
+		return parseLogFormat(v)
+	}
+	if v := os.Getenv("IPFS_LOGGING_FMT"); v != "" {
+		return parseLogFormat(v)
+	}
+	return logging.JSONOutput, nil
+}
+
+func parseLogFormat(format string) (logging.LogFormat, error) {
+	switch strings.ToLower(format) {
+	case "json":
+		return logging.JSONOutput, nil
+	case "color", "text", "console":
+		return logging.ColorizedOutput, nil
+	case "nocolor", "plain":
+		return logging.PlaintextOutput, nil
+	default:
+		return 0, fmt.Errorf("unknown log format %q (json, color, nocolor)", format)
+	}
+}
+
+func logStart(log *slog.Logger, opts Options) *slog.Logger {
+	l := log.With(
+		"provider", opts.Provider,
+		"mainMode", opts.Mirror.MainMode,
+		"mainMirror", opts.Mirror.Main.Local.BasePath,
+	)
+	if opts.StartAd != cid.Undef {
+		l = l.With("startAd", opts.StartAd)
+	}
+	if opts.Publisher.ID != "" {
+		addrs := make([]string, len(opts.Publisher.Addrs))
+		for i, a := range opts.Publisher.Addrs {
+			addrs[i] = a.String()
+		}
+		l = l.With("publisher", opts.Publisher.ID, "publisherAddrs", addrs)
+	}
+	return l
+}
+
+func logStats(log *slog.Logger, s Stats) *slog.Logger {
+	l := log.With(
+		"scanned", s.Scanned,
+		"alreadyPresent", s.AlreadyPresent,
+		"copiedExternal", s.CopiedExternal,
+		"downloaded", s.Downloaded,
+		"recreated", s.Recreated,
+		"skippedHAMT", s.SkippedHAMT,
+		"skippedNoEnts", s.SkippedNoEnts,
+		"skippedRm", s.SkippedRm,
+		"entryChunks", s.EntryChunks,
+		"multihashes", s.Multihashes,
+		"bytesDownloaded", s.BytesDownloaded,
+		"bytesWritten", s.BytesWritten,
+	)
+	if s.LastAd != cid.Undef {
+		l = l.With("lastAd", s.LastAd)
+	}
+	if s.StopReason != "" {
+		l = l.With("stopReason", s.StopReason)
+	}
+	return l
+}
+
+func logAdFields(log *slog.Logger, ad schema.Advertisement) *slog.Logger {
+	l := log.With("provider", ad.Provider, "isRm", ad.IsRm)
+	if p := ad.PreviousCid(); p != cid.Undef {
+		l = l.With("prev", p)
+	}
+	if hasEntries(ad) {
+		l = l.With("entries", ad.Entries.(cidlink.Link).Cid)
+	}
+	return l
+}
+
+func logCarFields(log *slog.Logger, data *carData) *slog.Logger {
+	if data == nil {
+		return log
+	}
+	kind := "entries"
+	if data.hamt {
+		kind = "HAMT"
+	} else if !hasEntries(data.ad) {
+		kind = "no-entries"
+	}
+	return log.With("kind", kind, "chunks", data.chunks, "multihashes", data.mhs, "carBytes", data.size)
+}

--- a/scripts/fill_carmirror/log_test.go
+++ b/scripts/fill_carmirror/log_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"testing"
+
+	logging "github.com/ipfs/go-log/v2"
+)
+
+func TestResolveLogFormat(t *testing.T) {
+	t.Setenv("GOLOG_LOG_FMT", "")
+	t.Setenv("IPFS_LOGGING_FMT", "")
+
+	got, err := resolveLogFormat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != logging.JSONOutput {
+		t.Fatalf("default format: got %v want json", got)
+	}
+
+	t.Setenv("GOLOG_LOG_FMT", "color")
+	got, err = resolveLogFormat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != logging.ColorizedOutput {
+		t.Fatalf("GOLOG_LOG_FMT=color: got %v want color", got)
+	}
+}

--- a/scripts/fill_carmirror/main.go
+++ b/scripts/fill_carmirror/main.go
@@ -28,6 +28,8 @@ func main() {
 External mirrors are tried before downloading from the publisher.
 A CAR already on main that fails validation is overwritten from external
 or the publisher instead of stopping the walk.
+IsRm and no-entries advertisements are not stored. An IsRm advertisement
+is logged (including whether a CAR already exists on main) and not written.
 Does not open the indexer value store.`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
@@ -130,8 +132,8 @@ func run(cctx *cli.Context) error {
 		opts.Progress = func(s Stats) {
 			select {
 			case <-ticker.C:
-				fmt.Printf("progress  scanned=%d present=%d external=%d downloaded=%d recreated=%d hamt=%d chunks=%d mhs=%d down_bytes=%d written=%d last=%s\n",
-					s.Scanned, s.AlreadyPresent, s.CopiedExternal, s.Downloaded, s.Recreated, s.SkippedHAMT,
+				fmt.Printf("progress  scanned=%d present=%d external=%d downloaded=%d recreated=%d rm=%d hamt=%d chunks=%d mhs=%d down_bytes=%d written=%d last=%s\n",
+					s.Scanned, s.AlreadyPresent, s.CopiedExternal, s.Downloaded, s.Recreated, s.SkippedRm, s.SkippedHAMT,
 					s.EntryChunks, s.Multihashes, s.BytesDownloaded, s.BytesWritten, s.LastAd)
 			default:
 			}

--- a/scripts/fill_carmirror/main.go
+++ b/scripts/fill_carmirror/main.go
@@ -30,7 +30,8 @@ A CAR already on main that fails validation is overwritten from external
 or the publisher instead of stopping the walk.
 IsRm and no-entries advertisements are not stored. An IsRm advertisement
 is logged (including whether a CAR already exists on main) and not written.
-Does not open the indexer value store.`,
+Does not open the indexer value store.
+Logging uses go-log env vars (GOLOG_LOG_FMT, GOLOG_LOG_LEVEL, GOLOG_FILE, ...).`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "config",
@@ -59,7 +60,7 @@ Does not open the indexer value store.`,
 			},
 			&cli.DurationFlag{
 				Name:  "progress",
-				Usage: "How often to print running stats",
+				Usage: "How often to log running stats",
 				Value: 10 * time.Second,
 			},
 		},
@@ -73,6 +74,10 @@ Does not open the indexer value store.`,
 }
 
 func run(cctx *cli.Context) error {
+	if err := setupLogger(); err != nil {
+		return err
+	}
+
 	providerID, err := peer.Decode(cctx.String("provider"))
 	if err != nil {
 		return fmt.Errorf("bad --provider: %w", err)
@@ -132,38 +137,31 @@ func run(cctx *cli.Context) error {
 		opts.Progress = func(s Stats) {
 			select {
 			case <-ticker.C:
-				fmt.Printf("progress  scanned=%d present=%d external=%d downloaded=%d recreated=%d rm=%d hamt=%d chunks=%d mhs=%d down_bytes=%d written=%d last=%s\n",
-					s.Scanned, s.AlreadyPresent, s.CopiedExternal, s.Downloaded, s.Recreated, s.SkippedRm, s.SkippedHAMT,
-					s.EntryChunks, s.Multihashes, s.BytesDownloaded, s.BytesWritten, s.LastAd)
+				logStats(log, s).Info("progress")
 			default:
 			}
 		}
 	}
 
-	fmt.Printf("Filling car mirror for provider %s\n", providerID)
-	if opts.StartAd != cid.Undef {
-		fmt.Println("Start ad:", opts.StartAd)
-	}
-	if opts.Publisher.ID != "" {
-		fmt.Println("Publisher:", opts.Publisher.ID, opts.Publisher.Addrs)
-	}
-	fmt.Println("MainMode:", opts.Mirror.MainMode)
-	fmt.Println("Main mirror:", opts.Mirror.Main.Local.BasePath)
+	logStart(log, opts).Info("starting fill")
 	for i, ext := range opts.Mirror.External {
 		loc := ext.HTTP.BaseURL
 		if loc == "" {
 			loc = ext.Local.BasePath
 		}
-		fmt.Printf("External[%d]: %s %s\n", i, ext.Type, loc)
+		log.Info("external mirror", "index", i, "type", ext.Type, "location", loc)
 	}
 
 	st, err := Fill(ctx, opts)
-	if st != nil {
-		st.print()
-	}
 	if err != nil {
+		if st != nil {
+			logStats(log, *st).Error("fill failed", "err", err)
+		} else {
+			log.Error("fill failed", "err", err)
+		}
 		return fmt.Errorf("fill failed: %w", err)
 	}
+	logStats(log, *st).Info("fill complete")
 	return nil
 }
 
@@ -184,7 +182,7 @@ func applyIndexer(ctx context.Context, indexerURL string, providerID peer.ID, op
 			return fmt.Errorf("indexer has no LastAdvertisement for %s", providerID)
 		}
 		opts.StartAd = info.LastAdvertisement
-		fmt.Println("Start ad from indexer provider info LastAdvertisement:", opts.StartAd)
+		log.Info("using LastAdvertisement from indexer", "startAd", opts.StartAd, "indexer", indexerURL)
 	}
 	if opts.Publisher.ID == "" && info.Publisher != nil && info.Publisher.ID != "" {
 		opts.Publisher = *info.Publisher

--- a/scripts/fill_carmirror/main.go
+++ b/scripts/fill_carmirror/main.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	findclient "github.com/ipni/go-libipni/find/client"
+	"github.com/ipni/storetheindex/config"
+	"github.com/ipni/storetheindex/fsutil"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/urfave/cli/v2"
+)
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	app := &cli.App{
+		Name:  "fill_carmirror",
+		Usage: "Fill missing advertisement CAR files for one provider",
+		Description: `Uses the daemon AdvertisementMirror config. MainMode must be readwrite.
+External mirrors are tried before downloading from the publisher.
+Does not open the indexer value store.`,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "config",
+				Usage: "Path to storetheindex config file (default: $STORETHEINDEX_PATH/config)",
+			},
+			&cli.StringFlag{
+				Name:     "provider",
+				Usage:    "Provider peer ID whose advertisement chain to fill",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:  "cid",
+				Usage: "Advertisement CID to start from (default: provider LastAdvertisement from --indexer)",
+			},
+			&cli.StringFlag{
+				Name:  "indexer",
+				Usage: "Finder URL used to look up the provider's last processed advertisement and publisher AddrInfo",
+			},
+			&cli.StringFlag{
+				Name:  "addr-info",
+				Usage: "Publisher multiaddr (overrides indexer publisher), e.g. /ip4/1.2.3.4/tcp/24001/p2p/<id>",
+			},
+			&cli.IntFlag{
+				Name:  "depth",
+				Usage: "Maximum advertisements to process; 0 means unlimited",
+			},
+			&cli.DurationFlag{
+				Name:  "progress",
+				Usage: "How often to print running stats",
+				Value: 10 * time.Second,
+			},
+		},
+		Action: run,
+	}
+
+	if err := app.RunContext(ctx, os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(cctx *cli.Context) error {
+	providerID, err := peer.Decode(cctx.String("provider"))
+	if err != nil {
+		return fmt.Errorf("bad --provider: %w", err)
+	}
+
+	cfgFile, err := resolveConfigPath(cctx.String("config"))
+	if err != nil {
+		return fmt.Errorf("cannot load config: %w", err)
+	}
+	cfg, err := config.Load(cfgFile)
+	if err != nil {
+		return fmt.Errorf("cannot load config: %w", err)
+	}
+	if err := resolveRelativeMirrorPaths(cfg, cfgFile); err != nil {
+		return err
+	}
+
+	opts := Options{
+		Mirror:            cfg.Ingest.AdvertisementMirror,
+		HttpTimeout:       time.Duration(cfg.Ingest.HttpSyncTimeout),
+		HttpRetryMax:      cfg.Ingest.HttpSyncRetryMax,
+		HttpRetryWaitMin:  time.Duration(cfg.Ingest.HttpSyncRetryWaitMin),
+		HttpRetryWaitMax:  time.Duration(cfg.Ingest.HttpSyncRetryWaitMax),
+		EntriesDepthLimit: int64(cfg.Ingest.EntriesDepthLimit),
+		Provider:          providerID,
+		Depth:             cctx.Int("depth"),
+	}
+
+	ctx := cctx.Context
+	if cidStr := cctx.String("cid"); cidStr != "" {
+		opts.StartAd, err = cid.Decode(cidStr)
+		if err != nil {
+			return fmt.Errorf("bad --cid: %w", err)
+		}
+	} else if !cctx.IsSet("indexer") {
+		return fmt.Errorf("required: --indexer (reads LastAdvertisement from provider info) or --cid")
+	}
+	if addrInfoStr := cctx.String("addr-info"); addrInfoStr != "" {
+		ai, err := peer.AddrInfoFromString(addrInfoStr)
+		if err != nil {
+			return fmt.Errorf("bad --addr-info: %w", err)
+		}
+		opts.Publisher = *ai
+	} else if !cctx.IsSet("indexer") {
+		return fmt.Errorf("required: --indexer (reads publisher AddrInfo from provider info) or --addr-info")
+	}
+
+	if indexerURL := cctx.String("indexer"); indexerURL != "" {
+		if err := applyIndexer(ctx, indexerURL, providerID, &opts); err != nil {
+			return fmt.Errorf("indexer lookup: %w", err)
+		}
+	}
+
+	if progressEvery := cctx.Duration("progress"); progressEvery > 0 {
+		ticker := time.NewTicker(progressEvery)
+		defer ticker.Stop()
+		opts.Progress = func(s Stats) {
+			select {
+			case <-ticker.C:
+				fmt.Printf("progress  scanned=%d present=%d external=%d downloaded=%d hamt=%d chunks=%d mhs=%d down_bytes=%d written=%d last=%s\n",
+					s.Scanned, s.AlreadyPresent, s.CopiedExternal, s.Downloaded, s.SkippedHAMT,
+					s.EntryChunks, s.Multihashes, s.BytesDownloaded, s.BytesWritten, s.LastAd)
+			default:
+			}
+		}
+	}
+
+	fmt.Printf("Filling car mirror for provider %s\n", providerID)
+	if opts.StartAd != cid.Undef {
+		fmt.Println("Start ad:", opts.StartAd)
+	}
+	if opts.Publisher.ID != "" {
+		fmt.Println("Publisher:", opts.Publisher.ID, opts.Publisher.Addrs)
+	}
+	fmt.Println("MainMode:", opts.Mirror.MainMode)
+	fmt.Println("Main mirror:", opts.Mirror.Main.Local.BasePath)
+	for i, ext := range opts.Mirror.External {
+		loc := ext.HTTP.BaseURL
+		if loc == "" {
+			loc = ext.Local.BasePath
+		}
+		fmt.Printf("External[%d]: %s %s\n", i, ext.Type, loc)
+	}
+
+	st, err := Fill(ctx, opts)
+	if st != nil {
+		st.print()
+	}
+	if err != nil {
+		return fmt.Errorf("fill failed: %w", err)
+	}
+	return nil
+}
+
+func applyIndexer(ctx context.Context, indexerURL string, providerID peer.ID, opts *Options) error {
+	cl, err := findclient.New(indexerURL)
+	if err != nil {
+		return err
+	}
+	info, err := cl.GetProvider(ctx, providerID)
+	if err != nil {
+		return err
+	}
+	if info == nil {
+		return fmt.Errorf("provider %s not known by indexer", providerID)
+	}
+	if opts.StartAd == cid.Undef {
+		if info.LastAdvertisement == cid.Undef {
+			return fmt.Errorf("indexer has no LastAdvertisement for %s", providerID)
+		}
+		opts.StartAd = info.LastAdvertisement
+		fmt.Println("Start ad from indexer provider info LastAdvertisement:", opts.StartAd)
+	}
+	if opts.Publisher.ID == "" && info.Publisher != nil && info.Publisher.ID != "" {
+		opts.Publisher = *info.Publisher
+	}
+	return nil
+}
+
+func resolveConfigPath(flagVal string) (string, error) {
+	if flagVal == "" {
+		return config.Path("", "")
+	}
+	expanded, err := fsutil.ExpandHome(flagVal)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Abs(expanded)
+}
+
+// resolveRelativeMirrorPaths makes local BasePath values absolute. Relative
+// paths are resolved against the directory containing the config file so a
+// local test config can use "mirror" next to itself.
+func resolveRelativeMirrorPaths(cfg *config.Config, configFile string) error {
+	baseDir := filepath.Dir(configFile)
+	resolve := func(path *string) error {
+		if path == nil || *path == "" || filepath.IsAbs(*path) {
+			return nil
+		}
+		abs, err := filepath.Abs(filepath.Join(baseDir, *path))
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(abs, 0o755); err != nil {
+			return fmt.Errorf("cannot create local car mirror dir %s: %w", abs, err)
+		}
+		*path = abs
+		return nil
+	}
+	if err := resolve(&cfg.Ingest.AdvertisementMirror.Main.Local.BasePath); err != nil {
+		return err
+	}
+	for i := range cfg.Ingest.AdvertisementMirror.External {
+		if err := resolve(&cfg.Ingest.AdvertisementMirror.External[i].Local.BasePath); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/scripts/fill_carmirror/main.go
+++ b/scripts/fill_carmirror/main.go
@@ -23,9 +23,11 @@ func main() {
 
 	app := &cli.App{
 		Name:  "fill_carmirror",
-		Usage: "Fill missing advertisement CAR files for one provider",
+		Usage: "Fill missing or invalid advertisement CAR files for one provider",
 		Description: `Uses the daemon AdvertisementMirror config. MainMode must be readwrite.
 External mirrors are tried before downloading from the publisher.
+A CAR already on main that fails validation is overwritten from external
+or the publisher instead of stopping the walk.
 Does not open the indexer value store.`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
@@ -128,8 +130,8 @@ func run(cctx *cli.Context) error {
 		opts.Progress = func(s Stats) {
 			select {
 			case <-ticker.C:
-				fmt.Printf("progress  scanned=%d present=%d external=%d downloaded=%d hamt=%d chunks=%d mhs=%d down_bytes=%d written=%d last=%s\n",
-					s.Scanned, s.AlreadyPresent, s.CopiedExternal, s.Downloaded, s.SkippedHAMT,
+				fmt.Printf("progress  scanned=%d present=%d external=%d downloaded=%d recreated=%d hamt=%d chunks=%d mhs=%d down_bytes=%d written=%d last=%s\n",
+					s.Scanned, s.AlreadyPresent, s.CopiedExternal, s.Downloaded, s.Recreated, s.SkippedHAMT,
 					s.EntryChunks, s.Multihashes, s.BytesDownloaded, s.BytesWritten, s.LastAd)
 			default:
 			}


### PR DESCRIPTION
## Context

CAR mirror can signigicantly speed up syncing up or resyncing data from a provider. Current CAR mirror on a NAS server contains missing or truncated CAR files. There was no way to fill that gap without opening the value store or running ingest.

## Proposed Changes
Add `scripts/fill_carmirror`, a standalone CLI that walks one provider's advertisement chain and writes missing or invalid CARs to a **readwrite** main advertisement mirror. It does not open the indexer value store.

- Uses the daemon `AdvertisementMirror` config (legacy `Read`/`Write`/`Storage`/`Retrieval` is converted the same way the daemon does).
- Per ad: validate main → copy from external if needed → otherwise sync from the publisher via dagsync.
- Invalid main CARs are overwritten from external/publisher instead of stopping the walk.
- `IsRm` and no-entries ads are skipped (logged, never written, never deleted).
- HAMT ads get an ad-only CAR.
- Ctrl-C cancels; it is not treated as an invalid CAR.

Example:
```
fill_carmirror --config /config/config \
  --provider 12D3KooW... \
  --cid baguqeera... \
  --indexer https://sf.cid.contact
```

## Tests
`scripts/fill_carmirror/fill_test.go` covers config gating (main must be readwrite), skip of IsRm/no-entries, recreate of invalid main CARs, external hit, and publisher download.

## Revert Strategy
Change is safe to revert. The tool is a new script; nothing in the daemon binary depends on it.
