### PR TITLE
fill_carmirror: estimate remaining ads and live progress

### DIFF
--- a/scripts/fill_carmirror/fill.go
+++ b/scripts/fill_carmirror/fill.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log/slog"
 	"sync/atomic"
 	"time"
 
@@ -74,8 +73,8 @@ type Options struct {
 	Publisher peer.AddrInfo
 	Depth     int // 0 means unlimited
 
-	// Progress is called with a copy of the running stats. Optional.
-	Progress func(Stats)
+	// Out receives fill events. Nil is a no-op.
+	Out Progress
 }
 
 // Stats is the running / final summary of a fill run.
@@ -108,6 +107,7 @@ type carData struct {
 
 type filler struct {
 	opts       Options
+	out        Progress
 	ds         datastore.Batching
 	mainReader *carstore.CarReader
 	mainWriter *carstore.CarWriter
@@ -179,6 +179,7 @@ func newFiller(opts Options) (*filler, error) {
 
 	return &filler{
 		opts:       opts,
+		out:        progressOrNop(opts.Out),
 		ds:         ds,
 		mainReader: mainReader,
 		mainWriter: mainWriter,
@@ -215,9 +216,7 @@ func (f *filler) run(ctx context.Context) (*Stats, error) {
 		prev, err := f.processAd(ctx, adCid, st)
 		st.Scanned++
 		st.LastAd = adCid
-		if f.opts.Progress != nil {
-			f.opts.Progress(*st)
-		}
+		f.out.Periodic(*st)
 		if err != nil {
 			if st.StopReason == "" {
 				st.StopReason = stopError
@@ -233,9 +232,9 @@ func (f *filler) run(ctx context.Context) (*Stats, error) {
 
 func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.Cid, error) {
 	n := st.Scanned + 1
-	log := log.With("n", n, "ad", adCid)
-	log.Debug("checking main")
-	data, src, mainBroken, err := f.loadExisting(ctx, log, adCid)
+	ap := f.out.Ad(n, adCid)
+	ap.CheckingMain()
+	data, src, mainBroken, err := f.loadExisting(ctx, ap, adCid)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return cid.Undef, err
 	}
@@ -243,13 +242,12 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 	var ad schema.Advertisement
 	if err == nil {
 		ad = data.ad
-		log = logAdFields(log, ad)
-		logCarFields(log, data).Info("loaded advertisement", "source", src.String())
+		ap.Loaded(src, data)
 	} else {
 		if mainBroken {
-			log.Info("main CAR unusable, fetching from publisher", "publisher", f.opts.Publisher.ID)
+			ap.MainUnusableFetching(f.opts.Publisher.ID)
 		} else {
-			log.Info("not in mirrors, fetching from publisher", "publisher", f.opts.Publisher.ID)
+			ap.NotInMirrorsFetching(f.opts.Publisher.ID)
 		}
 		ad, err = f.fetchFromProvider(ctx, adCid)
 		if err != nil {
@@ -257,11 +255,10 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 		}
 		src = sourceProvider
 		st.BytesDownloaded = f.downloaded.Load()
-		log = logAdFields(log, ad)
-		log.Info("fetched advertisement")
+		ap.FetchedAd(ad)
 	}
 
-	if skipUnstored(log, ad, src, mainBroken, st) {
+	if skipUnstored(ap, ad, src, mainBroken, st) {
 		return ad.PreviousCid(), nil
 	}
 
@@ -273,7 +270,7 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 		if data.hamt {
 			st.SkippedHAMT++
 		}
-		logCarFields(log, data).Info("present on main")
+		ap.PresentOnMain(data)
 		return ad.PreviousCid(), nil
 
 	case sourceExternal:
@@ -296,16 +293,12 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 			st.EntryChunks += data.chunks
 			st.Multihashes += data.mhs
 		}
-		if mainBroken {
-			logCarFields(log, data).Info("recreated from external", "written", written)
-		} else {
-			logCarFields(log, data).Info("copied from external", "written", written)
-		}
+		ap.CopiedFromExternal(data, written, mainBroken)
 		return ad.PreviousCid(), nil
 	}
 
 	entsCid := ad.Entries.(cidlink.Link).Cid
-	log.Info("syncing first entries block", "entries", entsCid)
+	ap.SyncingFirstEntries(entsCid)
 	if err = f.syncOneEntry(ctx, entsCid); err != nil {
 		return cid.Undef, fmt.Errorf("cannot sync first entries block for %s: %w", adCid, err)
 	}
@@ -314,7 +307,7 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 		return cid.Undef, err
 	}
 	if hamt {
-		log.Info("entries are HAMT, writing ad only")
+		ap.HAMTAdOnly()
 		_ = f.ds.Delete(ctx, datastore.NewKey(entsCid.String()))
 		written, err := f.writeAdOnly(ctx, adCid)
 		if err != nil {
@@ -324,11 +317,11 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 		noteWrittenFromPublisher(st, mainBroken)
 		st.BytesWritten += written
 		st.BytesDownloaded = f.downloaded.Load()
-		log.Info(publisherAction(mainBroken), "hamt", true, "written", written, "bytesDownloaded", st.BytesDownloaded)
+		ap.WrittenFromPublisher(mainBroken, true, 0, 0, written, st.BytesDownloaded)
 		return ad.PreviousCid(), nil
 	}
 
-	log.Info("syncing remaining entry chunks", "entries", entsCid)
+	ap.SyncingRemaining(entsCid)
 	chunks, mhs, err := f.syncRemainingEntries(ctx, entsCid)
 	if err != nil {
 		return cid.Undef, fmt.Errorf("cannot sync entries for %s: %w", adCid, err)
@@ -347,20 +340,20 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 		written = info.Size
 		st.BytesWritten += written
 	}
-	log.Info(publisherAction(mainBroken), "chunks", chunks, "multihashes", mhs, "written", written, "bytesDownloaded", st.BytesDownloaded)
+	ap.WrittenFromPublisher(mainBroken, false, chunks, mhs, written, st.BytesDownloaded)
 	return ad.PreviousCid(), nil
 }
 
-func skipUnstored(log *slog.Logger, ad schema.Advertisement, src source, mainBroken bool, st *Stats) bool {
+func skipUnstored(ap AdProgress, ad schema.Advertisement, src source, mainBroken bool, st *Stats) bool {
 	if ad.IsRm {
 		onMain := src == sourceMain || mainBroken
 		st.SkippedRm++
-		log.Info("skip IsRm", "carOnMain", onMain)
+		ap.SkipIsRm(ad, onMain)
 		return true
 	}
 	if !hasEntries(ad) {
 		st.SkippedNoEnts++
-		log.Info("skip no-entries")
+		ap.SkipNoEntries(ad)
 		return true
 	}
 	return false
@@ -380,7 +373,7 @@ func publisherAction(mainBroken bool) string {
 	return "downloaded"
 }
 
-func (f *filler) loadExisting(ctx context.Context, log *slog.Logger, adCid cid.Cid) (*carData, source, bool, error) {
+func (f *filler) loadExisting(ctx context.Context, ap AdProgress, adCid cid.Cid) (*carData, source, bool, error) {
 	mainBroken := false
 	block, err := f.mainReader.Read(ctx, adCid, false)
 	switch {
@@ -392,29 +385,29 @@ func (f *filler) loadExisting(ctx context.Context, log *slog.Logger, adCid cid.C
 		if isCanceled(vErr) {
 			return nil, sourceNone, false, vErr
 		}
-		log.Info("main CAR invalid, will recreate", "err", vErr)
+		ap.MainInvalid(vErr)
 		mainBroken = true
 	case isCanceled(err):
 		return nil, sourceNone, false, err
 	case errors.Is(err, fs.ErrNotExist):
-		log.Debug("main miss")
+		ap.MainMiss()
 	default:
-		log.Info("main read error, will recreate", "err", err)
+		ap.MainReadError(err)
 		mainBroken = true
 	}
 
 	for i, reader := range f.externals {
-		log.Debug("checking external", "external", i, "location", reader.Location())
+		ap.CheckingExternal(i, reader.Location())
 		block, err = reader.Read(ctx, adCid, false)
 		if err != nil {
 			if isCanceled(err) {
 				return nil, sourceNone, mainBroken, err
 			}
 			if errors.Is(err, fs.ErrNotExist) {
-				log.Debug("external miss", "external", i)
+				ap.ExternalMiss(i)
 				continue
 			}
-			log.Info("external read error", "external", i, "err", err)
+			ap.ExternalReadError(i, err)
 			continue
 		}
 		data, vErr := inspectCar(adCid, block)
@@ -422,10 +415,10 @@ func (f *filler) loadExisting(ctx context.Context, log *slog.Logger, adCid cid.C
 			if isCanceled(vErr) {
 				return nil, sourceNone, mainBroken, vErr
 			}
-			log.Info("external invalid CAR", "external", i, "err", vErr)
+			ap.ExternalInvalid(i, vErr)
 			continue
 		}
-		log.Info("external hit", "external", i)
+		ap.ExternalHit(i)
 		return data, sourceExternal, mainBroken, nil
 	}
 

--- a/scripts/fill_carmirror/fill.go
+++ b/scripts/fill_carmirror/fill.go
@@ -73,6 +73,13 @@ type Options struct {
 	Publisher peer.AddrInfo
 	Depth     int // 0 means unlimited
 
+	// Estimate, when true, counts advertisements in the chain (ads only)
+	// before filling so progress can show a total. EstimateTimeout limits
+	// that count; 0 means no time limit. A timeout or error yields a partial
+	// total and fill still runs.
+	Estimate        bool
+	EstimateTimeout time.Duration
+
 	// Out receives fill events. Nil is a no-op.
 	Out Progress
 }
@@ -93,6 +100,11 @@ type Stats struct {
 	BytesWritten    int64
 	StopReason      string
 	LastAd          cid.Cid
+	// TotalAds is the advertisement count from StartAd toward genesis, if
+	// --estimate ran. TotalExact is true when the count reached genesis (or
+	// --depth). Otherwise TotalAds is a lower bound.
+	TotalAds   int
+	TotalExact bool
 }
 
 type carData struct {
@@ -203,6 +215,13 @@ func (f *filler) run(ctx context.Context) (*Stats, error) {
 		return st, errors.New("no start advertisement: pass --cid or --indexer so LastAdvertisement can be read from provider info")
 	}
 
+	if f.opts.Estimate {
+		if err := f.runEstimate(ctx, st); err != nil {
+			st.StopReason = stopCanceled
+			return st, err
+		}
+	}
+
 	for adCid != cid.Undef {
 		if err := ctx.Err(); err != nil {
 			st.StopReason = stopCanceled
@@ -230,9 +249,85 @@ func (f *filler) run(ctx context.Context) (*Stats, error) {
 	return st, nil
 }
 
+const estimateSegment = 200
+
+func (f *filler) runEstimate(ctx context.Context, st *Stats) error {
+	f.out.Estimating(f.opts.EstimateTimeout)
+	estCtx := ctx
+	if f.opts.EstimateTimeout > 0 {
+		var cancel context.CancelFunc
+		estCtx, cancel = context.WithTimeout(ctx, f.opts.EstimateTimeout)
+		defer cancel()
+	}
+	startDown := f.downloaded.Load()
+	n, exact, err := f.countAds(estCtx)
+	f.downloaded.Store(startDown)
+	st.TotalAds = n
+	st.TotalExact = exact && err == nil
+	if err != nil && ctx.Err() != nil {
+		f.out.Estimated(n, false)
+		return ctx.Err()
+	}
+	f.out.Estimated(n, st.TotalExact)
+	return nil
+}
+
+func (f *filler) countAds(ctx context.Context) (int, bool, error) {
+	if err := f.ensurePublisher(ctx); err != nil {
+		return 0, false, err
+	}
+	n := 0
+	next := f.opts.StartAd
+	for next != cid.Undef {
+		if err := ctx.Err(); err != nil {
+			return n, false, err
+		}
+		if f.opts.Depth > 0 && n >= f.opts.Depth {
+			return n, true, nil
+		}
+		limit := estimateSegment
+		if f.opts.Depth > 0 && n+limit > f.opts.Depth {
+			limit = f.opts.Depth - n
+		}
+		var lastPrev cid.Cid
+		got := 0
+		hook := dagsync.MakeGeneralBlockHook(func(adCid cid.Cid) (cid.Cid, error) {
+			raw, err := f.ds.Get(ctx, datastore.NewKey(adCid.String()))
+			if err != nil {
+				return cid.Undef, err
+			}
+			ad, err := schema.BytesToAdvertisement(adCid, raw)
+			if err != nil {
+				return cid.Undef, err
+			}
+			got++
+			lastPrev = ad.PreviousCid()
+			return lastPrev, nil
+		})
+		_, err := f.sub.SyncAdChain(ctx, f.opts.Publisher,
+			dagsync.WithHeadAdCid(next),
+			dagsync.ScopedDepthLimit(int64(limit)),
+			dagsync.ScopedSegmentDepthLimit(int64(limit)),
+			dagsync.ScopedBlockHook(hook),
+		)
+		n += got
+		if got > 0 {
+			f.out.EstimateProgress(n)
+		}
+		if err != nil {
+			return n, false, err
+		}
+		if got == 0 || got < limit {
+			return n, true, nil
+		}
+		next = lastPrev
+	}
+	return n, true, nil
+}
+
 func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.Cid, error) {
 	n := st.Scanned + 1
-	ap := f.out.Ad(n, adCid)
+	ap := f.out.Ad(n, adCid, st.TotalAds, st.TotalExact)
 	ap.CheckingMain()
 	data, src, mainBroken, err := f.loadExisting(ctx, ap, adCid)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {

--- a/scripts/fill_carmirror/fill.go
+++ b/scripts/fill_carmirror/fill.go
@@ -128,6 +128,12 @@ type filler struct {
 
 	host host.Host
 	sub  *dagsync.Subscriber
+
+	// entryProg, when set, reports each entry chunk as it is stored during a
+	// publisher fetch. dagsync only runs the block hook after the remaining
+	// chain is fully synced, so this is what shows live per-chunk progress.
+	entryProg AdProgress
+	entryN    int
 }
 
 // Fill walks a provider's advertisement chain and writes missing or invalid
@@ -393,6 +399,9 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 	}
 
 	entsCid := ad.Entries.(cidlink.Link).Cid
+	f.entryN = 0
+	f.entryProg = ap
+	defer func() { f.entryProg = nil }()
 	ap.SyncingFirstEntries(entsCid)
 	if err = f.syncOneEntry(ctx, entsCid); err != nil {
 		return cid.Undef, fmt.Errorf("cannot sync first entries block for %s: %w", adCid, err)
@@ -416,7 +425,6 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 		return ad.PreviousCid(), nil
 	}
 
-	ap.SyncingRemaining(entsCid)
 	chunks, mhs, err := f.syncRemainingEntries(ctx, entsCid)
 	if err != nil {
 		return cid.Undef, fmt.Errorf("cannot sync entries for %s: %w", adCid, err)
@@ -740,7 +748,11 @@ func (f *filler) ensurePublisher(ctx context.Context) error {
 			c := lnk.(cidlink.Link).Cid
 			b := buf.Bytes()
 			f.downloaded.Add(int64(len(b)))
-			return f.ds.Put(lctx.Ctx, datastore.NewKey(c.String()), b)
+			if err := f.ds.Put(lctx.Ctx, datastore.NewKey(c.String()), b); err != nil {
+				return err
+			}
+			f.noteEntryChunk(c, b)
+			return nil
 		}, nil
 	}
 
@@ -760,6 +772,22 @@ func (f *filler) ensurePublisher(ctx context.Context) error {
 	f.host = h
 	f.sub = sub
 	return nil
+}
+
+func (f *filler) noteEntryChunk(c cid.Cid, data []byte) {
+	ap := f.entryProg
+	if ap == nil {
+		return
+	}
+	ch, err := decodeEntryChunk(c, data)
+	if err != nil {
+		return
+	}
+	f.entryN++
+	ap.FetchedEntryChunk(f.entryN, c, len(ch.Entries), len(data), f.downloaded.Load())
+	if ch.Next != nil {
+		ap.FetchingEntryChunk(f.entryN+1, ch.Next.(cidlink.Link).Cid)
+	}
 }
 
 func hasEntries(ad schema.Advertisement) bool {

--- a/scripts/fill_carmirror/fill.go
+++ b/scripts/fill_carmirror/fill.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -134,6 +135,15 @@ type filler struct {
 	// chain is fully synced, so this is what shows live per-chunk progress.
 	entryProg AdProgress
 	entryN    int
+
+	// carProg reports CAR assembly. CarWriter has no callbacks, so a datastore
+	// Get wrapper logs each entries block as it is read into the CAR, and a
+	// filestore Put wrapper logs bytes copied to the mirror.
+	carProg       AdProgress
+	carWriteN     int
+	carWriteTotal int
+	carWriteAd    cid.Cid
+	carWriteLast  cid.Cid
 }
 
 // Fill walks a provider's advertisement chain and writes missing or invalid
@@ -158,7 +168,14 @@ func newFiller(opts Options) (*filler, error) {
 		return nil, errors.New("main car mirror has no storage backend")
 	}
 
-	ds := dssync.MutexWrap(datastore.NewMapDatastore())
+	ds := &hookDS{Batching: dssync.MutexWrap(datastore.NewMapDatastore())}
+	f := &filler{
+		opts: opts,
+		out:  progressOrNop(opts.Out),
+		ds:   ds,
+	}
+	ds.f = f
+
 	mainStore, err := filestore.MakeFilestore(opts.Mirror.Main.Config)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create main car file store: %w", err)
@@ -166,6 +183,7 @@ func newFiller(opts Options) (*filler, error) {
 	if mainStore == nil {
 		return nil, errors.New("main car mirror storage backend is disabled")
 	}
+	mainStore = &hookFileStore{Interface: mainStore, f: f}
 
 	mainWriter, err := carstore.NewWriter(ds, mainStore, carstore.WithCompress(opts.Mirror.Main.Compress))
 	if err != nil {
@@ -195,14 +213,10 @@ func newFiller(opts Options) (*filler, error) {
 		externals = append(externals, reader)
 	}
 
-	return &filler{
-		opts:       opts,
-		out:        progressOrNop(opts.Out),
-		ds:         ds,
-		mainReader: mainReader,
-		mainWriter: mainWriter,
-		externals:  externals,
-	}, nil
+	f.mainReader = mainReader
+	f.mainWriter = mainWriter
+	f.externals = externals
+	return f, nil
 }
 
 func (f *filler) close() {
@@ -379,7 +393,7 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 		if skipEnts {
 			data.entries = nil
 		}
-		written, err := f.writeFromData(ctx, adCid, data)
+		written, err := f.writeFromData(ctx, ap, adCid, data)
 		if err != nil {
 			return cid.Undef, fmt.Errorf("cannot copy %s from external to main: %w", adCid, err)
 		}
@@ -413,7 +427,7 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 	if hamt {
 		ap.HAMTAdOnly()
 		_ = f.ds.Delete(ctx, datastore.NewKey(entsCid.String()))
-		written, err := f.writeAdOnly(ctx, adCid)
+		written, err := f.writeMainCAR(ctx, ap, adCid, true, 0)
 		if err != nil {
 			return cid.Undef, fmt.Errorf("cannot write ad-only CAR for HAMT ad %s: %w", adCid, err)
 		}
@@ -430,7 +444,7 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 		return cid.Undef, fmt.Errorf("cannot sync entries for %s: %w", adCid, err)
 	}
 
-	info, err := f.mainWriter.Write(ctx, adCid, false, false)
+	written, err := f.writeMainCAR(ctx, ap, adCid, false, chunks)
 	if err != nil {
 		return cid.Undef, fmt.Errorf("cannot write CAR for %s: %w", adCid, err)
 	}
@@ -438,11 +452,7 @@ func (f *filler) processAd(ctx context.Context, adCid cid.Cid, st *Stats) (cid.C
 	st.EntryChunks += chunks
 	st.Multihashes += mhs
 	st.BytesDownloaded = f.downloaded.Load()
-	var written int64
-	if info != nil {
-		written = info.Size
-		st.BytesWritten += written
-	}
+	st.BytesWritten += written
 	ap.WrittenFromPublisher(mainBroken, false, chunks, mhs, written, st.BytesDownloaded)
 	return ad.PreviousCid(), nil
 }
@@ -605,30 +615,35 @@ func inspectCar(adCid cid.Cid, block *carstore.AdBlock) (*carData, error) {
 	return out, nil
 }
 
-func (f *filler) writeFromData(ctx context.Context, adCid cid.Cid, data *carData) (int64, error) {
+func (f *filler) writeFromData(ctx context.Context, ap AdProgress, adCid cid.Cid, data *carData) (int64, error) {
 	if err := f.ds.Put(ctx, datastore.NewKey(adCid.String()), data.adData); err != nil {
 		return 0, err
 	}
 	skipEnts := data.hamt || !hasEntries(data.ad)
+	chunks := 0
 	if !skipEnts {
+		chunks = data.chunks
 		for _, e := range data.entries {
 			if err := f.ds.Put(ctx, datastore.NewKey(e.Cid.String()), e.Data); err != nil {
 				return 0, err
 			}
 		}
 	}
-	info, err := f.mainWriter.Write(ctx, adCid, skipEnts, false)
-	if err != nil {
-		return 0, err
-	}
-	if info == nil {
-		return 0, nil
-	}
-	return info.Size, nil
+	return f.writeMainCAR(ctx, ap, adCid, skipEnts, chunks)
 }
 
-func (f *filler) writeAdOnly(ctx context.Context, adCid cid.Cid) (int64, error) {
-	info, err := f.mainWriter.Write(ctx, adCid, true, false)
+func (f *filler) writeMainCAR(ctx context.Context, ap AdProgress, adCid cid.Cid, skipEnts bool, chunks int) (int64, error) {
+	ap.WritingCAR(chunks)
+	f.carProg = ap
+	f.carWriteN = 0
+	f.carWriteTotal = chunks
+	f.carWriteAd = adCid
+	f.carWriteLast = cid.Undef
+	defer func() { f.carProg = nil }()
+	if chunks == 0 {
+		ap.StoringCARFile()
+	}
+	info, err := f.mainWriter.Write(ctx, adCid, skipEnts, false)
 	if err != nil {
 		return 0, err
 	}
@@ -788,6 +803,82 @@ func (f *filler) noteEntryChunk(c cid.Cid, data []byte) {
 	if ch.Next != nil {
 		ap.FetchingEntryChunk(f.entryN+1, ch.Next.(cidlink.Link).Cid)
 	}
+}
+
+type hookDS struct {
+	datastore.Batching
+	f *filler
+}
+
+func (d *hookDS) Get(ctx context.Context, key datastore.Key) ([]byte, error) {
+	val, err := d.Batching.Get(ctx, key)
+	if err == nil {
+		d.f.noteCarStoreGet(key, val)
+	}
+	return val, err
+}
+
+func (f *filler) noteCarStoreGet(key datastore.Key, data []byte) {
+	ap := f.carProg
+	if ap == nil {
+		return
+	}
+	c, err := cid.Decode(strings.TrimPrefix(key.String(), "/"))
+	if err != nil || c == f.carWriteAd || c == f.carWriteLast {
+		return
+	}
+	ch, err := decodeEntryChunk(c, data)
+	if err != nil {
+		return
+	}
+	f.carWriteLast = c
+	f.carWriteN++
+	ap.StoringEntryChunk(f.carWriteN, f.carWriteTotal, c, len(ch.Entries), len(data))
+	if f.carWriteTotal > 0 && f.carWriteN >= f.carWriteTotal {
+		ap.StoringCARFile()
+	}
+}
+
+type hookFileStore struct {
+	filestore.Interface
+	f *filler
+}
+
+func (h *hookFileStore) Put(ctx context.Context, path string, r io.Reader) (*filestore.File, error) {
+	ap := h.f.carProg
+	if ap == nil {
+		return h.Interface.Put(ctx, path, r)
+	}
+	if h.f.carWriteTotal > 0 && h.f.carWriteN < h.f.carWriteTotal {
+		ap.StoringCARFile()
+	}
+	cr := &carPutReader{r: r, ap: ap}
+	file, err := h.Interface.Put(ctx, path, cr)
+	if cr.n > 0 && cr.n != cr.last {
+		ap.StoringCARFileBytes(cr.n)
+	}
+	return file, err
+}
+
+const carPutReportEvery = 32 << 20
+
+type carPutReader struct {
+	r    io.Reader
+	ap   AdProgress
+	n    int64
+	last int64
+}
+
+func (c *carPutReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	if n > 0 {
+		c.n += int64(n)
+		if c.n-c.last >= carPutReportEvery || err == io.EOF {
+			c.last = c.n
+			c.ap.StoringCARFileBytes(c.n)
+		}
+	}
+	return n, err
 }
 
 func hasEntries(ad schema.Advertisement) bool {

--- a/scripts/fill_carmirror/fill_test.go
+++ b/scripts/fill_carmirror/fill_test.go
@@ -353,11 +353,13 @@ func TestFillDownloadsFromProvider(t *testing.T) {
 	pub.SetRoot(ad2.cid)
 
 	main := localStore(t)
+	rec := &chunkRec{}
 	st, err := Fill(ctx, Options{
 		Mirror:      rwMirror(main),
 		StartAd:     ad2.cid,
 		Publisher:   peer.AddrInfo{ID: pub.ID(), Addrs: pub.Addrs()},
 		HttpTimeout: 10 * time.Second,
+		Out:         rec,
 	})
 	require.NoError(t, err)
 	require.Equal(t, 2, st.Downloaded)
@@ -365,6 +367,8 @@ func TestFillDownloadsFromProvider(t *testing.T) {
 	require.Equal(t, stopGenesis, st.StopReason)
 	require.Positive(t, st.BytesWritten)
 	require.Positive(t, st.BytesDownloaded)
+	require.Equal(t, 4, rec.fetched)
+	require.Equal(t, 2, rec.fetching)
 
 	reader, err := carstore.NewReader(mustStore(t, main), carstore.WithCompress(main.Compress))
 	require.NoError(t, err)
@@ -506,6 +510,26 @@ func carExists(t *testing.T, storeCfg config.StoreConfig, adCid cid.Cid) bool {
 		return false
 	}
 	return true
+}
+
+type chunkRec struct {
+	nopProgress
+	fetched  int
+	fetching int
+}
+
+func (r *chunkRec) Ad(int, cid.Cid, int, bool) AdProgress {
+	return chunkAd{r: r}
+}
+
+type chunkAd struct {
+	nopAd
+	r *chunkRec
+}
+
+func (a chunkAd) FetchingEntryChunk(int, cid.Cid) { a.r.fetching++ }
+func (a chunkAd) FetchedEntryChunk(int, cid.Cid, int, int, int64) {
+	a.r.fetched++
 }
 
 func storeAdChain(t *testing.T, ds datastore.Datastore, chunksPerAd int) (latest, prev testAd) {

--- a/scripts/fill_carmirror/fill_test.go
+++ b/scripts/fill_carmirror/fill_test.go
@@ -378,6 +378,35 @@ func TestFillDownloadsFromProvider(t *testing.T) {
 	}
 }
 
+func TestFillEstimateCountsAds(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	pubDS := dssync.MutexWrap(datastore.NewMapDatastore())
+	ad2, _ := storeAdChain(t, pubDS, 2)
+
+	priv, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	require.NoError(t, err)
+	pub, err := ipnisync.NewPublisher(mkLinkSystem(pubDS), priv, ipnisync.WithHTTPListenAddrs("127.0.0.1:0"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pub.Close() })
+	pub.SetRoot(ad2.cid)
+
+	st, err := Fill(ctx, Options{
+		Mirror:          rwMirror(localStore(t)),
+		StartAd:         ad2.cid,
+		Publisher:       peer.AddrInfo{ID: pub.ID(), Addrs: pub.Addrs()},
+		HttpTimeout:     10 * time.Second,
+		Estimate:        true,
+		EstimateTimeout: 30 * time.Second,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, st.Scanned)
+	require.Equal(t, 2, st.TotalAds)
+	require.True(t, st.TotalExact)
+	require.Equal(t, stopGenesis, st.StopReason)
+}
+
 func TestFillUsesEachSourceOnce(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/scripts/fill_carmirror/fill_test.go
+++ b/scripts/fill_carmirror/fill_test.go
@@ -369,6 +369,9 @@ func TestFillDownloadsFromProvider(t *testing.T) {
 	require.Positive(t, st.BytesDownloaded)
 	require.Equal(t, 4, rec.fetched)
 	require.Equal(t, 2, rec.fetching)
+	require.Equal(t, 2, rec.writing)
+	require.Equal(t, 4, rec.stored)
+	require.Equal(t, 2, rec.carFile)
 
 	reader, err := carstore.NewReader(mustStore(t, main), carstore.WithCompress(main.Compress))
 	require.NoError(t, err)
@@ -516,6 +519,9 @@ type chunkRec struct {
 	nopProgress
 	fetched  int
 	fetching int
+	writing  int
+	stored   int
+	carFile  int
 }
 
 func (r *chunkRec) Ad(int, cid.Cid, int, bool) AdProgress {
@@ -531,6 +537,11 @@ func (a chunkAd) FetchingEntryChunk(int, cid.Cid) { a.r.fetching++ }
 func (a chunkAd) FetchedEntryChunk(int, cid.Cid, int, int, int64) {
 	a.r.fetched++
 }
+func (a chunkAd) WritingCAR(int) { a.r.writing++ }
+func (a chunkAd) StoringEntryChunk(int, int, cid.Cid, int, int) {
+	a.r.stored++
+}
+func (a chunkAd) StoringCARFile() { a.r.carFile++ }
 
 func storeAdChain(t *testing.T, ds datastore.Datastore, chunksPerAd int) (latest, prev testAd) {
 	t.Helper()

--- a/scripts/fill_carmirror/log.go
+++ b/scripts/fill_carmirror/log.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
@@ -101,8 +102,28 @@ func (p *LogProgress) UsingIndexer(startAd cid.Cid, indexerURL string) {
 	p.log.Info("using LastAdvertisement from indexer", "startAd", startAd, "indexer", indexerURL)
 }
 
-func (p *LogProgress) Ad(n int, adCid cid.Cid) AdProgress {
-	return logAd{log: p.log.With("n", n, "ad", adCid)}
+func (p *LogProgress) Estimating(timeout time.Duration) {
+	if timeout > 0 {
+		p.log.Info("counting advertisements", "timeout", timeout)
+		return
+	}
+	p.log.Info("counting advertisements")
+}
+
+func (p *LogProgress) EstimateProgress(n int) {
+	p.log.Info("count progress", "advertisements", n)
+}
+
+func (p *LogProgress) Estimated(total int, exact bool) {
+	p.log.Info("count complete", "totalAds", total, "exact", exact)
+}
+
+func (p *LogProgress) Ad(n int, adCid cid.Cid, total int, exact bool) AdProgress {
+	l := p.log.With("n", n, "ad", adCid)
+	if total > 0 {
+		l = l.With("totalAds", total, "totalExact", exact)
+	}
+	return logAd{log: l}
 }
 
 func (p *LogProgress) Periodic(s Stats) {
@@ -226,6 +247,9 @@ func withStats(log *slog.Logger, s Stats) *slog.Logger {
 	}
 	if s.StopReason != "" {
 		l = l.With("stopReason", s.StopReason)
+	}
+	if s.TotalAds > 0 {
+		l = l.With("totalAds", s.TotalAds, "totalExact", s.TotalExact)
 	}
 	return l
 }

--- a/scripts/fill_carmirror/log.go
+++ b/scripts/fill_carmirror/log.go
@@ -214,6 +214,12 @@ func (a logAd) SyncingFirstEntries(entsCid cid.Cid) {
 	a.log.Info("syncing first entries block", "entries", entsCid)
 }
 func (a logAd) HAMTAdOnly() { a.log.Info("entries are HAMT, writing ad only") }
+func (a logAd) FetchingEntryChunk(n int, chunkCid cid.Cid) {
+	a.log.Info("fetching entry chunk", "chunk", n, "entries", chunkCid)
+}
+func (a logAd) FetchedEntryChunk(n int, chunkCid cid.Cid, mhs, chunkBytes int, downBytes int64) {
+	a.log.Info("got entry chunk", "chunk", n, "entries", chunkCid, "multihashes", mhs, "bytes", chunkBytes, "bytesDownloaded", downBytes)
+}
 func (a logAd) WrittenFromPublisher(mainBroken, hamt bool, chunks, mhs int, written, downBytes int64) {
 	l := a.log.With("written", written, "bytesDownloaded", downBytes)
 	if hamt {
@@ -222,9 +228,6 @@ func (a logAd) WrittenFromPublisher(mainBroken, hamt bool, chunks, mhs int, writ
 		l = l.With("chunks", chunks, "multihashes", mhs)
 	}
 	l.Info(publisherAction(mainBroken))
-}
-func (a logAd) SyncingRemaining(entsCid cid.Cid) {
-	a.log.Info("syncing remaining entry chunks", "entries", entsCid)
 }
 
 func withStats(log *slog.Logger, s Stats) *slog.Logger {

--- a/scripts/fill_carmirror/log.go
+++ b/scripts/fill_carmirror/log.go
@@ -220,6 +220,18 @@ func (a logAd) FetchingEntryChunk(n int, chunkCid cid.Cid) {
 func (a logAd) FetchedEntryChunk(n int, chunkCid cid.Cid, mhs, chunkBytes int, downBytes int64) {
 	a.log.Info("got entry chunk", "chunk", n, "entries", chunkCid, "multihashes", mhs, "bytes", chunkBytes, "bytesDownloaded", downBytes)
 }
+func (a logAd) WritingCAR(chunks int) {
+	a.log.Info("writing CAR", "chunks", chunks)
+}
+func (a logAd) StoringEntryChunk(n, total int, chunkCid cid.Cid, mhs, chunkBytes int) {
+	a.log.Info("storing CAR chunk", "chunk", n, "total", total, "entries", chunkCid, "multihashes", mhs, "bytes", chunkBytes)
+}
+func (a logAd) StoringCARFile() {
+	a.log.Info("compressing and storing CAR file")
+}
+func (a logAd) StoringCARFileBytes(n int64) {
+	a.log.Info("storing CAR file", "bytes", n)
+}
 func (a logAd) WrittenFromPublisher(mainBroken, hamt bool, chunks, mhs int, written, downBytes int64) {
 	l := a.log.With("written", written, "bytesDownloaded", downBytes)
 	if hamt {

--- a/scripts/fill_carmirror/log.go
+++ b/scripts/fill_carmirror/log.go
@@ -10,19 +10,17 @@ import (
 	logging "github.com/ipfs/go-log/v2"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipni/go-libipni/ingest/schema"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/gologshim"
 )
 
 const loggerName = "fill_carmirror"
 
-// Discard until setupLogger wires slog through go-log, so tests stay quiet.
-var log = slog.New(slog.DiscardHandler)
-
-func setupLogger() error {
+func setupLogger() (*slog.Logger, error) {
 	cfg := logging.GetConfig()
 	format, err := resolveLogFormat()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	cfg.Format = format
 	if !cfg.Stdout && !cfg.Stderr && cfg.File == "" && cfg.URL == "" {
@@ -31,15 +29,14 @@ func setupLogger() error {
 	logging.SetupLogging(cfg)
 	if os.Getenv("GOLOG_LOG_LEVEL") == "" && os.Getenv("IPFS_LOGGING") == "" {
 		if err := logging.SetLogLevel(loggerName, "info"); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
 	handler := logging.SlogHandler()
 	slog.SetDefault(slog.New(handler))
 	gologshim.SetDefaultHandler(handler)
-	log = slog.New(handler.WithAttrs([]slog.Attr{slog.String("logger", loggerName)}))
-	return nil
+	return slog.New(handler.WithAttrs([]slog.Attr{slog.String("logger", loggerName)})), nil
 }
 
 func resolveLogFormat() (logging.LogFormat, error) {
@@ -65,8 +62,17 @@ func parseLogFormat(format string) (logging.LogFormat, error) {
 	}
 }
 
-func logStart(log *slog.Logger, opts Options) *slog.Logger {
-	l := log.With(
+// LogProgress writes fill events as structured logs.
+type LogProgress struct {
+	log *slog.Logger
+}
+
+func NewLogProgress(log *slog.Logger) *LogProgress {
+	return &LogProgress{log: log}
+}
+
+func (p *LogProgress) Start(opts Options) {
+	l := p.log.With(
 		"provider", opts.Provider,
 		"mainMode", opts.Mirror.MainMode,
 		"mainMirror", opts.Mirror.Main.Local.BasePath,
@@ -81,10 +87,126 @@ func logStart(log *slog.Logger, opts Options) *slog.Logger {
 		}
 		l = l.With("publisher", opts.Publisher.ID, "publisherAddrs", addrs)
 	}
+	l.Info("starting fill")
+	for i, ext := range opts.Mirror.External {
+		loc := ext.HTTP.BaseURL
+		if loc == "" {
+			loc = ext.Local.BasePath
+		}
+		p.log.Info("external mirror", "index", i, "type", ext.Type, "location", loc)
+	}
+}
+
+func (p *LogProgress) UsingIndexer(startAd cid.Cid, indexerURL string) {
+	p.log.Info("using LastAdvertisement from indexer", "startAd", startAd, "indexer", indexerURL)
+}
+
+func (p *LogProgress) Ad(n int, adCid cid.Cid) AdProgress {
+	return logAd{log: p.log.With("n", n, "ad", adCid)}
+}
+
+func (p *LogProgress) Periodic(s Stats) {
+	withStats(p.log, s).Info("progress")
+}
+
+func (p *LogProgress) Done(s Stats, err error) {
+	l := withStats(p.log, s)
+	if err != nil {
+		l.Error("fill failed", "err", err)
+		return
+	}
+	l.Info("fill complete")
+}
+
+type logAd struct {
+	log *slog.Logger
+}
+
+func (a logAd) withAd(ad schema.Advertisement) *slog.Logger {
+	l := a.log.With("provider", ad.Provider, "isRm", ad.IsRm)
+	if p := ad.PreviousCid(); p != cid.Undef {
+		l = l.With("prev", p)
+	}
+	if hasEntries(ad) {
+		l = l.With("entries", ad.Entries.(cidlink.Link).Cid)
+	}
 	return l
 }
 
-func logStats(log *slog.Logger, s Stats) *slog.Logger {
+func (a logAd) withCar(data *carData) *slog.Logger {
+	if data == nil {
+		return a.log
+	}
+	return a.log.With("kind", carKind(data), "chunks", data.chunks, "multihashes", data.mhs, "carBytes", data.size)
+}
+
+func (a logAd) CheckingMain() { a.log.Debug("checking main") }
+func (a logAd) MainInvalid(err error) {
+	a.log.Info("main CAR invalid, will recreate", "err", err)
+}
+func (a logAd) MainMiss() { a.log.Debug("main miss") }
+func (a logAd) MainReadError(err error) {
+	a.log.Info("main read error, will recreate", "err", err)
+}
+func (a logAd) CheckingExternal(i int, loc string) {
+	a.log.Debug("checking external", "external", i, "location", loc)
+}
+func (a logAd) ExternalMiss(i int) {
+	a.log.Debug("external miss", "external", i)
+}
+func (a logAd) ExternalReadError(i int, err error) {
+	a.log.Info("external read error", "external", i, "err", err)
+}
+func (a logAd) ExternalInvalid(i int, err error) {
+	a.log.Info("external invalid CAR", "external", i, "err", err)
+}
+func (a logAd) ExternalHit(i int) { a.log.Info("external hit", "external", i) }
+func (a logAd) Loaded(src source, data *carData) {
+	a.withCar(data).With("source", src.String()).Info("loaded advertisement")
+}
+func (a logAd) MainUnusableFetching(publisher peer.ID) {
+	a.log.Info("main CAR unusable, fetching from publisher", "publisher", publisher)
+}
+func (a logAd) NotInMirrorsFetching(publisher peer.ID) {
+	a.log.Info("not in mirrors, fetching from publisher", "publisher", publisher)
+}
+func (a logAd) FetchedAd(ad schema.Advertisement) {
+	a.withAd(ad).Info("fetched advertisement")
+}
+func (a logAd) SkipIsRm(ad schema.Advertisement, carOnMain bool) {
+	a.withAd(ad).Info("skip IsRm", "carOnMain", carOnMain)
+}
+func (a logAd) SkipNoEntries(ad schema.Advertisement) {
+	a.withAd(ad).Info("skip no-entries")
+}
+func (a logAd) PresentOnMain(data *carData) {
+	a.withCar(data).Info("present on main")
+}
+func (a logAd) CopiedFromExternal(data *carData, written int64, recreated bool) {
+	msg := "copied from external"
+	if recreated {
+		msg = "recreated from external"
+	}
+	a.withCar(data).Info(msg, "written", written)
+}
+func (a logAd) SyncingFirstEntries(entsCid cid.Cid) {
+	a.log.Info("syncing first entries block", "entries", entsCid)
+}
+func (a logAd) HAMTAdOnly() { a.log.Info("entries are HAMT, writing ad only") }
+func (a logAd) WrittenFromPublisher(mainBroken, hamt bool, chunks, mhs int, written, downBytes int64) {
+	l := a.log.With("written", written, "bytesDownloaded", downBytes)
+	if hamt {
+		l = l.With("hamt", true)
+	} else {
+		l = l.With("chunks", chunks, "multihashes", mhs)
+	}
+	l.Info(publisherAction(mainBroken))
+}
+func (a logAd) SyncingRemaining(entsCid cid.Cid) {
+	a.log.Info("syncing remaining entry chunks", "entries", entsCid)
+}
+
+func withStats(log *slog.Logger, s Stats) *slog.Logger {
 	l := log.With(
 		"scanned", s.Scanned,
 		"alreadyPresent", s.AlreadyPresent,
@@ -106,28 +228,4 @@ func logStats(log *slog.Logger, s Stats) *slog.Logger {
 		l = l.With("stopReason", s.StopReason)
 	}
 	return l
-}
-
-func logAdFields(log *slog.Logger, ad schema.Advertisement) *slog.Logger {
-	l := log.With("provider", ad.Provider, "isRm", ad.IsRm)
-	if p := ad.PreviousCid(); p != cid.Undef {
-		l = l.With("prev", p)
-	}
-	if hasEntries(ad) {
-		l = l.With("entries", ad.Entries.(cidlink.Link).Cid)
-	}
-	return l
-}
-
-func logCarFields(log *slog.Logger, data *carData) *slog.Logger {
-	if data == nil {
-		return log
-	}
-	kind := "entries"
-	if data.hamt {
-		kind = "HAMT"
-	} else if !hasEntries(data.ad) {
-		kind = "no-entries"
-	}
-	return log.With("kind", kind, "chunks", data.chunks, "multihashes", data.mhs, "carBytes", data.size)
 }

--- a/scripts/fill_carmirror/main.go
+++ b/scripts/fill_carmirror/main.go
@@ -32,6 +32,10 @@ IsRm and no-entries advertisements are not stored. An IsRm advertisement
 is reported (including whether a CAR already exists on main) and not written.
 Does not open the indexer value store.
 
+--estimate counts advertisements (ads only, no entries) before filling
+so progress can show a total. --estimate-timeout bounds that count;
+fill still runs if the count times out.
+
 By default each event is a timestamped line on stdout. Pass --log for
 structured logs (GOLOG_LOG_FMT, GOLOG_LOG_LEVEL, GOLOG_FILE, ...).`,
 		Flags: []cli.Flag{
@@ -64,6 +68,15 @@ structured logs (GOLOG_LOG_FMT, GOLOG_LOG_LEVEL, GOLOG_FILE, ...).`,
 				Name:  "progress",
 				Usage: "How often to print running stats",
 				Value: 10 * time.Second,
+			},
+			&cli.BoolFlag{
+				Name:  "estimate",
+				Usage: "Count advertisements in the chain before filling (ads only)",
+			},
+			&cli.DurationFlag{
+				Name:  "estimate-timeout",
+				Usage: "Time limit for --estimate; 0 means no limit",
+				Value: 5 * time.Minute,
 			},
 			&cli.BoolFlag{
 				Name:  "log",
@@ -106,6 +119,8 @@ func run(cctx *cli.Context) error {
 		EntriesDepthLimit: int64(cfg.Ingest.EntriesDepthLimit),
 		Provider:          providerID,
 		Depth:             cctx.Int("depth"),
+		Estimate:          cctx.Bool("estimate"),
+		EstimateTimeout:   cctx.Duration("estimate-timeout"),
 	}
 
 	ctx := cctx.Context

--- a/scripts/fill_carmirror/main.go
+++ b/scripts/fill_carmirror/main.go
@@ -29,9 +29,11 @@ External mirrors are tried before downloading from the publisher.
 A CAR already on main that fails validation is overwritten from external
 or the publisher instead of stopping the walk.
 IsRm and no-entries advertisements are not stored. An IsRm advertisement
-is logged (including whether a CAR already exists on main) and not written.
+is reported (including whether a CAR already exists on main) and not written.
 Does not open the indexer value store.
-Logging uses go-log env vars (GOLOG_LOG_FMT, GOLOG_LOG_LEVEL, GOLOG_FILE, ...).`,
+
+By default each event is a timestamped line on stdout. Pass --log for
+structured logs (GOLOG_LOG_FMT, GOLOG_LOG_LEVEL, GOLOG_FILE, ...).`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "config",
@@ -60,8 +62,12 @@ Logging uses go-log env vars (GOLOG_LOG_FMT, GOLOG_LOG_LEVEL, GOLOG_FILE, ...).`
 			},
 			&cli.DurationFlag{
 				Name:  "progress",
-				Usage: "How often to log running stats",
+				Usage: "How often to print running stats",
 				Value: 10 * time.Second,
+			},
+			&cli.BoolFlag{
+				Name:  "log",
+				Usage: "Write structured logs instead of timestamped lines",
 			},
 		},
 		Action: run,
@@ -74,10 +80,6 @@ Logging uses go-log env vars (GOLOG_LOG_FMT, GOLOG_LOG_LEVEL, GOLOG_FILE, ...).`
 }
 
 func run(cctx *cli.Context) error {
-	if err := setupLogger(); err != nil {
-		return err
-	}
-
 	providerID, err := peer.Decode(cctx.String("provider"))
 	if err != nil {
 		return fmt.Errorf("bad --provider: %w", err)
@@ -125,44 +127,53 @@ func run(cctx *cli.Context) error {
 		return fmt.Errorf("required: --indexer (reads publisher AddrInfo from provider info) or --addr-info")
 	}
 
+	hadStart := opts.StartAd != cid.Undef
 	if indexerURL := cctx.String("indexer"); indexerURL != "" {
 		if err := applyIndexer(ctx, indexerURL, providerID, &opts); err != nil {
 			return fmt.Errorf("indexer lookup: %w", err)
 		}
 	}
 
+	out, err := newCLIProgress(cctx)
+	if err != nil {
+		return err
+	}
+	opts.Out = out
+
+	if indexerURL := cctx.String("indexer"); indexerURL != "" && !hadStart {
+		out.UsingIndexer(opts.StartAd, indexerURL)
+	}
+
 	if progressEvery := cctx.Duration("progress"); progressEvery > 0 {
 		ticker := time.NewTicker(progressEvery)
 		defer ticker.Stop()
-		opts.Progress = func(s Stats) {
-			select {
-			case <-ticker.C:
-				logStats(log, s).Info("progress")
-			default:
-			}
-		}
+		opts.Out = &throttlePeriodic{Progress: opts.Out, ticker: ticker}
+	} else {
+		opts.Out = noPeriodic{opts.Out}
 	}
 
-	logStart(log, opts).Info("starting fill")
-	for i, ext := range opts.Mirror.External {
-		loc := ext.HTTP.BaseURL
-		if loc == "" {
-			loc = ext.Local.BasePath
-		}
-		log.Info("external mirror", "index", i, "type", ext.Type, "location", loc)
-	}
-
+	opts.Out.Start(opts)
 	st, err := Fill(ctx, opts)
+	if st != nil {
+		opts.Out.Done(*st, err)
+	} else if err != nil {
+		opts.Out.Done(Stats{}, err)
+	}
 	if err != nil {
-		if st != nil {
-			logStats(log, *st).Error("fill failed", "err", err)
-		} else {
-			log.Error("fill failed", "err", err)
-		}
 		return fmt.Errorf("fill failed: %w", err)
 	}
-	logStats(log, *st).Info("fill complete")
 	return nil
+}
+
+func newCLIProgress(cctx *cli.Context) (Progress, error) {
+	if !cctx.Bool("log") {
+		return NewPrintProgress(os.Stdout), nil
+	}
+	log, err := setupLogger()
+	if err != nil {
+		return nil, err
+	}
+	return NewLogProgress(log), nil
 }
 
 func applyIndexer(ctx context.Context, indexerURL string, providerID peer.ID, opts *Options) error {
@@ -182,7 +193,6 @@ func applyIndexer(ctx context.Context, indexerURL string, providerID peer.ID, op
 			return fmt.Errorf("indexer has no LastAdvertisement for %s", providerID)
 		}
 		opts.StartAd = info.LastAdvertisement
-		log.Info("using LastAdvertisement from indexer", "startAd", opts.StartAd, "indexer", indexerURL)
 	}
 	if opts.Publisher.ID == "" && info.Publisher != nil && info.Publisher.ID != "" {
 		opts.Publisher = *info.Publisher

--- a/scripts/fill_carmirror/print.go
+++ b/scripts/fill_carmirror/print.go
@@ -172,6 +172,12 @@ func (a printAd) SyncingFirstEntries(entsCid cid.Cid) {
 	a.line("syncing first entries block %s", entsCid)
 }
 func (a printAd) HAMTAdOnly() { a.line("entries are HAMT, writing ad only") }
+func (a printAd) FetchingEntryChunk(n int, chunkCid cid.Cid) {
+	a.line("fetching entry chunk %d  %s", n, chunkCid)
+}
+func (a printAd) FetchedEntryChunk(n int, chunkCid cid.Cid, mhs, chunkBytes int, downBytes int64) {
+	a.line("got entry chunk %d  %s  mhs=%d bytes=%d down_bytes=%d", n, chunkCid, mhs, chunkBytes, downBytes)
+}
 func (a printAd) WrittenFromPublisher(mainBroken, hamt bool, chunks, mhs int, written, downBytes int64) {
 	action := publisherAction(mainBroken)
 	if hamt {
@@ -179,7 +185,4 @@ func (a printAd) WrittenFromPublisher(mainBroken, hamt bool, chunks, mhs int, wr
 		return
 	}
 	a.line("%s  chunks=%d mhs=%d written=%d down_bytes=%d", action, chunks, mhs, written, downBytes)
-}
-func (a printAd) SyncingRemaining(entsCid cid.Cid) {
-	a.line("syncing remaining entry chunks from %s", entsCid)
 }

--- a/scripts/fill_carmirror/print.go
+++ b/scripts/fill_carmirror/print.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipni/go-libipni/ingest/schema"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+const printTimeFormat = "2006-01-02T15:04:05.000-0700"
+
+// PrintProgress writes timestamped lines in the original fill_carmirror style.
+type PrintProgress struct {
+	w   io.Writer
+	now func() time.Time
+}
+
+func NewPrintProgress(w io.Writer) *PrintProgress {
+	return &PrintProgress{w: w, now: time.Now}
+}
+
+func (p *PrintProgress) ts() string {
+	now := p.now
+	if now == nil {
+		now = time.Now
+	}
+	return now().Format(printTimeFormat)
+}
+
+func (p *PrintProgress) line(format string, args ...any) {
+	fmt.Fprintf(p.w, "%s  "+format+"\n", append([]any{p.ts()}, args...)...)
+}
+
+func (p *PrintProgress) Start(opts Options) {
+	p.line("Filling car mirror for provider %s", opts.Provider)
+	if opts.StartAd != cid.Undef {
+		p.line("Start ad: %s", opts.StartAd)
+	}
+	if opts.Publisher.ID != "" {
+		p.line("Publisher: %s %s", opts.Publisher.ID, opts.Publisher.Addrs)
+	}
+	p.line("MainMode: %s", opts.Mirror.MainMode)
+	p.line("Main mirror: %s", opts.Mirror.Main.Local.BasePath)
+	for i, ext := range opts.Mirror.External {
+		loc := ext.HTTP.BaseURL
+		if loc == "" {
+			loc = ext.Local.BasePath
+		}
+		p.line("External[%d]: %s %s", i, ext.Type, loc)
+	}
+}
+
+func (p *PrintProgress) UsingIndexer(startAd cid.Cid, indexerURL string) {
+	p.line("using LastAdvertisement from indexer %s: %s", indexerURL, startAd)
+}
+
+func (p *PrintProgress) Ad(n int, adCid cid.Cid) AdProgress {
+	return printAd{p: p, n: n, ad: adCid}
+}
+
+func (p *PrintProgress) Periodic(s Stats) {
+	p.line("progress  scanned=%d present=%d external=%d downloaded=%d recreated=%d rm=%d hamt=%d chunks=%d mhs=%d down_bytes=%d written=%d last=%s",
+		s.Scanned, s.AlreadyPresent, s.CopiedExternal, s.Downloaded, s.Recreated, s.SkippedRm, s.SkippedHAMT,
+		s.EntryChunks, s.Multihashes, s.BytesDownloaded, s.BytesWritten, s.LastAd)
+}
+
+func (p *PrintProgress) Done(s Stats, err error) {
+	p.line("Stats:")
+	fmt.Fprintf(p.w, "  scanned:           %d\n", s.Scanned)
+	fmt.Fprintf(p.w, "  already present:   %d\n", s.AlreadyPresent)
+	fmt.Fprintf(p.w, "  copied (external): %d\n", s.CopiedExternal)
+	fmt.Fprintf(p.w, "  downloaded:        %d\n", s.Downloaded)
+	fmt.Fprintf(p.w, "  recreated:         %d\n", s.Recreated)
+	fmt.Fprintf(p.w, "  skipped HAMT:      %d\n", s.SkippedHAMT)
+	fmt.Fprintf(p.w, "  skipped no ents:   %d\n", s.SkippedNoEnts)
+	fmt.Fprintf(p.w, "  skipped IsRm:      %d\n", s.SkippedRm)
+	fmt.Fprintf(p.w, "  entry chunks:      %d\n", s.EntryChunks)
+	fmt.Fprintf(p.w, "  multihashes:       %d\n", s.Multihashes)
+	fmt.Fprintf(p.w, "  bytes downloaded:  %d\n", s.BytesDownloaded)
+	fmt.Fprintf(p.w, "  bytes written:     %d\n", s.BytesWritten)
+	if s.LastAd != cid.Undef {
+		fmt.Fprintf(p.w, "  last ad:           %s\n", s.LastAd)
+	}
+	if s.StopReason != "" {
+		fmt.Fprintf(p.w, "  stop reason:       %s\n", s.StopReason)
+	}
+}
+
+type printAd struct {
+	p  *PrintProgress
+	n  int
+	ad cid.Cid
+}
+
+func (a printAd) line(format string, args ...any) {
+	a.p.line("[%d] %s  "+format, append([]any{a.n, a.ad}, args...)...)
+}
+
+func (a printAd) CheckingMain() { a.line("checking main") }
+func (a printAd) MainInvalid(err error) {
+	a.line("main CAR invalid, will recreate: %s", err)
+}
+func (a printAd) MainMiss() { a.line("main miss") }
+func (a printAd) MainReadError(err error) {
+	a.line("main read error, will recreate: %s", err)
+}
+func (a printAd) CheckingExternal(i int, loc string) {
+	a.line("checking external[%d] %s", i, loc)
+}
+func (a printAd) ExternalMiss(i int) { a.line("external[%d] miss", i) }
+func (a printAd) ExternalReadError(i int, err error) {
+	a.line("external[%d] read error: %s", i, err)
+}
+func (a printAd) ExternalInvalid(i int, err error) {
+	a.line("external[%d] invalid CAR: %s", i, err)
+}
+func (a printAd) ExternalHit(i int) { a.line("external[%d] hit", i) }
+func (a printAd) Loaded(src source, data *carData) {
+	a.line("loaded from %s  %s", src, formatCarData(data))
+}
+func (a printAd) MainUnusableFetching(publisher peer.ID) {
+	a.line("main CAR unusable, fetching from publisher %s", publisher)
+}
+func (a printAd) NotInMirrorsFetching(publisher peer.ID) {
+	a.line("not in mirrors, fetching from publisher %s", publisher)
+}
+func (a printAd) FetchedAd(ad schema.Advertisement) {
+	a.line("fetched ad  %s", formatAd(ad))
+}
+func (a printAd) SkipIsRm(ad schema.Advertisement, carOnMain bool) {
+	a.line("skip IsRm  car_on_main=%t  %s", carOnMain, formatAd(ad))
+}
+func (a printAd) SkipNoEntries(ad schema.Advertisement) {
+	a.line("skip no-entries  %s", formatAd(ad))
+}
+func (a printAd) PresentOnMain(data *carData) {
+	a.line("present on main  %s", formatCarData(data))
+}
+func (a printAd) CopiedFromExternal(data *carData, written int64, recreated bool) {
+	action := "copied from external"
+	if recreated {
+		action = "recreated from external"
+	}
+	a.line("%s  %s  written=%d", action, formatCarData(data), written)
+}
+func (a printAd) SyncingFirstEntries(entsCid cid.Cid) {
+	a.line("syncing first entries block %s", entsCid)
+}
+func (a printAd) HAMTAdOnly() { a.line("entries are HAMT, writing ad only") }
+func (a printAd) WrittenFromPublisher(mainBroken, hamt bool, chunks, mhs int, written, downBytes int64) {
+	action := publisherAction(mainBroken)
+	if hamt {
+		a.line("%s (HAMT skipped)  written=%d down_bytes=%d", action, written, downBytes)
+		return
+	}
+	a.line("%s  chunks=%d mhs=%d written=%d down_bytes=%d", action, chunks, mhs, written, downBytes)
+}
+func (a printAd) SyncingRemaining(entsCid cid.Cid) {
+	a.line("syncing remaining entry chunks from %s", entsCid)
+}

--- a/scripts/fill_carmirror/print.go
+++ b/scripts/fill_carmirror/print.go
@@ -57,13 +57,33 @@ func (p *PrintProgress) UsingIndexer(startAd cid.Cid, indexerURL string) {
 	p.line("using LastAdvertisement from indexer %s: %s", indexerURL, startAd)
 }
 
-func (p *PrintProgress) Ad(n int, adCid cid.Cid) AdProgress {
-	return printAd{p: p, n: n, ad: adCid}
+func (p *PrintProgress) Estimating(timeout time.Duration) {
+	if timeout > 0 {
+		p.line("counting advertisements in chain (timeout %s)", timeout)
+		return
+	}
+	p.line("counting advertisements in chain")
+}
+
+func (p *PrintProgress) EstimateProgress(n int) {
+	p.line("counted %d advertisements so far", n)
+}
+
+func (p *PrintProgress) Estimated(total int, exact bool) {
+	if exact {
+		p.line("chain has %d advertisements", total)
+		return
+	}
+	p.line("chain has at least %d advertisements (count incomplete)", total)
+}
+
+func (p *PrintProgress) Ad(n int, adCid cid.Cid, total int, exact bool) AdProgress {
+	return printAd{p: p, n: n, ad: adCid, total: total, exact: exact}
 }
 
 func (p *PrintProgress) Periodic(s Stats) {
-	p.line("progress  scanned=%d present=%d external=%d downloaded=%d recreated=%d rm=%d hamt=%d chunks=%d mhs=%d down_bytes=%d written=%d last=%s",
-		s.Scanned, s.AlreadyPresent, s.CopiedExternal, s.Downloaded, s.Recreated, s.SkippedRm, s.SkippedHAMT,
+	p.line("progress  scanned=%s present=%d external=%d downloaded=%d recreated=%d rm=%d hamt=%d chunks=%d mhs=%d down_bytes=%d written=%d last=%s",
+		formatScanned(s), s.AlreadyPresent, s.CopiedExternal, s.Downloaded, s.Recreated, s.SkippedRm, s.SkippedHAMT,
 		s.EntryChunks, s.Multihashes, s.BytesDownloaded, s.BytesWritten, s.LastAd)
 }
 
@@ -90,13 +110,15 @@ func (p *PrintProgress) Done(s Stats, err error) {
 }
 
 type printAd struct {
-	p  *PrintProgress
-	n  int
-	ad cid.Cid
+	p     *PrintProgress
+	n     int
+	ad    cid.Cid
+	total int
+	exact bool
 }
 
 func (a printAd) line(format string, args ...any) {
-	a.p.line("[%d] %s  "+format, append([]any{a.n, a.ad}, args...)...)
+	a.p.line("%s %s  "+format, append([]any{formatAdIndex(a.n, a.total, a.exact), a.ad}, args...)...)
 }
 
 func (a printAd) CheckingMain() { a.line("checking main") }

--- a/scripts/fill_carmirror/print.go
+++ b/scripts/fill_carmirror/print.go
@@ -178,6 +178,26 @@ func (a printAd) FetchingEntryChunk(n int, chunkCid cid.Cid) {
 func (a printAd) FetchedEntryChunk(n int, chunkCid cid.Cid, mhs, chunkBytes int, downBytes int64) {
 	a.line("got entry chunk %d  %s  mhs=%d bytes=%d down_bytes=%d", n, chunkCid, mhs, chunkBytes, downBytes)
 }
+func (a printAd) WritingCAR(chunks int) {
+	if chunks <= 0 {
+		a.line("writing CAR (ad only)")
+		return
+	}
+	a.line("writing CAR (%d chunks)", chunks)
+}
+func (a printAd) StoringEntryChunk(n, total int, chunkCid cid.Cid, mhs, chunkBytes int) {
+	if total > 0 {
+		a.line("storing CAR chunk %d/%d  %s  mhs=%d bytes=%d", n, total, chunkCid, mhs, chunkBytes)
+		return
+	}
+	a.line("storing CAR chunk %d  %s  mhs=%d bytes=%d", n, chunkCid, mhs, chunkBytes)
+}
+func (a printAd) StoringCARFile() {
+	a.line("compressing and storing CAR file")
+}
+func (a printAd) StoringCARFileBytes(n int64) {
+	a.line("storing CAR file  bytes=%d", n)
+}
 func (a printAd) WrittenFromPublisher(mainBroken, hamt bool, chunks, mhs int, written, downBytes int64) {
 	action := publisherAction(mainBroken)
 	if hamt {

--- a/scripts/fill_carmirror/progress.go
+++ b/scripts/fill_carmirror/progress.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipni/go-libipni/ingest/schema"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// Progress receives fill events. PrintProgress is the CLI default; LogProgress
+// is used when --log is set. A nil Progress is a no-op.
+type Progress interface {
+	Start(opts Options)
+	UsingIndexer(startAd cid.Cid, indexerURL string)
+	Ad(n int, adCid cid.Cid) AdProgress
+	Periodic(s Stats)
+	Done(s Stats, err error)
+}
+
+// AdProgress is Progress scoped to one advertisement in the walk.
+type AdProgress interface {
+	CheckingMain()
+	MainInvalid(err error)
+	MainMiss()
+	MainReadError(err error)
+	CheckingExternal(i int, loc string)
+	ExternalMiss(i int)
+	ExternalReadError(i int, err error)
+	ExternalInvalid(i int, err error)
+	ExternalHit(i int)
+	Loaded(src source, data *carData)
+	MainUnusableFetching(publisher peer.ID)
+	NotInMirrorsFetching(publisher peer.ID)
+	FetchedAd(ad schema.Advertisement)
+	SkipIsRm(ad schema.Advertisement, carOnMain bool)
+	SkipNoEntries(ad schema.Advertisement)
+	PresentOnMain(data *carData)
+	CopiedFromExternal(data *carData, written int64, recreated bool)
+	SyncingFirstEntries(entsCid cid.Cid)
+	HAMTAdOnly()
+	WrittenFromPublisher(mainBroken, hamt bool, chunks, mhs int, written, downBytes int64)
+	SyncingRemaining(entsCid cid.Cid)
+}
+
+type nopProgress struct{}
+
+func (nopProgress) Start(Options)                {}
+func (nopProgress) UsingIndexer(cid.Cid, string) {}
+func (nopProgress) Ad(int, cid.Cid) AdProgress   { return nopAd{} }
+func (nopProgress) Periodic(Stats)               {}
+func (nopProgress) Done(Stats, error)            {}
+
+type nopAd struct{}
+
+func (nopAd) CheckingMain()                                           {}
+func (nopAd) MainInvalid(error)                                       {}
+func (nopAd) MainMiss()                                               {}
+func (nopAd) MainReadError(error)                                     {}
+func (nopAd) CheckingExternal(int, string)                            {}
+func (nopAd) ExternalMiss(int)                                        {}
+func (nopAd) ExternalReadError(int, error)                            {}
+func (nopAd) ExternalInvalid(int, error)                              {}
+func (nopAd) ExternalHit(int)                                         {}
+func (nopAd) Loaded(source, *carData)                                 {}
+func (nopAd) MainUnusableFetching(peer.ID)                            {}
+func (nopAd) NotInMirrorsFetching(peer.ID)                            {}
+func (nopAd) FetchedAd(schema.Advertisement)                          {}
+func (nopAd) SkipIsRm(schema.Advertisement, bool)                     {}
+func (nopAd) SkipNoEntries(schema.Advertisement)                      {}
+func (nopAd) PresentOnMain(*carData)                                  {}
+func (nopAd) CopiedFromExternal(*carData, int64, bool)                {}
+func (nopAd) SyncingFirstEntries(cid.Cid)                             {}
+func (nopAd) HAMTAdOnly()                                             {}
+func (nopAd) WrittenFromPublisher(bool, bool, int, int, int64, int64) {}
+func (nopAd) SyncingRemaining(cid.Cid)                                {}
+
+func progressOrNop(p Progress) Progress {
+	if p == nil {
+		return nopProgress{}
+	}
+	return p
+}
+
+// throttlePeriodic rate-limits Periodic calls to ticker; other methods pass through.
+type throttlePeriodic struct {
+	Progress
+	ticker *time.Ticker
+}
+
+func (t *throttlePeriodic) Periodic(s Stats) {
+	select {
+	case <-t.ticker.C:
+		t.Progress.Periodic(s)
+	default:
+	}
+}
+
+type noPeriodic struct{ Progress }
+
+func (noPeriodic) Periodic(Stats) {}
+
+func formatAd(ad schema.Advertisement) string {
+	prev := "nil"
+	if p := ad.PreviousCid(); p != cid.Undef {
+		prev = p.String()
+	}
+	ents := "none"
+	if hasEntries(ad) {
+		ents = ad.Entries.(cidlink.Link).Cid.String()
+	}
+	rm := ""
+	if ad.IsRm {
+		rm = " rm=true"
+	}
+	return fmt.Sprintf("prev=%s entries=%s provider=%s%s", prev, ents, ad.Provider, rm)
+}
+
+func formatCarData(data *carData) string {
+	kind := "entries"
+	if data.hamt {
+		kind = "HAMT"
+	} else if !hasEntries(data.ad) {
+		kind = "no-entries"
+	}
+	return fmt.Sprintf("%s  %s  chunks=%d mhs=%d car_bytes=%d", formatAd(data.ad), kind, data.chunks, data.mhs, data.size)
+}
+
+func carKind(data *carData) string {
+	if data == nil {
+		return ""
+	}
+	if data.hamt {
+		return "HAMT"
+	}
+	if !hasEntries(data.ad) {
+		return "no-entries"
+	}
+	return "entries"
+}

--- a/scripts/fill_carmirror/progress.go
+++ b/scripts/fill_carmirror/progress.go
@@ -15,7 +15,10 @@ import (
 type Progress interface {
 	Start(opts Options)
 	UsingIndexer(startAd cid.Cid, indexerURL string)
-	Ad(n int, adCid cid.Cid) AdProgress
+	Estimating(timeout time.Duration)
+	EstimateProgress(n int)
+	Estimated(total int, exact bool)
+	Ad(n int, adCid cid.Cid, total int, exact bool) AdProgress
 	Periodic(s Stats)
 	Done(s Stats, err error)
 }
@@ -47,11 +50,14 @@ type AdProgress interface {
 
 type nopProgress struct{}
 
-func (nopProgress) Start(Options)                {}
-func (nopProgress) UsingIndexer(cid.Cid, string) {}
-func (nopProgress) Ad(int, cid.Cid) AdProgress   { return nopAd{} }
-func (nopProgress) Periodic(Stats)               {}
-func (nopProgress) Done(Stats, error)            {}
+func (nopProgress) Start(Options)                         {}
+func (nopProgress) UsingIndexer(cid.Cid, string)          {}
+func (nopProgress) Estimating(time.Duration)              {}
+func (nopProgress) EstimateProgress(int)                  {}
+func (nopProgress) Estimated(int, bool)                   {}
+func (nopProgress) Ad(int, cid.Cid, int, bool) AdProgress { return nopAd{} }
+func (nopProgress) Periodic(Stats)                        {}
+func (nopProgress) Done(Stats, error)                     {}
 
 type nopAd struct{}
 
@@ -126,6 +132,30 @@ func formatCarData(data *carData) string {
 		kind = "no-entries"
 	}
 	return fmt.Sprintf("%s  %s  chunks=%d mhs=%d car_bytes=%d", formatAd(data.ad), kind, data.chunks, data.mhs, data.size)
+}
+
+func formatAdIndex(n, total int, exact bool) string {
+	if total <= 0 {
+		return fmt.Sprintf("[%d]", n)
+	}
+	if exact {
+		return fmt.Sprintf("[%d / %d]", n, total)
+	}
+	return fmt.Sprintf("[%d / %d+]", n, total)
+}
+
+func formatScanned(s Stats) string {
+	if s.TotalAds <= 0 {
+		return fmt.Sprintf("%d", s.Scanned)
+	}
+	if s.TotalExact {
+		pct := 0
+		if s.TotalAds > 0 {
+			pct = s.Scanned * 100 / s.TotalAds
+		}
+		return fmt.Sprintf("%d/%d (%d%%)", s.Scanned, s.TotalAds, pct)
+	}
+	return fmt.Sprintf("%d/%d+", s.Scanned, s.TotalAds)
 }
 
 func carKind(data *carData) string {

--- a/scripts/fill_carmirror/progress.go
+++ b/scripts/fill_carmirror/progress.go
@@ -46,6 +46,10 @@ type AdProgress interface {
 	HAMTAdOnly()
 	FetchingEntryChunk(n int, chunkCid cid.Cid)
 	FetchedEntryChunk(n int, chunkCid cid.Cid, mhs, chunkBytes int, downBytes int64)
+	WritingCAR(chunks int)
+	StoringEntryChunk(n, total int, chunkCid cid.Cid, mhs, chunkBytes int)
+	StoringCARFile()
+	StoringCARFileBytes(n int64)
 	WrittenFromPublisher(mainBroken, hamt bool, chunks, mhs int, written, downBytes int64)
 }
 
@@ -83,6 +87,10 @@ func (nopAd) SyncingFirstEntries(cid.Cid)                             {}
 func (nopAd) HAMTAdOnly()                                             {}
 func (nopAd) FetchingEntryChunk(int, cid.Cid)                         {}
 func (nopAd) FetchedEntryChunk(int, cid.Cid, int, int, int64)         {}
+func (nopAd) WritingCAR(int)                                          {}
+func (nopAd) StoringEntryChunk(int, int, cid.Cid, int, int)           {}
+func (nopAd) StoringCARFile()                                         {}
+func (nopAd) StoringCARFileBytes(int64)                               {}
 func (nopAd) WrittenFromPublisher(bool, bool, int, int, int64, int64) {}
 
 func progressOrNop(p Progress) Progress {

--- a/scripts/fill_carmirror/progress.go
+++ b/scripts/fill_carmirror/progress.go
@@ -44,8 +44,9 @@ type AdProgress interface {
 	CopiedFromExternal(data *carData, written int64, recreated bool)
 	SyncingFirstEntries(entsCid cid.Cid)
 	HAMTAdOnly()
+	FetchingEntryChunk(n int, chunkCid cid.Cid)
+	FetchedEntryChunk(n int, chunkCid cid.Cid, mhs, chunkBytes int, downBytes int64)
 	WrittenFromPublisher(mainBroken, hamt bool, chunks, mhs int, written, downBytes int64)
-	SyncingRemaining(entsCid cid.Cid)
 }
 
 type nopProgress struct{}
@@ -80,8 +81,9 @@ func (nopAd) PresentOnMain(*carData)                                  {}
 func (nopAd) CopiedFromExternal(*carData, int64, bool)                {}
 func (nopAd) SyncingFirstEntries(cid.Cid)                             {}
 func (nopAd) HAMTAdOnly()                                             {}
+func (nopAd) FetchingEntryChunk(int, cid.Cid)                         {}
+func (nopAd) FetchedEntryChunk(int, cid.Cid, int, int, int64)         {}
 func (nopAd) WrittenFromPublisher(bool, bool, int, int, int64, int64) {}
-func (nopAd) SyncingRemaining(cid.Cid)                                {}
 
 func progressOrNop(p Progress) Progress {
 	if p == nil {

--- a/scripts/fill_carmirror/progress_test.go
+++ b/scripts/fill_carmirror/progress_test.go
@@ -58,6 +58,21 @@ func TestPrintAdIndexIncludesTotal(t *testing.T) {
 	}
 }
 
+func TestPrintEntryChunkProgress(t *testing.T) {
+	var buf bytes.Buffer
+	p := &PrintProgress{w: &buf, now: func() time.Time { return time.Time{} }}
+	ap := p.Ad(1, cid.Undef, 0, false)
+	ap.FetchingEntryChunk(2, cid.Undef)
+	ap.FetchedEntryChunk(2, cid.Undef, 16, 100, 500)
+	out := buf.String()
+	if !strings.Contains(out, "fetching entry chunk 2") {
+		t.Fatalf("missing fetching: %s", out)
+	}
+	if !strings.Contains(out, "got entry chunk 2") || !strings.Contains(out, "mhs=16") {
+		t.Fatalf("missing got: %s", out)
+	}
+}
+
 func TestFormatScanned(t *testing.T) {
 	if got := formatScanned(Stats{Scanned: 3}); got != "3" {
 		t.Fatalf("no total: got %q", got)

--- a/scripts/fill_carmirror/progress_test.go
+++ b/scripts/fill_carmirror/progress_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-cid"
+)
+
+func TestPrintProgressTimestamps(t *testing.T) {
+	var buf bytes.Buffer
+	fixed := time.Date(2026, 9, 4, 9, 56, 1, 123000000, time.FixedZone("CEST", 2*3600))
+	p := &PrintProgress{w: &buf, now: func() time.Time { return fixed }}
+
+	p.Start(Options{})
+	ap := p.Ad(1, cid.Undef)
+	ap.CheckingMain()
+	p.Periodic(Stats{Scanned: 3})
+
+	wantPrefix := "2026-09-04T09:56:01.123+0200  "
+	out := buf.String()
+	for _, line := range strings.Split(strings.TrimSuffix(out, "\n"), "\n") {
+		if !strings.HasPrefix(line, wantPrefix) {
+			t.Fatalf("line missing timestamp prefix %q: %q", wantPrefix, line)
+		}
+	}
+	if !strings.Contains(out, "checking main") {
+		t.Fatalf("missing checking main: %s", out)
+	}
+	if !strings.Contains(out, "progress  scanned=3") {
+		t.Fatalf("missing progress: %s", out)
+	}
+}

--- a/scripts/fill_carmirror/progress_test.go
+++ b/scripts/fill_carmirror/progress_test.go
@@ -73,6 +73,29 @@ func TestPrintEntryChunkProgress(t *testing.T) {
 	}
 }
 
+func TestPrintCARStoreProgress(t *testing.T) {
+	var buf bytes.Buffer
+	p := &PrintProgress{w: &buf, now: func() time.Time { return time.Time{} }}
+	ap := p.Ad(1, cid.Undef, 0, false)
+	ap.WritingCAR(3)
+	ap.StoringEntryChunk(2, 3, cid.Undef, 16, 100)
+	ap.StoringCARFile()
+	ap.StoringCARFileBytes(64)
+	out := buf.String()
+	if !strings.Contains(out, "writing CAR (3 chunks)") {
+		t.Fatalf("missing writing: %s", out)
+	}
+	if !strings.Contains(out, "storing CAR chunk 2/3") {
+		t.Fatalf("missing storing chunk: %s", out)
+	}
+	if !strings.Contains(out, "compressing and storing CAR file") {
+		t.Fatalf("missing storing file: %s", out)
+	}
+	if !strings.Contains(out, "storing CAR file  bytes=64") {
+		t.Fatalf("missing file bytes: %s", out)
+	}
+}
+
 func TestFormatScanned(t *testing.T) {
 	if got := formatScanned(Stats{Scanned: 3}); got != "3" {
 		t.Fatalf("no total: got %q", got)

--- a/scripts/fill_carmirror/progress_test.go
+++ b/scripts/fill_carmirror/progress_test.go
@@ -15,7 +15,7 @@ func TestPrintProgressTimestamps(t *testing.T) {
 	p := &PrintProgress{w: &buf, now: func() time.Time { return fixed }}
 
 	p.Start(Options{})
-	ap := p.Ad(1, cid.Undef)
+	ap := p.Ad(1, cid.Undef, 0, false)
 	ap.CheckingMain()
 	p.Periodic(Stats{Scanned: 3})
 
@@ -29,7 +29,43 @@ func TestPrintProgressTimestamps(t *testing.T) {
 	if !strings.Contains(out, "checking main") {
 		t.Fatalf("missing checking main: %s", out)
 	}
+	if !strings.Contains(out, "[1] ") {
+		t.Fatalf("missing ad index: %s", out)
+	}
 	if !strings.Contains(out, "progress  scanned=3") {
 		t.Fatalf("missing progress: %s", out)
+	}
+}
+
+func TestFormatAdIndex(t *testing.T) {
+	if got := formatAdIndex(1, 0, false); got != "[1]" {
+		t.Fatalf("no total: got %q", got)
+	}
+	if got := formatAdIndex(3, 10, true); got != "[3 / 10]" {
+		t.Fatalf("exact: got %q", got)
+	}
+	if got := formatAdIndex(3, 10, false); got != "[3 / 10+]" {
+		t.Fatalf("partial: got %q", got)
+	}
+}
+
+func TestPrintAdIndexIncludesTotal(t *testing.T) {
+	var buf bytes.Buffer
+	p := &PrintProgress{w: &buf, now: func() time.Time { return time.Time{} }}
+	p.Ad(3, cid.Undef, 10, true).CheckingMain()
+	if !strings.Contains(buf.String(), "[3 / 10] ") {
+		t.Fatalf("missing total in ad line: %s", buf.String())
+	}
+}
+
+func TestFormatScanned(t *testing.T) {
+	if got := formatScanned(Stats{Scanned: 3}); got != "3" {
+		t.Fatalf("no total: got %q", got)
+	}
+	if got := formatScanned(Stats{Scanned: 3, TotalAds: 10, TotalExact: true}); got != "3/10 (30%)" {
+		t.Fatalf("exact: got %q", got)
+	}
+	if got := formatScanned(Stats{Scanned: 3, TotalAds: 10}); got != "3/10+" {
+		t.Fatalf("partial: got %q", got)
 	}
 }


### PR DESCRIPTION
## Context
fill_carmirror is already on main. Long Aurora fills were hard to operate: default output was structured logs, there was no remaining-ad count, and a slow advert could sit silent for minutes (dagsync only fires the entries hook after the whole remaining chain, and CAR write has no callbacks).

## Proposed Changes
- Default stdout to timestamped lines; `--log` keeps structured logs (`GOLOG_*`).
- `--estimate` / `--estimate-timeout` (default 5m) do an ads-only pre-count so progress can show `[n / total]` (or `n/total+` if the count times out). Fill still runs after a timeout.
- Per-chunk fetch progress as each entries block is stored, plus `fetching entry chunk N` so a slow HTTP GET is visible.
- CAR write progress via datastore Get and filestore Put wrappers in fill_carmirror only (no carstore/filestore API changes): `storing CAR chunk n/total`, then compressing/storing with byte updates.

## Tests
Package tests in `scripts/fill_carmirror` cover estimate counts, print prefixes with totals, per-chunk fetch events, and CAR store events (`go test ./scripts/fill_carmirror/`).

## Revert Strategy
Change is safe to revert. This is a standalone CLI under `scripts/fill_carmirror`; it does not change daemon ingest.
